### PR TITLE
Case-folding and iterative assignments

### DIFF
--- a/src/gi_giargument.c
+++ b/src/gi_giargument.c
@@ -2196,7 +2196,7 @@ convert_array_pointer_arg_to_object(GIArgument *arg,
     else if (item_type_tag == GI_TYPE_TAG_UTF8 || item_type_tag == GI_TYPE_TAG_FILENAME)
     {
         size_t len = g_type_info_get_array_fixed_size(array_type_info);
-        SCM out = SCM_EOL;
+        SCM out = SCM_EOL, out_iter;
         if (array_is_zero_terminated)
         {
             if (arg->v_pointer == NULL)
@@ -2209,20 +2209,21 @@ convert_array_pointer_arg_to_object(GIArgument *arg,
                     len++;
             }
         }
+        out = scm_make_list (scm_from_size_t (len), SCM_BOOL_F);
+        out_iter = out;
         for (int i = 0; i < len; i ++)
         {
             char *p = ((char **)arg->v_pointer)[i];
-            if (!p)
-                out = scm_append(scm_list_2(out, scm_list_1(SCM_BOOL_F)));
-            else
+            if (p)
             {
                 SCM entry;
                 if (item_type_tag == GI_TYPE_TAG_UTF8)
                     entry = scm_from_utf8_string(((char **)arg->v_pointer)[i]);
                 else
                     entry = scm_from_locale_string(((char **)arg->v_pointer)[i]);
-                out = scm_append(scm_list_2(out, scm_list_1(entry)));
+                scm_set_car_x (out_iter, entry);
             }
+            out_iter = scm_cdr (out_iter);
         }
         *obj = out;
     }

--- a/test/str_tokenize_and_fold.scm
+++ b/test/str_tokenize_and_fold.scm
@@ -1,6 +1,7 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
-             (test automake-test-lib))
+             (test automake-test-lib)
+             (srfi srfi-1))
 
 ;; FIXME: the ascii-alternates output parameter
 ;; is from a gchar*** output parameter.  This is
@@ -17,5 +18,5 @@
          (ascii-alternates (cadr out)))
      (write tokens) (newline)
      (write ascii-alternates) (newline)
-     (equal? tokens (list "Les" "pâtes")))))
-
+     ;; take case-folding into account
+     (every string-ci=? (list "Les" "pâtes") tokens))))


### PR DESCRIPTION
This "fixes" a bug in the str_tokenize_and_fold test (the function should fold case as well) and makes strv conversion take linear time instead of quadratic time (in big O notation).