### PR TITLE
Make `convert_array_pointer_arg_to_object` mimic `object_to_c_array_arg`

### DIFF
--- a/src/gi_giargument.c
+++ b/src/gi_giargument.c
@@ -165,42 +165,42 @@ static void object_to_c_string_arg(char *subr, int argpos,
                                    GIArgument *arg);
 static void object_to_c_void_pointer_arg(char *subr, int argpos, SCM obj, GIArgument *arg);
 static void object_to_c_interface_pointer_arg(char *subr, int argpos, SCM object,
-                                                         GIArgInfo *arg_info,
-                                                          unsigned *must_free,
-                                                          GIArgument *arg);
-static void object_to_c_array_arg(char *subr, int argpos, SCM object,
-                                              GITypeInfo *array_type_info,
-                                              GITransfer array_transfer,
+                                              GIArgInfo *arg_info,
                                               unsigned *must_free,
                                               GIArgument *arg);
+static void object_to_c_array_arg(char *subr, int argpos, SCM object,
+                                  GITypeInfo *array_type_info,
+                                  GITransfer array_transfer,
+                                  unsigned *must_free,
+                                  GIArgument *arg);
 static void
 object_to_c_native_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                             struct array_info *ai,
                              GIArgument *arg);
 static void
 object_to_c_native_immediate_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                                       struct array_info *ai,
                                        GIArgument *arg);
 static void
 object_to_c_native_string_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                                    struct array_info *ai,
                                     GIArgument *arg);
 static void
 object_to_c_native_interface_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
-                                    GIArgument *arg);
+                                       struct array_info *ai,
+                                       GIArgument *arg);
 static void
 object_to_c_ptr_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
-                             GIArgument *arg);
+                          struct array_info *ai,
+                          GIArgument *arg);
 static void
 object_to_c_garray_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                             struct array_info *ai,
                              GIArgument *arg);
 static void
 object_to_c_byte_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
-                             GIArgument *arg);
+                           struct array_info *ai,
+                           GIArgument *arg);
 static void convert_immediate_arg_to_object(GIArgument *arg, GITypeTag type_tag, SCM *obj);
 static void convert_interface_arg_to_object(GIArgument *arg, GITypeInfo *type_info, SCM *obj);
 static void convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag, GITransfer transfer, SCM *obj);
@@ -842,8 +842,8 @@ object_to_c_interface_arg(char *subr, int argpos, SCM obj,
         }
     }
     else if ((referenced_base_type == GI_INFO_TYPE_STRUCT)
-              || (referenced_base_type == GI_INFO_TYPE_UNION)
-              || (referenced_base_type == GI_INFO_TYPE_OBJECT))
+             || (referenced_base_type == GI_INFO_TYPE_UNION)
+             || (referenced_base_type == GI_INFO_TYPE_OBJECT))
     {
         // This is uncommon case where a struct is used directly,
         // and not as a pointer, such as in gtk_text_buffer_get_bounds.
@@ -979,8 +979,8 @@ object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
         scm_wrong_type_arg_msg(subr, argpos, obj, msg);
     }
     else if ((referenced_base_type == GI_INFO_TYPE_STRUCT)
-              || (referenced_base_type == GI_INFO_TYPE_UNION)
-              || (referenced_base_type == GI_INFO_TYPE_OBJECT))
+             || (referenced_base_type == GI_INFO_TYPE_UNION)
+             || (referenced_base_type == GI_INFO_TYPE_OBJECT))
     {
         arg->v_pointer = scm_foreign_object_ref(obj, OBJ_SLOT);
         *must_free = GIR_FREE_NONE;
@@ -989,7 +989,7 @@ object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
     {
         scm_misc_error(subr,
                        "Marshalling to C callback pointer args is unimplemented: ~S",
-                        scm_list_1(obj));
+                       scm_list_1(obj));
     }
     else if (referenced_base_type == GI_INFO_TYPE_INTERFACE)
     {
@@ -1003,10 +1003,10 @@ object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
 
 static void
 object_to_c_array_arg(char *subr, int argpos, SCM object,
-                                  GITypeInfo *array_type_info,
-                                  GITransfer array_transfer,
-                                  unsigned *must_free,
-                                  GIArgument *arg)
+                      GITypeInfo *array_type_info,
+                      GITransfer array_transfer,
+                      unsigned *must_free,
+                      GIArgument *arg)
 {
     struct array_info ai = {0};
 
@@ -1094,7 +1094,7 @@ object_to_c_array_arg(char *subr, int argpos, SCM object,
         g_base_info_unref(item_type_info);
         object_to_c_native_array_arg(subr, argpos, object, &ai, arg);
     }
-        break;
+    break;
     case GI_ARRAY_TYPE_ARRAY:
         object_to_c_garray_array_arg(subr, argpos, object, &ai, arg);
         break;
@@ -1112,7 +1112,7 @@ object_to_c_array_arg(char *subr, int argpos, SCM object,
 
 static void
 object_to_c_native_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                             struct array_info *ai,
                              GIArgument *arg)
 {
     if (TYPE_TAG_IS_EXACT_INTEGER(ai->item_type_tag)
@@ -1217,7 +1217,7 @@ object_to_c_native_immediate_array_arg(char *subr, int argpos,
 
 static void
 object_to_c_byte_array_arg(char *subr, int argpos, SCM object,
-                            struct array_info *ai,
+                           struct array_info *ai,
                            GIArgument *arg)
 {
     if (scm_is_bytevector(object))
@@ -1246,7 +1246,7 @@ object_to_c_garray_array_arg(char *subr, int argpos, SCM object, struct array_in
 
 static void
 object_to_c_ptr_array_arg(char *subr, int argpos, SCM object, struct array_info *ai,
-                             GIArgument *arg)
+                          GIArgument *arg)
 {
 #define FUNC_NAME "%object->c-ptr-array-arg"
     scm_misc_error(FUNC_NAME,
@@ -1258,7 +1258,7 @@ object_to_c_ptr_array_arg(char *subr, int argpos, SCM object, struct array_info 
 
 static void
 object_to_c_native_direct_struct_array_arg(char *subr, int argpos, SCM object,
-                                        struct array_info *ai, GIArgument *arg)
+                                           struct array_info *ai, GIArgument *arg)
 {
     // This is the uncommon case of the argument containing
     // an array of structs themselves, rather than an array
@@ -1279,8 +1279,8 @@ object_to_c_native_direct_struct_array_arg(char *subr, int argpos, SCM object,
 
 static void
 object_to_c_native_indirect_object_array_arg(char *subr, int argpos, SCM object,
-                                        struct array_info *ai,
-                                        GIArgument *arg)
+                                             struct array_info *ai,
+                                             GIArgument *arg)
 {
     // Arrays of pointers to OBJECTS.  The only example I could find
     // is g_socket_send_message.
@@ -1316,9 +1316,9 @@ object_to_c_native_indirect_object_array_arg(char *subr, int argpos, SCM object,
 
 static void
 object_to_c_native_interface_array_arg(char *subr,
-                                        int argpos,
-                                        SCM object,
-                                        struct array_info *ai,
+                                       int argpos,
+                                       SCM object,
+                                       struct array_info *ai,
                                        GIArgument *arg)
 {
 #define FUNC_NAME "%object->c-native-interface-array-arg"
@@ -1331,7 +1331,7 @@ object_to_c_native_interface_array_arg(char *subr,
         // integers.
         ai->item_type_tag = GI_TYPE_TAG_UINT32;
         object_to_c_native_immediate_array_arg(subr,argpos,object,
-                                ai, arg);
+                                               ai, arg);
     }
     else if ((ai->referenced_base_type == GI_INFO_TYPE_STRUCT)
              || (ai->referenced_base_type == GI_INFO_TYPE_UNION)
@@ -1695,9 +1695,9 @@ gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *o
         case GI_TYPE_TAG_ARRAY:
             // g_critical("Unhandled array argument type %s %d", __FILE__, __LINE__);
             convert_array_pointer_arg_to_object(arg,
-                                                      type_info,
-                                                      GI_TRANSFER_EVERYTHING,
-                                                      obj);
+                                                type_info,
+                                                GI_TRANSFER_EVERYTHING,
+                                                obj);
             break;
 
         default:
@@ -2261,274 +2261,274 @@ GITypeTag type_tag = g_type_info_get_tag(type_info);
 int ret = GI_GIARGUMENT_OK;
 
 switch (type_tag)
-{
-case GI_TYPE_TAG_VOID:
-{
-    /* Convert const void * to SCM pointers */
-    if (g_type_info_is_pointer(type_info))
-    {
-        if (transfer != GI_TRANSFER_NOTHING)
-            ret = GI_GIARGUMENT_NON_CONST_VOID_POINTER;
-        else
-            obj = scm_from_pointer(arg->v_pointer, NULL);
-    }
-    break;
-}
-case GI_TYPE_TAG_ARRAY:
-{
-    /* Convert a GArray* of simple types to a SCM bytevector */
-    /* Arrays are assumed to be packed in a GArray */
-    GArray *array;
-    GITypeInfo *item_type_info;
-    GITypeTag item_type_tag;
-    gsize item_size;
+ {
+ case GI_TYPE_TAG_VOID:
+ {
+     /* Convert const void * to SCM pointers */
+     if (g_type_info_is_pointer(type_info))
+     {
+         if (transfer != GI_TRANSFER_NOTHING)
+             ret = GI_GIARGUMENT_NON_CONST_VOID_POINTER;
+         else
+             obj = scm_from_pointer(arg->v_pointer, NULL);
+     }
+     break;
+ }
+ case GI_TYPE_TAG_ARRAY:
+ {
+     /* Convert a GArray* of simple types to a SCM bytevector */
+     /* Arrays are assumed to be packed in a GArray */
+     GArray *array;
+     GITypeInfo *item_type_info;
+     GITypeTag item_type_tag;
+     gsize item_size;
 
-    if (arg->v_pointer == NULL)
-        obj = scm_c_make_bytevector(0);
+     if (arg->v_pointer == NULL)
+         obj = scm_c_make_bytevector(0);
 
-    item_type_info = g_type_info_get_param_type(type_info, 0);
-    item_type_tag = g_type_info_get_tag(item_type_info);
+     item_type_info = g_type_info_get_param_type(type_info, 0);
+     item_type_tag = g_type_info_get_tag(item_type_info);
 
-    array = arg->v_pointer;
-    item_size = g_array_get_element_size(array);
+     array = arg->v_pointer;
+     item_size = g_array_get_element_size(array);
 
-    if (item_size > sizeof(GIArgument))
-        ret = GI_GIARGUMENT_ARRAY_ELEMENT_TOO_BIG;
-    else if (TYPE_TAG_IS_EXACT_INTEGER(item_type_tag) || TYPE_TAG_IS_REAL_NUMBER(item_type_tag))
-    {
-        // This is a simple numerical array, so we'll put it into
-        // a bytevector.  We need to put the contents in
-        // GC-managed memory, so we can't keep the contents even
-        // if it is GI_TRANSFER_EVERYTHING.
-        obj = scm_c_make_bytevector(array->len * item_size);
-        memcpy(SCM_BYTEVECTOR_CONTENTS(obj),
-               array->data,
-               array->len * item_size);
+     if (item_size > sizeof(GIArgument))
+         ret = GI_GIARGUMENT_ARRAY_ELEMENT_TOO_BIG;
+     else if (TYPE_TAG_IS_EXACT_INTEGER(item_type_tag) || TYPE_TAG_IS_REAL_NUMBER(item_type_tag))
+     {
+         // This is a simple numerical array, so we'll put it into
+         // a bytevector.  We need to put the contents in
+         // GC-managed memory, so we can't keep the contents even
+         // if it is GI_TRANSFER_EVERYTHING.
+         obj = scm_c_make_bytevector(array->len * item_size);
+         memcpy(SCM_BYTEVECTOR_CONTENTS(obj),
+                array->data,
+                array->len * item_size);
 
-        // Since we've made a copy of the original array into a
-        // bytevector, we can delete the original array
-        if (transfer == GI_TRANSFER_EVERYTHING)
-            g_array_free(array, TRUE);
-        else if (transfer == GI_TRANSFER_CONTAINER)
-            g_array_free(array, FALSE);
-        arg->v_pointer = NULL;
-    }
-    else
-        ret = GI_GIARGUMENT_UNHANDLED_ARRAY_ELEMENT_TYPE;
+         // Since we've made a copy of the original array into a
+         // bytevector, we can delete the original array
+         if (transfer == GI_TRANSFER_EVERYTHING)
+             g_array_free(array, TRUE);
+         else if (transfer == GI_TRANSFER_CONTAINER)
+             g_array_free(array, FALSE);
+         arg->v_pointer = NULL;
+     }
+     else
+         ret = GI_GIARGUMENT_UNHANDLED_ARRAY_ELEMENT_TYPE;
 
-    g_base_info_unref(item_type_info);
-    break;
-}
-case GI_TYPE_TAG_INTERFACE:
-{
-    GIBaseInfo *info;
-    GIInfoType info_type;
+     g_base_info_unref(item_type_info);
+     break;
+ }
+ case GI_TYPE_TAG_INTERFACE:
+ {
+     GIBaseInfo *info;
+     GIInfoType info_type;
 
-    info = g_type_info_get_interface(type_info);
-    info_type = g_base_info_get_type(info);
+     info = g_type_info_get_interface(type_info);
+     info_type = g_base_info_get_type(info);
 
-    switch (info_type)
-    {
-    case GI_INFO_TYPE_CALLBACK:
-        // Should be handled by invoke? Never reached?
-        ret = GI_GIARGUMENT_UNHANDLED_INTERFACE_TYPE;
-        break;
-    case GI_INFO_TYPE_BOXED:
-    case GI_INFO_TYPE_STRUCT:
-    case GI_INFO_TYPE_UNION:
-    {
-        GType g_type = g_registered_type_info_get_g_type((GIRegisteredTypeInfo *)info);
-        gboolean is_foreign = (info_type == GI_INFO_TYPE_STRUCT) &&
-            (g_struct_info_is_foreign((GIStructInfo *)info));
+     switch (info_type)
+     {
+     case GI_INFO_TYPE_CALLBACK:
+         // Should be handled by invoke? Never reached?
+         ret = GI_GIARGUMENT_UNHANDLED_INTERFACE_TYPE;
+         break;
+     case GI_INFO_TYPE_BOXED:
+     case GI_INFO_TYPE_STRUCT:
+     case GI_INFO_TYPE_UNION:
+     {
+         GType g_type = g_registered_type_info_get_g_type((GIRegisteredTypeInfo *)info);
+         gboolean is_foreign = (info_type == GI_INFO_TYPE_STRUCT) &&
+             (g_struct_info_is_foreign((GIStructInfo *)info));
 
-        ret = arg_struct_to_scm (arg, info, g_type, transfer, FALSE, is_foreign, obj);
-        break;
-    }
+         ret = arg_struct_to_scm (arg, info, g_type, transfer, FALSE, is_foreign, obj);
+         break;
+     }
 #if 0
-    case GI_INFO_TYPE_ENUM:
-    case GI_INFO_TYPE_FLAGS:
-    {
-        GType type;
+     case GI_INFO_TYPE_ENUM:
+     case GI_INFO_TYPE_FLAGS:
+     {
+         GType type;
 
-        type = g_registered_type_info_get_g_type ( (GIRegisteredTypeInfo *) info);
+         type = g_registered_type_info_get_g_type ( (GIRegisteredTypeInfo *) info);
 
-        if (type == G_TYPE_NONE) {
-            /* An enum with a GType of None is an enum without GType */
-            PyObject *py_type = pygi_type_import_by_gi_info (info);
-            PyObject *py_args = NULL;
+         if (type == G_TYPE_NONE) {
+             /* An enum with a GType of None is an enum without GType */
+             PyObject *py_type = pygi_type_import_by_gi_info (info);
+             PyObject *py_args = NULL;
 
-            if (!py_type)
-                return NULL;
+             if (!py_type)
+                 return NULL;
 
-            py_args = PyTuple_New (1);
-            if (PyTuple_SetItem (py_args, 0, pygi_gint_to_py (arg->v_int)) != 0) {
-                Py_DECREF (py_args);
-                Py_DECREF (py_type);
-                return NULL;
-            }
+             py_args = PyTuple_New (1);
+             if (PyTuple_SetItem (py_args, 0, pygi_gint_to_py (arg->v_int)) != 0) {
+                 Py_DECREF (py_args);
+                 Py_DECREF (py_type);
+                 return NULL;
+             }
 
-            obj = PyObject_CallFunction (py_type, "i", arg->v_int);
+             obj = PyObject_CallFunction (py_type, "i", arg->v_int);
 
-            Py_DECREF (py_args);
-            Py_DECREF (py_type);
+             Py_DECREF (py_args);
+             Py_DECREF (py_type);
 
-        } else if (info_type == GI_INFO_TYPE_ENUM) {
-            object = pyg_enum_from_gtype (type, arg->v_int);
-        } else {
-            object = pyg_flags_from_gtype (type, arg->v_uint);
-        }
+         } else if (info_type == GI_INFO_TYPE_ENUM) {
+             object = pyg_enum_from_gtype (type, arg->v_int);
+         } else {
+             object = pyg_flags_from_gtype (type, arg->v_uint);
+         }
 
-        break;
-    }
+         break;
+     }
 #endif
-    case GI_INFO_TYPE_INTERFACE:
-    case GI_INFO_TYPE_OBJECT:
-        obj = gi_arg_gobject_to_scm_called_from_c(arg, transfer);
+     case GI_INFO_TYPE_INTERFACE:
+     case GI_INFO_TYPE_OBJECT:
+         obj = gi_arg_gobject_to_scm_called_from_c(arg, transfer);
 
-        break;
-    default:
-        g_assert_not_reached();
-    }
+         break;
+     default:
+         g_assert_not_reached();
+     }
 
-    g_base_info_unref(info);
-    break;
-}
+     g_base_info_unref(info);
+     break;
+ }
 #if 0
-case GI_TYPE_TAG_GLIST:
-case GI_TYPE_TAG_GSLIST:
-{
-    GSList *list;
-    gsize length;
-    GITypeInfo *item_type_info;
-    GITransfer item_transfer;
-    gsize i;
+ case GI_TYPE_TAG_GLIST:
+ case GI_TYPE_TAG_GSLIST:
+ {
+     GSList *list;
+     gsize length;
+     GITypeInfo *item_type_info;
+     GITransfer item_transfer;
+     gsize i;
 
-    list = arg->v_pointer;
-    length = g_slist_length (list);
+     list = arg->v_pointer;
+     length = g_slist_length (list);
 
-    object = PyList_New (length);
-    if (object == NULL) {
-        break;
-    }
+     object = PyList_New (length);
+     if (object == NULL) {
+         break;
+     }
 
-    item_type_info = g_type_info_get_param_type (type_info, 0);
-    g_assert (item_type_info != NULL);
+     item_type_info = g_type_info_get_param_type (type_info, 0);
+     g_assert (item_type_info != NULL);
 
-    item_transfer = transfer == GI_TRANSFER_CONTAINER ? GI_TRANSFER_NOTHING : transfer;
+     item_transfer = transfer == GI_TRANSFER_CONTAINER ? GI_TRANSFER_NOTHING : transfer;
 
-    for (i = 0; list != NULL; list = g_slist_next (list), i++) {
-        GIArgument item;
-        PyObject *py_item;
+     for (i = 0; list != NULL; list = g_slist_next (list), i++) {
+         GIArgument item;
+         PyObject *py_item;
 
-        item.v_pointer = list->data;
+         item.v_pointer = list->data;
 
-        py_item = _pygi_argument_to_object (&item, item_type_info, item_transfer);
-        if (py_item == NULL) {
-            Py_CLEAR (object);
-            _PyGI_ERROR_PREFIX ("Item %zu: ", i);
-            break;
-        }
+         py_item = _pygi_argument_to_object (&item, item_type_info, item_transfer);
+         if (py_item == NULL) {
+             Py_CLEAR (object);
+             _PyGI_ERROR_PREFIX ("Item %zu: ", i);
+             break;
+         }
 
-        PyList_SET_ITEM (object, i, py_item);
-    }
+         PyList_SET_ITEM (object, i, py_item);
+     }
 
-    g_base_info_unref ( (GIBaseInfo *) item_type_info);
-    break;
-}
-case GI_TYPE_TAG_GHASH:
-{
-    GITypeInfo *key_type_info;
-    GITypeInfo *value_type_info;
-    GITransfer item_transfer;
-    GHashTableIter hash_table_iter;
-    GIArgument key;
-    GIArgument value;
+     g_base_info_unref ( (GIBaseInfo *) item_type_info);
+     break;
+ }
+ case GI_TYPE_TAG_GHASH:
+ {
+     GITypeInfo *key_type_info;
+     GITypeInfo *value_type_info;
+     GITransfer item_transfer;
+     GHashTableIter hash_table_iter;
+     GIArgument key;
+     GIArgument value;
 
-    if (arg->v_pointer == NULL) {
-        object = Py_None;
-        Py_INCREF (object);
-        break;
-    }
+     if (arg->v_pointer == NULL) {
+         object = Py_None;
+         Py_INCREF (object);
+         break;
+     }
 
-    object = PyDict_New();
-    if (object == NULL) {
-        break;
-    }
+     object = PyDict_New();
+     if (object == NULL) {
+         break;
+     }
 
-    key_type_info = g_type_info_get_param_type (type_info, 0);
-    g_assert (key_type_info != NULL);
-    g_assert (g_type_info_get_tag (key_type_info) != GI_TYPE_TAG_VOID);
+     key_type_info = g_type_info_get_param_type (type_info, 0);
+     g_assert (key_type_info != NULL);
+     g_assert (g_type_info_get_tag (key_type_info) != GI_TYPE_TAG_VOID);
 
-    value_type_info = g_type_info_get_param_type (type_info, 1);
-    g_assert (value_type_info != NULL);
-    g_assert (g_type_info_get_tag (value_type_info) != GI_TYPE_TAG_VOID);
+     value_type_info = g_type_info_get_param_type (type_info, 1);
+     g_assert (value_type_info != NULL);
+     g_assert (g_type_info_get_tag (value_type_info) != GI_TYPE_TAG_VOID);
 
-    item_transfer = transfer == GI_TRANSFER_CONTAINER ? GI_TRANSFER_NOTHING : transfer;
+     item_transfer = transfer == GI_TRANSFER_CONTAINER ? GI_TRANSFER_NOTHING : transfer;
 
-    g_hash_table_iter_init (&hash_table_iter, (GHashTable *) arg->v_pointer);
-    while (g_hash_table_iter_next (&hash_table_iter, &key.v_pointer, &value.v_pointer)) {
-        PyObject *py_key;
-        PyObject *py_value;
-        int retval;
+     g_hash_table_iter_init (&hash_table_iter, (GHashTable *) arg->v_pointer);
+     while (g_hash_table_iter_next (&hash_table_iter, &key.v_pointer, &value.v_pointer)) {
+         PyObject *py_key;
+         PyObject *py_value;
+         int retval;
 
-        py_key = _pygi_argument_to_object (&key, key_type_info, item_transfer);
-        if (py_key == NULL) {
-            break;
-        }
+         py_key = _pygi_argument_to_object (&key, key_type_info, item_transfer);
+         if (py_key == NULL) {
+             break;
+         }
 
-        hash_pointer_to_arg (&value, value_type_info);
-        py_value = _pygi_argument_to_object (&value, value_type_info, item_transfer);
-        if (py_value == NULL) {
-            Py_DECREF (py_key);
-            break;
-        }
+         hash_pointer_to_arg (&value, value_type_info);
+         py_value = _pygi_argument_to_object (&value, value_type_info, item_transfer);
+         if (py_value == NULL) {
+             Py_DECREF (py_key);
+             break;
+         }
 
-        retval = PyDict_SetItem (object, py_key, py_value);
+         retval = PyDict_SetItem (object, py_key, py_value);
 
-        Py_DECREF (py_key);
-        Py_DECREF (py_value);
+         Py_DECREF (py_key);
+         Py_DECREF (py_value);
 
-        if (retval < 0) {
-            Py_CLEAR (object);
-            break;
-        }
-    }
+         if (retval < 0) {
+             Py_CLEAR (object);
+             break;
+         }
+     }
 
-    g_base_info_unref ( (GIBaseInfo *) key_type_info);
-    g_base_info_unref ( (GIBaseInfo *) value_type_info);
-    break;
-}
-case GI_TYPE_TAG_ERROR:
-{
-    GError *error = (GError *) arg->v_pointer;
-    if (error != NULL && transfer == GI_TRANSFER_NOTHING) {
-        /* If we have not been transferred the ownership we must copy
-         * the error, because pygi_error_check() is going to free it.
-         */
-        error = g_error_copy (error);
-    }
+     g_base_info_unref ( (GIBaseInfo *) key_type_info);
+     g_base_info_unref ( (GIBaseInfo *) value_type_info);
+     break;
+ }
+ case GI_TYPE_TAG_ERROR:
+ {
+     GError *error = (GError *) arg->v_pointer;
+     if (error != NULL && transfer == GI_TRANSFER_NOTHING) {
+         /* If we have not been transferred the ownership we must copy
+          * the error, because pygi_error_check() is going to free it.
+          */
+         error = g_error_copy (error);
+     }
 
-    if (pygi_error_check (&error)) {
-        PyObject *err_type;
-        PyObject *err_value;
-        PyObject *err_trace;
-        PyErr_Fetch (&err_type, &err_value, &err_trace);
-        Py_XDECREF (err_type);
-        Py_XDECREF (err_trace);
-        object = err_value;
-    } else {
-        object = Py_None;
-        Py_INCREF (object);
-        break;
-    }
-    break;
-}
+     if (pygi_error_check (&error)) {
+         PyObject *err_type;
+         PyObject *err_value;
+         PyObject *err_trace;
+         PyErr_Fetch (&err_type, &err_value, &err_trace);
+         Py_XDECREF (err_type);
+         Py_XDECREF (err_trace);
+         object = err_value;
+     } else {
+         object = Py_None;
+         Py_INCREF (object);
+         break;
+     }
+     break;
+ }
 #endif
-default:
-{
-    obj = gi_marshal_to_scm_basic_type(arg, type_tag, transfer);
-}
-}
+ default:
+ {
+     obj = gi_marshal_to_scm_basic_type(arg, type_tag, transfer);
+ }
+ }
 
 return ret;
 }

--- a/src/gir_function.c
+++ b/src/gir_function.c
@@ -345,7 +345,7 @@ gir_function_invoke (char *name, GIFunctionInfo *info, GObject *object, SCM args
     case 1:
         return scm_car (output);
     default:
-        return output;
+        return scm_values (output);
     }
 }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -121,6 +121,23 @@ DATE_AND_TIME_FUNCTIONS_TESTS = \
  date_copy.scm \
  date_clear.scm
 
+MEMCHK_TESTS = \
+ memchk_1.scm \
+ memchk_2.scm
+
+BYTE_ARRAY_TESTS = \
+ byte_array_new.scm \
+ byte_array_new_take.scm \
+ bytes_new_null_size.scm \
+ bytes_new_null_contents.scm
+
+GAPPLICATION_TESTS = \
+ gapplication_1.scm \
+ gapplication_2.scm
+
+FUZZY_MATCH_TESTS = \
+ fuzzy_match.scm
+
 TESTS = \
  $(VERSION_INFORMATION_TESTS) \
  $(BASIC_TYPE_TESTS) \
@@ -141,14 +158,10 @@ TESTS = \
  $(DATA_CHECKSUM_TESTS) \
  $(SECURE_HMAC_DIGESTS_TESTS) \
  $(DATE_AND_TIME_FUNCTIONS_TESTS) \
- memchk_1.scm \
- memchk_2.scm \
- byte_array_new.scm \
- byte_array_new_take.scm \
- bytes_new_null_size.scm \
- bytes_new_null_contents.scm \
- gapplication_1.scm \
- gapplication_2.scm \
+ $(MEMCHK_TESTS) \
+ $(BYTE_ARRAY_TESTS) \
+ $(GAPPLICATION_TESTS) \
+ $(FUZZY_MATCH_TESTS) \
  softerror_create.scm
 
 XFAIL_TESTS = \

--- a/test/bytes_new_null_contents.scm
+++ b/test/bytes_new_null_contents.scm
@@ -15,21 +15,17 @@
 ;;  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 (use-modules (gi)
-	     (gi glib-2)
-	     (srfi srfi-1)
+	         (gi glib-2)
+	         (ice-9 receive)
              (test automake-test-lib))
 
 (setlocale LC_ALL "C")
 (automake-test
  (begin
-   (let* ((self (Bytes-new #f 0))
-	  (output (call-method self "get-data"))
-	  (data (first output))
-	  (siz (second output)))
-     
-     (format #t "New Byte Array: ~S~%" self)
-     (format #t "Output: ~S~%" output)
-     (format #t "Data: ~S~%" data)
-     (format #t "Size: ~S~%" siz)
-     (and (not data)
-	  (equal? 0 siz)))))
+   (let ((self (Bytes-new #f 0)))
+     (receive (data siz) (call-method self "get-data")
+       (format #t "New Byte Array: ~S~%" self)
+       (format #t "Data: ~S~%" data)
+       (format #t "Size: ~S~%" siz)
+       (and (not data)
+	        (equal? 0 siz))))))

--- a/test/convert.scm
+++ b/test/convert.scm
@@ -13,10 +13,7 @@
                        5
                        "UTF-8"
                        "US-ASCII")))
-   (let ((output (bytevector->u8-list
-                  (pointer->bytevector
-                   (first input)          ; a pointer
-                   (third input)          ; number of output bytes
-                   ))))
+   (let ((output (take (bytevector->u8-list (first input))
+                       (third input))))
      (equal? output '(65 66 67 68 69)   ; UTF-8 'ABCDE'
              ))))

--- a/test/convert.scm
+++ b/test/convert.scm
@@ -1,7 +1,7 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
-             (system foreign)
              (srfi srfi-1)
+             (ice-9 receive)
              (test automake-test-lib))
 
 ;; Convert a bytevector containing an ascii string into
@@ -9,11 +9,11 @@
 ;; unchanged.
 
 (automake-test
- (let ((input (convert (u8-list->bytevector '(65 66 67 68 69)) ; ASCII 'ABCDE'
-                       5
-                       "UTF-8"
-                       "US-ASCII")))
-   (let ((output (take (bytevector->u8-list (first input))
-                       (third input))))
-     (equal? output '(65 66 67 68 69)   ; UTF-8 'ABCDE'
-             ))))
+ (receive (converted bytes-read bytes-written)
+     (convert (u8-list->bytevector '(65 66 67 68 69)) ; ASCII 'ABCDE'
+              5
+              "UTF-8"
+              "US-ASCII")
+   (equal? (take (bytevector->u8-list converted) bytes-written)
+           '(65 66 67 68 69)) ; UTF-8 'ABCDE'
+   ))

--- a/test/convert_latin1.scm
+++ b/test/convert_latin1.scm
@@ -13,11 +13,9 @@
                        2
                        "UTF-8"
                        "ISO-8859-1")))
-   (let ((output (bytevector->u8-list
-                  (pointer->bytevector
-                   (first input)          ; a pointer
-                   (third input)          ; number of output bytes
-                   ))))
+   ;; for some reason, the null byte is still included in the output
+   (let ((output (take (bytevector->u8-list (first input))
+                       (third input))))
      (write output)
      (equal? output '(195 129           ; UTF-8 encoded Á
                           195 137       ; UTF-8 encoded É

--- a/test/convert_latin1.scm
+++ b/test/convert_latin1.scm
@@ -1,22 +1,21 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
-             (system foreign)
              (srfi srfi-1)
+             (ice-9 receive)
              (test automake-test-lib))
 
 ;; Convert a bytevector containing a Latin-1 string into
 ;; a bytevector containg a UTF8 string.
 
 (automake-test
- (let ((input (convert (u8-list->bytevector '(193 ; Latin-1 encoded Á
-                                              201)) ; Latin-1 encoded É
+ (receive (converted bytes-read bytes-written)
+     (convert (u8-list->bytevector '(193 ; Latin-1 encoded Á
+                                     201)) ; Latin-1 encoded É
                        2
                        "UTF-8"
-                       "ISO-8859-1")))
-   ;; for some reason, the null byte is still included in the output
-   (let ((output (take (bytevector->u8-list (first input))
-                       (third input))))
-     (write output)
-     (equal? output '(195 129           ; UTF-8 encoded Á
-                          195 137       ; UTF-8 encoded É
-                          )))))
+                       "ISO-8859-1")
+
+   (equal? (take (bytevector->u8-list converted) bytes-written)
+           '(195 129           ; UTF-8 encoded Á
+                 195 137       ; UTF-8 encoded É
+           ))))

--- a/test/fuzzy_match.scm
+++ b/test/fuzzy_match.scm
@@ -1,0 +1,35 @@
+(use-modules (gi) (gi glib-2)
+             (rnrs bytevectors)
+             (system foreign)
+             (test automake-test-lib))
+
+(catch #t
+  (lambda () (typelib-load "Dazzle" "1.0"))
+  (lambda args (exit EXIT_SKIPPED)))
+
+(define new-data
+  (let ((idx -1))
+    (lambda ()
+      (set! idx (1+ idx))
+      (make-pointer idx))))
+
+(define (bv->match-data bv)
+  (let ((c-struct
+         (parse-c-struct
+          (bytevector->pointer bv)
+          (list '* '* float int))))
+    (cons
+     (pointer->string (car c-struct))
+     (cdr c-struct))))
+
+(automake-test
+ (let ((idx (FuzzyMutableIndex-new #f))
+       (matches '()))
+   (send idx (insert "lorem" (new-data)))
+   (send idx (insert "ipsum" (new-data)))
+   (send idx (insert "dolor" (new-data)))
+   (send idx (insert "sit" (new-data)))
+   (send idx (insert "amet" (new-data)))
+   (set! matches (send idx (match "lor" 0)))
+   (display (map bv->match-data (vector->list matches)))
+   (newline)))

--- a/test/io_channel_new_file.scm
+++ b/test/io_channel_new_file.scm
@@ -1,6 +1,6 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
-             (srfi srfi-1)
+             (ice-9 receive)
              (test automake-test-lib))
 
 (define SIZ 10)
@@ -22,10 +22,9 @@
          (buf (make-bytevector SIZ 0)))
 
      ;; Read as much as we can.
-     (let ((status/nbytes (send channel (read-chars buf SIZ))))
-       (let ((status      (first  status/nbytes))
-             (nbytes      (second status/nbytes)))
-         (let ((bv (subbytevector buf 0 nbytes)))
+     (receive (status nbytes)
+         (send channel (read-chars buf SIZ))
+       (let ((bv (subbytevector buf 0 nbytes)))
            (format #t "Output bytevector contents: ~S~%" bv)
            (format #t "Output bytevector as UTF8: ~S~%" (utf8->string bv))
            (format #t "Bytes read: ~S~%" nbytes)
@@ -34,4 +33,4 @@
                  (utf8->string bv)
                  "foobar")
                 (equal? 6               ; the number of bytes in 'foobar'
-                        nbytes))))))))
+                        nbytes)))))))

--- a/test/io_channel_pipe.scm
+++ b/test/io_channel_pipe.scm
@@ -1,5 +1,6 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
+             (ice-9 receive)
              (test automake-test-lib))
 
 (define SIZ 10)
@@ -10,7 +11,6 @@
     bv2))
 
 (automake-test
-
  ;; let's make a pipe to push data through
  (let* ((ports (pipe))
         (in-port (car ports))
@@ -31,15 +31,13 @@
        (display "hello" out-port)
        (close out-port)
 
-       ;; 
-       (let ((status-nbytes (send channel (read-chars buf SIZ))))
-         (let ((status (car status-nbytes))
-               (nbytes-read (cadr status-nbytes)))
-               
-           (write (utf8->string buf)) (newline)
-           (write status-nbytes) (newline)
+       ;;
+       (receive (status nbytes-read)
+           (send channel (read-chars buf SIZ))
+         (write (utf8->string buf)) (newline)
+           (write (list status nbytes-read)) (newline)
            (and (string=?
                  (utf8->string (subbytevector buf 0 5))
                  "hello")
                 (equal? 5               ; the number of bytes in 'hello'
-                        nbytes-read))))))))
+                        nbytes-read)))))))

--- a/test/io_channel_unichar.scm
+++ b/test/io_channel_unichar.scm
@@ -10,6 +10,10 @@
     (bytevector-copy! bv start bv2 0 (- end start))
     bv2))
 
+(define-syntax-rule (second-value body)
+  (call-with-values (lambda () body)
+    (lambda args (second args))))
+
 (automake-test
  (begin
    ;; Let's make a channel that writes to a file.
@@ -20,8 +24,8 @@
 
    ;; Now, make a channel that reads from that file.
    (let* ((channel (IOChannel-new-file "tmp.txt" "r"))
-          (alpha (second (send channel (read-unichar))))
-          (beta  (second (send channel (read-unichar)))))
+          (alpha (second-value (send channel (read-unichar))))
+          (beta  (second-value (send channel (read-unichar)))))
      (write alpha) (newline)
      (write beta) (newline)
      (and

--- a/test/str_tokenize_and_fold.scm
+++ b/test/str_tokenize_and_fold.scm
@@ -1,6 +1,7 @@
 (use-modules (gi) (gi glib-2)
              (rnrs bytevectors)
              (test automake-test-lib)
+             (ice-9 receive)
              (srfi srfi-1))
 
 ;; FIXME: the ascii-alternates output parameter
@@ -13,10 +14,9 @@
 ;;                         gchar ***ascii_alternates);
 
 (automake-test
- (let ((out (str-tokenize-and-fold "Les pâtes" "fr_FR")))
-   (let ((tokens (car out))
-         (ascii-alternates (cadr out)))
-     (write tokens) (newline)
+ (receive (tokens ascii-alternates)
+     (str-tokenize-and-fold "Les pâtes" "fr_FR")
+   (write tokens) (newline)
      (write ascii-alternates) (newline)
      ;; take case-folding into account
-     (every string-ci=? (list "Les" "pâtes") tokens))))
+     (every string-ci=? (list "Les" "pâtes") tokens)))


### PR DESCRIPTION
Since one of them was refactored, why leave the other unchanged?
`array_info` structs are now filled in a single place, that should make it easier to implement support for other array types without too much copy&paste programming (hopefully).
Somewhat unrelated, I also indented the whole file in Emacs with the "stroustrup" style, which seemed to match the project's C style pretty much.