### PR TITLE
resources, module definitions in C and indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .libs
 *.out
 *.go
+*.gresource
 
 GPATH
 GRTAGS

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,8 @@ GUILE_PROGS
 GUILE_FLAGS
 GUILE_SITE_DIR
 
+AC_PATH_PROG([GLIB_COMPILE_RESOURCES],[glib-compile-resources])
+
 ################
 # Guile has three directories that don't follow the GNU Filesystem
 # Heirarchy Standards.  If one follows the GNU FHS, files get installed
@@ -224,6 +226,7 @@ AC_CONFIG_FILES([
  test/Makefile
  tools/Makefile
  examples/Makefile
+ examples/resources/Makefile
  ])
 AC_CONFIG_FILES([tools/uninstalled-env], [chmod +x tools/uninstalled-env])
 AC_CONFIG_FILES([tools/run-guile], [chmod +x tools/run-guile])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -16,3 +16,5 @@ builderdir = $(datadir)/doc/guile-gi/builder
 dist_builder_DATA = \
  builder/main.scm \
  builder/builder.ui
+
+SUBDIRS = resources

--- a/examples/resources/Makefile.am
+++ b/examples/resources/Makefile.am
@@ -1,0 +1,13 @@
+resourcesdir = $(datadir)/doc/guile-gi/resources
+dist_resources_DATA = \
+ main.scm \
+ builder.ui \
+ test.gresource.xml
+
+nodist_resources_DATA = \
+ test.gresource
+
+test.gresource: test.gresource.xml
+	$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) $<
+
+CLEANFILES := test.gresource

--- a/examples/resources/builder.ui
+++ b/examples/resources/builder.ui
@@ -1,0 +1,45 @@
+<interface>
+  <object id="window" class="GtkWindow">
+    <property name="visible">True</property>
+    <property name="title">Grid</property>
+    <property name="border-width">10</property>
+    <child>
+      <object id="grid" class="GtkGrid">
+        <property name="visible">True</property>
+        <child>
+          <object id="button1" class="GtkButton">
+            <property name="visible">True</property>
+            <property name="label">Button 1</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object id="button2" class="GtkButton">
+            <property name="visible">True</property>
+            <property name="label">Button 2</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object id="quit" class="GtkButton">
+            <property name="visible">True</property>
+            <property name="label">Quit</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
+            <property name="width">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/examples/resources/main.scm
+++ b/examples/resources/main.scm
@@ -1,0 +1,48 @@
+(use-modules (gi)
+             (ice-9 ftw))
+
+(use-typelibs ("Gio" "2.0")
+              (("Gtk" "3.0") #:prefix gtk::))
+
+(define (print-hello button data)
+  (display "Hello World")
+  (newline))
+
+(define find-resource
+  (compose resource:load
+           (lambda (filename)
+             (let ((location
+                    (ftw (getcwd)
+                         (lambda (pathname statinfo flag)
+                           (if (string-suffix? filename pathname)
+                               pathname
+                               #t)))))
+               (unless (string? location)
+                 (error "Can't find file ~S" filename))
+               location))
+           (lambda (resource)
+             (string-append resource ".gresource"))))
+
+(define (main)
+  (gtk::init 0 #f)
+
+  (resources-register (find-resource "test"))
+
+  (let* ((builder (gtk::builder:new-from-resource "/test/builder.ui"))
+         (window (send builder (get-object "window")))
+         (button1 (send builder (get-object "button1")))
+         (button2 (send builder (get-object "button2")))
+         (button3 (send builder (get-object "quit"))))
+    (connect window (destroy
+                       (lambda (object data)
+                         (gtk::main-quit))))
+    (connect button1 (clicked print-hello))
+    (connect button2 (clicked print-hello))
+    (connect button3 (clicked
+                      (lambda (button data)
+                        (gtk::main-quit)))))
+
+  (gtk::main)
+  *unspecified*)
+
+(main)

--- a/examples/resources/test.gresource.xml
+++ b/examples/resources/test.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/test">
+    <file compressed="true">builder.ui</file>
+  </gresource>
+</gresources>

--- a/src/.indent.pro
+++ b/src/.indent.pro
@@ -1,0 +1,79 @@
+/* Requires GNU indent 2.2.12
+ * - use long options for readability
+ * - group options logically
+ * - indent apparently does not understand attributes, so surround function
+ *   declarations using them *INDENT-OFF* and *INDENT-ON* comments.
+ * - you may wish to indent in-place without creating backups using
+ *   `VERSION_CONTROL=none indent ...'
+ */
+--line-length 99
+--indent-level 4
+--indent-label 2
+--no-tabs
+
+/* alignment */
+--continue-at-parentheses
+--break-after-boolean-operator
+
+/* brace style: "basically" Stroustrup */
+--braces-after-struct-decl-line
+--braces-after-func-def-line
+--braces-on-if-line
+--dont-cuddle-else
+--case-brace-indentation 0
+
+/* spacing */
+--no-space-after-function-call-names
+--space-after-if
+--no-space-after-casts
+
+/* blank lines */
+--no-blank-lines-after-commas
+--blank-lines-after-procedures
+
+/* don't confuse make
+ * does this even work?
+ */
+--preserve-mtime
+
+/* misc... */
+--start-left-side-of-comments
+--pointer-align-right
+
+/* put typedefs here
+ * GLib contains a lot of them, so really only update this list if something
+ * breaks, e.g. misaligned pointers
+ */
+-T SCM
+
+-T ffi_cif
+-T ffi_closure
+
+-T gboolean
+-T gchar
+-T gint
+-T gssize
+-T GClosure
+-T GObject
+-T GObjectClass
+-T GParamSpec
+-T GPtrArray
+-T GTypeInstance
+-T GValue
+
+-T GIArgInfo
+-T GIArgument
+-T GIBaseInfo
+-T GICallableInfo
+-T GICallbackInfo
+-T GIConstantInfo
+-T GIEnumInfo
+-T GIFunctionInfo
+-T GIInterfaceInfo
+-T GIObjectInfo
+-T GISignalInfo
+-T GITypeInfo
+
+-T GirPredicate
+-T GuGObjectData
+-T SignalSpec

--- a/src/fo_gen.c
+++ b/src/fo_gen.c
@@ -4,341 +4,334 @@
 
 FILE *fp;
 
-static char * __attribute__((malloc))
-getter (const char *self, const char *type, int n)
+/* *INDENT-OFF* */
+__attribute__ ((malloc)) static char *
+getter(const char *self, const char *type, int n)
+/* *INDENT-ON* */
 {
-  if ((strlen (type) > 2 && type[strlen(type)-1] == '*')
-      || (!strcmp (type, "gpointer")))
-    return g_strdup_printf ("(%s) scm_foreign_object_ref (%s, %d)", type, self, n);
-  else if (!strcmp (type, "GType") || !strcmp (type, "size_t"))
-    return g_strdup_printf ("(%s) GPOINTER_TO_SIZE (scm_foreign_object_ref (%s, %d))",
-			    type, self, n);
-  else if (!strcmp (type, "gboolean") || !strcmp (type, "bool"))
-    return g_strdup_printf ("(%s) GPOINTER_TO_SIZE(scm_foreign_object_ref (%s, %d))",
-			    type, self, n);
-  else if (!strcmp (type, "gint") || !strcmp (type, "int"))
-    return g_strdup_printf ("(%s) GPOINTER_TO_INT (scm_foreign_object_ref (%s, %d))",
-			    type, self, n);
-  else if (!strcmp (type, "SCM"))
-    return g_strdup_printf ("SCM_PACK_POINTER (scm_foreign_object_ref (%s, %d))", self, n);
-  else {
-    fprintf (stderr, "UNKNOWN TYPE %s\n", type);
-    return g_strdup_printf ("scm_foreign_object_ref (%s, %d)", self, n);
-  }
-}
-
-static char * __attribute__((malloc))
-setter (const char *self, const char *var, const char *type, int n)
-{
-  if ((strlen (type) > 2 && type[strlen(type)-1] == '*')
-      || (!strcmp (type, "gpointer")))
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d, %s)", self, n, var);
-  else if (!strcmp (type, "GType") || !strcmp (type, "size_t"))
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d, GSIZE_TO_POINTER (%s))",
-			    self, n, var);
-  else if (!strcmp (type, "gboolean") || !strcmp (type, "bool"))
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d,  GSIZE_TO_POINTER (%s))",
-			    self, n, var);
-  else if (!strcmp (type, "gint") || !strcmp (type, "int"))
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d, GINT_TO_POINTER(%s))",
-			    self, n, var);
-  else if (!strcmp (type, "SCM"))
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d, SCM_UNPACK_POINTER (%s))",
-			    self, n, var);
-  else {
-    fprintf (stderr, "UNKNOWN TYPE %s\n", type);
-
-    return g_strdup_printf ("scm_foreign_object_set_x (%s, %d, %s)", self, n, var);
-  }
-}
-
-static void
-do_includes (char *name)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  char *filename = g_strdup_printf("__gi_%s.h", lower);
-
-  fprintf(fp, "#include <libguile.h>\n");
-  fprintf(fp, "#include <glib.h>\n");
-  fprintf(fp, "#include <glib-object.h>\n");
-  fprintf(fp, "#include <girepository.h>\n");
-  fprintf(fp, "#include \"%s\"\n", filename);
-  fprintf(fp, "\n");
-  g_free (filename);
-  g_free (lower);
-}
-
-static void
-do_header_includes (char *name)
-{
-  fprintf(fp, "#ifndef ___GI_%s_H_\n", name);
-  fprintf(fp, "#define ___GI_%s_H_\n", name);
-  fprintf(fp, "#include <libguile.h>\n");
-  fprintf(fp, "#include <glib.h>\n");
-  fprintf(fp, "#include <glib-object.h>\n");
-  fprintf(fp, "\n");
-}
-
-static void
-do_declaration (const gchar *name, gsize n, gchar **fields, gboolean finalizer)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  gchar *upper = g_ascii_strup(name, -1);
-  fprintf(fp, "SCM gi_%s_type;\n", lower);
-  fprintf(fp, "SCM gi_%s_type_store;\n", lower);
-  fprintf(fp, "\n");
-
-  for (int i = 0; i < (int) n; i ++)
-    {
-      gchar *field_upper = g_ascii_strup(fields[i], -1);
-      fprintf(fp, "#define GI_%s_%s_SLOT (%u)\n", upper, field_upper, i);
-      g_free (field_upper);
+    if ((strlen(type) > 2 && type[strlen(type) - 1] == '*')
+        || (!strcmp(type, "gpointer")))
+        return g_strdup_printf("(%s) scm_foreign_object_ref (%s, %d)", type, self, n);
+    else if (!strcmp(type, "GType") || !strcmp(type, "size_t"))
+        return g_strdup_printf("(%s) GPOINTER_TO_SIZE (scm_foreign_object_ref (%s, %d))",
+                               type, self, n);
+    else if (!strcmp(type, "gboolean") || !strcmp(type, "bool"))
+        return g_strdup_printf("(%s) GPOINTER_TO_SIZE(scm_foreign_object_ref (%s, %d))",
+                               type, self, n);
+    else if (!strcmp(type, "gint") || !strcmp(type, "int"))
+        return g_strdup_printf("(%s) GPOINTER_TO_INT (scm_foreign_object_ref (%s, %d))",
+                               type, self, n);
+    else if (!strcmp(type, "SCM"))
+        return g_strdup_printf("SCM_PACK_POINTER (scm_foreign_object_ref (%s, %d))", self, n);
+    else {
+        fprintf(stderr, "UNKNOWN TYPE %s\n", type);
+        return g_strdup_printf("scm_foreign_object_ref (%s, %d)", self, n);
     }
-
-  fprintf(fp, "\n");
-  g_free (lower);
-  g_free (upper);
 }
 
-static void
-do_header_declaration (const gchar *name, gsize n, gchar **fields, gboolean finalizer)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  gchar *upper = g_ascii_strup(name, -1);
-  fprintf(fp, "extern SCM gi_%s_type;\n", lower);
-  fprintf(fp, "extern SCM gi_%s_type_store;\n", lower);
-  if (finalizer)
-    fprintf(fp, "void gi_%s_finalizer (SCM self);\n", lower);
-  fprintf(fp, "\n");
-  g_free (lower);
-  g_free (upper);
-}
+/* *INDENT-OFF* */
+__attribute__ ((malloc)) static char *
+setter(const char *self, const char *var, const char *type, int n)
+/* *INDENT-ON* */
 
-static void
-do_predicate (const gchar *name)
 {
-  gchar *lower = g_ascii_strdown (name, -1);
-  fprintf (fp, "SCM gi_%s_p (SCM self)\n", lower);
-  fprintf (fp, "{\n");
-  fprintf (fp, "  return scm_from_bool (SCM_IS_A_P (self, gi_%s_type));\n",
-	   lower);
-  fprintf (fp, "}\n");
-}
+    if ((strlen(type) > 2 && type[strlen(type) - 1] == '*')
+        || (!strcmp(type, "gpointer")))
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d, %s)", self, n, var);
+    else if (!strcmp(type, "GType") || !strcmp(type, "size_t"))
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d, GSIZE_TO_POINTER (%s))",
+                               self, n, var);
+    else if (!strcmp(type, "gboolean") || !strcmp(type, "bool"))
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d,  GSIZE_TO_POINTER (%s))",
+                               self, n, var);
+    else if (!strcmp(type, "gint") || !strcmp(type, "int"))
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d, GINT_TO_POINTER(%s))",
+                               self, n, var);
+    else if (!strcmp(type, "SCM"))
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d, SCM_UNPACK_POINTER (%s))",
+                               self, n, var);
+    else {
+        fprintf(stderr, "UNKNOWN TYPE %s\n", type);
 
-static void
-do_header_predicate (const gchar *name)
-{
-  gchar *lower = g_ascii_strdown (name, -1);
-  fprintf (fp, "SCM gi_%s_p (SCM self);\n", lower);
-}
-
-static void
-do_getters (const gchar *name, gsize n, gchar **fields, gchar **types)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  for (gsize i = 0; i < n; i ++)
-    {
-      gchar *field_lower = g_ascii_strdown (fields[i], -1);
-      gchar *func_name = g_strdup_printf("gi_%s_get_%s", lower, field_lower);
-      gchar *conv = getter("self", types[i], i);
-      fprintf (fp, "%s\n", types[i]);
-      fprintf (fp, "%s (SCM %s)\n", func_name, "self");
-      fprintf (fp, "{\n");
-      fprintf (fp, "\treturn %s;\n", conv);
-      fprintf (fp, "}\n");
-      fprintf (fp, "\n");
-      g_free (conv);
-      g_free (func_name);
-      g_free (field_lower);
+        return g_strdup_printf("scm_foreign_object_set_x (%s, %d, %s)", self, n, var);
     }
-  g_free (lower);
 }
 
 static void
-do_header_getters (const gchar *name, gsize n, gchar **fields, gchar **types)
+do_includes(char *name)
 {
-  gchar *lower = g_ascii_strdown(name, -1);
-  for (gsize i = 0; i < n; i ++)
-    {
-      gchar *field_lower = g_ascii_strdown (fields[i], -1);
-      gchar *func_name = g_strdup_printf("gi_%s_get_%s", lower, field_lower);
-      gchar *conv = getter("self", types[i], i);
-      fprintf (fp, "%s", types[i]);
-      fprintf (fp, "\t%s (SCM %s);\n", func_name, "self");
-      g_free (conv);
-      g_free (func_name);
-      g_free (field_lower);
-    }
-  g_free (lower);
-}
+    gchar *lower = g_ascii_strdown(name, -1);
+    char *filename = g_strdup_printf("__gi_%s.h", lower);
 
-static void
-do_setters (const gchar *name, gsize n, gchar **fields, gchar **types)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  for (gsize i = 0; i < n; i ++)
-    {
-      gchar *field_lower = g_ascii_strdown (fields[i], -1);
-      gchar *func_name = g_strdup_printf("gi_%s_set_%s", lower, field_lower);
-      gchar *conv = setter("self", "val", types[i], i);
-      fprintf (fp, "void\n");
-      fprintf (fp, "%s (SCM self, %s val)\n", func_name, types[i]);
-      fprintf (fp, "{\n");
-      fprintf (fp, "\t%s;\n", conv);
-      fprintf (fp, "}\n");
-      fprintf (fp, "\n");
-      g_free (conv);
-      g_free (func_name);
-      g_free (field_lower);
-    }
-  g_free (lower);
-}
-
-static void
-do_header_setters (const gchar *name, gsize n, gchar **fields, gchar **types)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  for (gsize i = 0; i < n; i ++)
-    {
-      gchar *field_lower = g_ascii_strdown (fields[i], -1);
-      gchar *func_name = g_strdup_printf("gi_%s_set_%s", lower, field_lower);
-      gchar *conv = setter("self", "val", types[i], i);
-      fprintf (fp, "void");
-      fprintf (fp, "\t%s (SCM self, %s val);\n", func_name, types[i]);
-      g_free (conv);
-      g_free (func_name);
-      g_free (field_lower);
-    }
-  g_free (lower);
-}
-
-static void
-do_init (const gchar *name, gsize n, gchar **fields, gboolean finalizer)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  gchar *func_name = g_strdup_printf("gi_init_%s_type", lower);
-  fprintf (fp, "void\n");
-  fprintf (fp, "%s (void)\n", func_name);
-  fprintf (fp, "{\n");
-  fprintf (fp, "\tSCM name, slots;\n");
-  fprintf (fp, "\tname = scm_from_utf8_symbol(\"<%s>\");\n", name);
-  fprintf (fp, "\tslots = scm_list_n(\n");
-  for (gsize i = 0; i < n; i ++)
-    {
-      fprintf(fp, "\t\tscm_from_utf8_symbol (\"%s\"),\n", fields[i]);
-    }
-  fprintf (fp, "\t\tSCM_UNDEFINED);\n");
-  fprintf (fp, "\tgi_%s_type = scm_make_foreign_object_type (name, slots, ", lower);
-  if (finalizer)
-    fprintf (fp, "gi_%s_finalizer", lower);
-  else
-    fprintf (fp, "NULL");
-  fprintf (fp, ");\n");
-  fprintf (fp, "\tgi_%s_type_store = scm_c_define (\"<%s>\", gi_%s_type);\n", lower, name, lower);
-  fprintf (fp, "\tscm_c_define_gsubr (\"%s?\", 1, 0, 0, gi_%s_p);\n",
-	   lower, lower);
-  fprintf (fp, "\tscm_c_export (\"%s\", \"%s?\", NULL);\n", name, lower);
-  fprintf (fp, "}\n");
-  g_free (lower);
-  g_free (func_name);
-}
-
-static void
-do_header_init (const gchar *name, gsize n, gchar **fields, gboolean finalizer)
-{
-  gchar *lower = g_ascii_strdown(name, -1);
-  gchar *func_name = g_strdup_printf("gi_init_%s_type", lower);
-  fprintf (fp, "void");
-  fprintf (fp, "\t%s (void);\n", func_name);
-  fprintf (fp, "#endif\n");
-  g_free (lower);
-  g_free (func_name);
-}
-
-int main(int argc, char **argv)
-{
-  GKeyFile *key_file = g_key_file_new();
-  GError *error = NULL;
-  gchar *name;
-  gchar **names;
-  gsize n_names;
-  gchar *lowercase;
-  gchar **fields;
-  gchar **types;
-  gboolean finalizer;
-  gsize n_fields;
-  gsize n_types;
-
-  if (argc < 3)
-  {
-    printf("Usage: fo_gen INI_FILE OUTPUT_PATH\n");
-    return 1;
-  }
-
-  g_key_file_set_list_separator(key_file, ',');
-  printf("Trying %s\n", argv[1]);
-  if (!g_key_file_load_from_file(key_file, argv[1], G_KEY_FILE_NONE, &error))
-  {
-    if (!g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-    {
-      g_warning("Error loading key file %s", error->message);
-      g_error_free(error);
-      error = NULL;
-      return 1;
-    }
-  }
-  names = g_key_file_get_string_list(key_file, "Foreign Objects", "Names", &n_names, &error);
-  for (gsize n = 0; n < n_names; n++)
-  {
-    char *filename;
-    char *filepath;
-    name = g_key_file_get_string(key_file, names[n], "Name", NULL);
-    fields = g_key_file_get_string_list(key_file, names[n], "Fields", &n_fields, NULL);
-    types = g_key_file_get_string_list(key_file, names[n], "Types", &n_types, NULL);
-    if (name == NULL || fields == NULL || types == NULL)
-      {
-	printf("Missing fields for %s\n", names[n]);
-	continue;
-      }
-    lowercase = g_ascii_strdown(name, -1);
-    finalizer = g_key_file_get_boolean(key_file, names[n], "Finalizer", NULL);
-
-    filename = g_strdup_printf("__gi_%s.c", lowercase);
-    filepath = g_build_filename(argv[2], filename, NULL);
-    fp = fopen(filepath, "wt");
-
-    do_includes(name);
-    do_declaration(name, n_fields, fields, finalizer);
-    do_getters(name, n_fields, fields, types);
-    do_setters(name, n_fields, fields, types);
-    do_predicate(name);
-    do_init(name, n_fields, fields, finalizer);
-
-    fclose(fp);
+    fprintf(fp, "#include <libguile.h>\n");
+    fprintf(fp, "#include <glib.h>\n");
+    fprintf(fp, "#include <glib-object.h>\n");
+    fprintf(fp, "#include <girepository.h>\n");
+    fprintf(fp, "#include \"%s\"\n", filename);
+    fprintf(fp, "\n");
     g_free(filename);
-    g_free(filepath);
+    g_free(lower);
+}
 
-    filename = g_strdup_printf("__gi_%s.h", lowercase);
-    filepath = g_build_filename(argv[2], filename, NULL);
-    fp = fopen(filepath, "wt");
+static void
+do_header_includes(char *name)
+{
+    fprintf(fp, "#ifndef ___GI_%s_H_\n", name);
+    fprintf(fp, "#define ___GI_%s_H_\n", name);
+    fprintf(fp, "#include <libguile.h>\n");
+    fprintf(fp, "#include <glib.h>\n");
+    fprintf(fp, "#include <glib-object.h>\n");
+    fprintf(fp, "\n");
+}
 
-    do_header_includes(name);
-    do_header_declaration(name, n_fields, fields, finalizer);
-    do_header_getters(name, n_fields, fields, types);
-    do_header_setters(name, n_fields, fields, types);
-    do_header_predicate(name);
-    do_header_init(name, n_fields, fields, finalizer);
+static void
+do_declaration(const gchar *name, gsize n, gchar **fields, gboolean finalizer)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    gchar *upper = g_ascii_strup(name, -1);
+    fprintf(fp, "SCM gi_%s_type;\n", lower);
+    fprintf(fp, "SCM gi_%s_type_store;\n", lower);
+    fprintf(fp, "\n");
 
-    fclose(fp);
-    g_free(filename);
-    g_free(filepath);
+    for (int i = 0; i < (int)n; i++) {
+        gchar *field_upper = g_ascii_strup(fields[i], -1);
+        fprintf(fp, "#define GI_%s_%s_SLOT (%u)\n", upper, field_upper, i);
+        g_free(field_upper);
+    }
 
-    g_free(lowercase);
-    g_free(name);
-    g_strfreev(fields);
-    g_strfreev(types);
-  }
+    fprintf(fp, "\n");
+    g_free(lower);
+    g_free(upper);
+}
 
-  g_key_file_free(key_file);
-  return 0;
+static void
+do_header_declaration(const gchar *name, gsize n, gchar **fields, gboolean finalizer)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    gchar *upper = g_ascii_strup(name, -1);
+    fprintf(fp, "extern SCM gi_%s_type;\n", lower);
+    fprintf(fp, "extern SCM gi_%s_type_store;\n", lower);
+    if (finalizer)
+        fprintf(fp, "void gi_%s_finalizer (SCM self);\n", lower);
+    fprintf(fp, "\n");
+    g_free(lower);
+    g_free(upper);
+}
+
+static void
+do_predicate(const gchar *name)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    fprintf(fp, "SCM gi_%s_p (SCM self)\n", lower);
+    fprintf(fp, "{\n");
+    fprintf(fp, "  return scm_from_bool (SCM_IS_A_P (self, gi_%s_type));\n", lower);
+    fprintf(fp, "}\n");
+}
+
+static void
+do_header_predicate(const gchar *name)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    fprintf(fp, "SCM gi_%s_p (SCM self);\n", lower);
+}
+
+static void
+do_getters(const gchar *name, gsize n, gchar **fields, gchar **types)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    for (gsize i = 0; i < n; i++) {
+        gchar *field_lower = g_ascii_strdown(fields[i], -1);
+        gchar *func_name = g_strdup_printf("gi_%s_get_%s", lower, field_lower);
+        gchar *conv = getter("self", types[i], i);
+        fprintf(fp, "%s\n", types[i]);
+        fprintf(fp, "%s (SCM %s)\n", func_name, "self");
+        fprintf(fp, "{\n");
+        fprintf(fp, "\treturn %s;\n", conv);
+        fprintf(fp, "}\n");
+        fprintf(fp, "\n");
+        g_free(conv);
+        g_free(func_name);
+        g_free(field_lower);
+    }
+    g_free(lower);
+}
+
+static void
+do_header_getters(const gchar *name, gsize n, gchar **fields, gchar **types)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    for (gsize i = 0; i < n; i++) {
+        gchar *field_lower = g_ascii_strdown(fields[i], -1);
+        gchar *func_name = g_strdup_printf("gi_%s_get_%s", lower, field_lower);
+        gchar *conv = getter("self", types[i], i);
+        fprintf(fp, "%s", types[i]);
+        fprintf(fp, "\t%s (SCM %s);\n", func_name, "self");
+        g_free(conv);
+        g_free(func_name);
+        g_free(field_lower);
+    }
+    g_free(lower);
+}
+
+static void
+do_setters(const gchar *name, gsize n, gchar **fields, gchar **types)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    for (gsize i = 0; i < n; i++) {
+        gchar *field_lower = g_ascii_strdown(fields[i], -1);
+        gchar *func_name = g_strdup_printf("gi_%s_set_%s", lower, field_lower);
+        gchar *conv = setter("self", "val", types[i], i);
+        fprintf(fp, "void\n");
+        fprintf(fp, "%s (SCM self, %s val)\n", func_name, types[i]);
+        fprintf(fp, "{\n");
+        fprintf(fp, "\t%s;\n", conv);
+        fprintf(fp, "}\n");
+        fprintf(fp, "\n");
+        g_free(conv);
+        g_free(func_name);
+        g_free(field_lower);
+    }
+    g_free(lower);
+}
+
+static void
+do_header_setters(const gchar *name, gsize n, gchar **fields, gchar **types)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    for (gsize i = 0; i < n; i++) {
+        gchar *field_lower = g_ascii_strdown(fields[i], -1);
+        gchar *func_name = g_strdup_printf("gi_%s_set_%s", lower, field_lower);
+        gchar *conv = setter("self", "val", types[i], i);
+        fprintf(fp, "void");
+        fprintf(fp, "\t%s (SCM self, %s val);\n", func_name, types[i]);
+        g_free(conv);
+        g_free(func_name);
+        g_free(field_lower);
+    }
+    g_free(lower);
+}
+
+static void
+do_init(const gchar *name, gsize n, gchar **fields, gboolean finalizer)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    gchar *func_name = g_strdup_printf("gi_init_%s_type", lower);
+    fprintf(fp, "void\n");
+    fprintf(fp, "%s (void)\n", func_name);
+    fprintf(fp, "{\n");
+    fprintf(fp, "\tSCM name, slots;\n");
+    fprintf(fp, "\tname = scm_from_utf8_symbol(\"<%s>\");\n", name);
+    fprintf(fp, "\tslots = scm_list_n(\n");
+    for (gsize i = 0; i < n; i++) {
+        fprintf(fp, "\t\tscm_from_utf8_symbol (\"%s\"),\n", fields[i]);
+    }
+    fprintf(fp, "\t\tSCM_UNDEFINED);\n");
+    fprintf(fp, "\tgi_%s_type = scm_make_foreign_object_type (name, slots, ", lower);
+    if (finalizer)
+        fprintf(fp, "gi_%s_finalizer", lower);
+    else
+        fprintf(fp, "NULL");
+    fprintf(fp, ");\n");
+    fprintf(fp, "\tgi_%s_type_store = scm_c_define (\"<%s>\", gi_%s_type);\n", lower, name, lower);
+    fprintf(fp, "\tscm_c_define_gsubr (\"%s?\", 1, 0, 0, gi_%s_p);\n", lower, lower);
+    fprintf(fp, "\tscm_c_export (\"%s\", \"%s?\", NULL);\n", name, lower);
+    fprintf(fp, "}\n");
+    g_free(lower);
+    g_free(func_name);
+}
+
+static void
+do_header_init(const gchar *name, gsize n, gchar **fields, gboolean finalizer)
+{
+    gchar *lower = g_ascii_strdown(name, -1);
+    gchar *func_name = g_strdup_printf("gi_init_%s_type", lower);
+    fprintf(fp, "void");
+    fprintf(fp, "\t%s (void);\n", func_name);
+    fprintf(fp, "#endif\n");
+    g_free(lower);
+    g_free(func_name);
+}
+
+int
+main(int argc, char **argv)
+{
+    GKeyFile *key_file = g_key_file_new();
+    GError *error = NULL;
+    gchar *name;
+    gchar **names;
+    gsize n_names;
+    gchar *lowercase;
+    gchar **fields;
+    gchar **types;
+    gboolean finalizer;
+    gsize n_fields;
+    gsize n_types;
+
+    if (argc < 3) {
+        printf("Usage: fo_gen INI_FILE OUTPUT_PATH\n");
+        return 1;
+    }
+
+    g_key_file_set_list_separator(key_file, ',');
+    printf("Trying %s\n", argv[1]);
+    if (!g_key_file_load_from_file(key_file, argv[1], G_KEY_FILE_NONE, &error)) {
+        if (!g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+            g_warning("Error loading key file %s", error->message);
+            g_error_free(error);
+            error = NULL;
+            return 1;
+        }
+    }
+    names = g_key_file_get_string_list(key_file, "Foreign Objects", "Names", &n_names, &error);
+    for (gsize n = 0; n < n_names; n++) {
+        char *filename;
+        char *filepath;
+        name = g_key_file_get_string(key_file, names[n], "Name", NULL);
+        fields = g_key_file_get_string_list(key_file, names[n], "Fields", &n_fields, NULL);
+        types = g_key_file_get_string_list(key_file, names[n], "Types", &n_types, NULL);
+        if (name == NULL || fields == NULL || types == NULL) {
+            printf("Missing fields for %s\n", names[n]);
+            continue;
+        }
+        lowercase = g_ascii_strdown(name, -1);
+        finalizer = g_key_file_get_boolean(key_file, names[n], "Finalizer", NULL);
+
+        filename = g_strdup_printf("__gi_%s.c", lowercase);
+        filepath = g_build_filename(argv[2], filename, NULL);
+        fp = fopen(filepath, "wt");
+
+        do_includes(name);
+        do_declaration(name, n_fields, fields, finalizer);
+        do_getters(name, n_fields, fields, types);
+        do_setters(name, n_fields, fields, types);
+        do_predicate(name);
+        do_init(name, n_fields, fields, finalizer);
+
+        fclose(fp);
+        g_free(filename);
+        g_free(filepath);
+
+        filename = g_strdup_printf("__gi_%s.h", lowercase);
+        filepath = g_build_filename(argv[2], filename, NULL);
+        fp = fopen(filepath, "wt");
+
+        do_header_includes(name);
+        do_header_declaration(name, n_fields, fields, finalizer);
+        do_header_getters(name, n_fields, fields, types);
+        do_header_setters(name, n_fields, fields, types);
+        do_header_predicate(name);
+        do_header_init(name, n_fields, fields, finalizer);
+
+        fclose(fp);
+        g_free(filename);
+        g_free(filepath);
+
+        g_free(lowercase);
+        g_free(name);
+        g_strfreev(fields);
+        g_strfreev(types);
+    }
+
+    g_key_file_free(key_file);
+    return 0;
 }

--- a/src/gi_gboxed.c
+++ b/src/gi_gboxed.c
@@ -6,10 +6,10 @@
 GQuark gugboxed_type_key;
 
 void
-gi_gboxed_finalizer (SCM self)
+gi_gboxed_finalizer(SCM self)
 {
-    if (gi_gboxed_get_free_on_dealloc (self) && gi_gboxed_get_ptr (self))
-	g_boxed_free (gi_gboxed_get_gtype (self), gi_gboxed_get_ptr (self));
+    if (gi_gboxed_get_free_on_dealloc(self) && gi_gboxed_get_ptr(self))
+        g_boxed_free(gi_gboxed_get_gtype(self), gi_gboxed_get_ptr(self));
     gi_gboxed_set_ptr(self, NULL);
 }
 
@@ -20,8 +20,7 @@ gi_gboxed_finalizer (SCM self)
  * reference to the wrapper class is stored in the module. */
 
 SCM
-gi_register_gboxed (SCM module, const gchar *class_name,
-		    GType boxed_type)
+gi_register_gboxed(SCM module, const gchar *class_name, GType boxed_type)
 {
     SCM type;
 
@@ -34,7 +33,7 @@ gi_register_gboxed (SCM module, const gchar *class_name,
 #endif
 
 SCM
-gi_gboxed_new (GType boxed_type, gpointer boxed, gboolean copy_boxed, gboolean own_ref)
+gi_gboxed_new(GType boxed_type, gpointer boxed, gboolean copy_boxed, gboolean own_ref)
 {
     void *ptr;
     SCM tp;
@@ -43,31 +42,27 @@ gi_gboxed_new (GType boxed_type, gpointer boxed, gboolean copy_boxed, gboolean o
     if (!boxed)
         return SCM_UNDEFINED;
 
-    self = scm_make_foreign_object_0 (gi_gboxed_type);
+    self = scm_make_foreign_object_0(gi_gboxed_type);
 
     if (copy_boxed)
         boxed = g_boxed_copy(boxed_type, boxed);
-    gi_gboxed_set_ptr (self, boxed);
-    gi_gboxed_set_gtype (self, boxed_type);
-    gi_gboxed_set_free_on_dealloc (self, own_ref);
+    gi_gboxed_set_ptr(self, boxed);
+    gi_gboxed_set_gtype(self, boxed_type);
+    gi_gboxed_set_free_on_dealloc(self, own_ref);
     return self;
 }
 
 static SCM
-_wrap_gi_gboxed_copy (SCM self)
+_wrap_gi_gboxed_copy(SCM self)
 {
-    return gi_gboxed_new (gi_gboxed_get_gtype (self),
-			  gi_gboxed_get_ptr (self),
-			  TRUE,
-			  TRUE);
+    return gi_gboxed_new(gi_gboxed_get_gtype(self), gi_gboxed_get_ptr(self), TRUE, TRUE);
 }
 
 void
-gi_init_gboxed (void)
+gi_init_gboxed(void)
 {
-    gi_init_gboxed_type ();
+    gi_init_gboxed_type();
     gugboxed_type_key = g_quark_from_static_string("guile-gi::gboxed");
-    scm_c_define_gsubr ("gboxed-copy", 1, 0, 0, _wrap_gi_gboxed_copy);
-    scm_c_export ("gboxed-copy",
-		  NULL);
+    scm_c_define_gsubr("gboxed-copy", 1, 0, 0, _wrap_gi_gboxed_copy);
+    scm_c_export("gboxed-copy", NULL);
 }

--- a/src/gi_gboxed.h
+++ b/src/gi_gboxed.h
@@ -2,7 +2,6 @@
 #define _GI_BOXED_H_
 #include "__gi_gboxed.h"
 
-SCM gi_gboxed_new (GType boxed_type, gpointer boxed, gboolean copy_boxed,
-		   gboolean own_ref);
+SCM gi_gboxed_new(GType boxed_type, gpointer boxed, gboolean copy_boxed, gboolean own_ref);
 void gi_init_gboxed(void);
 #endif

--- a/src/gi_genum.c
+++ b/src/gi_genum.c
@@ -6,20 +6,20 @@
 GQuark gugenum_class_key;
 
 gboolean
-gi_genum_check (SCM x)
+gi_genum_check(SCM x)
 {
-    return (SCM_IS_A_P (x, gi_genum_type));
+    return (SCM_IS_A_P(x, gi_genum_type));
 }
 
 /* re pyg_enum_val_new */
 static SCM
-gi_genum_val_new (SCM subclass, GType gtype, int intval)
+gi_genum_val_new(SCM subclass, GType gtype, int intval)
 {
     SCM genum;
 
-    genum = scm_make_foreign_object_0 (gi_genum_type);
-    gi_genum_set_gtype (genum, gtype);
-    gi_genum_set_value (genum, intval);
+    genum = scm_make_foreign_object_0(gi_genum_type);
+    gi_genum_set_gtype(genum, gtype);
+    gi_genum_set_value(genum, intval);
     return genum;
 }
 
@@ -27,35 +27,35 @@ gi_genum_val_new (SCM subclass, GType gtype, int intval)
    gtype when necessary. */
 /* re pyg_enum_from_gtype */
 SCM
-gi_genum_from_gtype (GType gtype, int value)
+gi_genum_from_gtype(GType gtype, int value)
 {
     void *ptr;
     SCM class;
     SCM values;
     SCM retval;
-    
-    g_return_val_if_fail (gtype != G_TYPE_INVALID, SCM_BOOL_F);
+
+    g_return_val_if_fail(gtype != G_TYPE_INVALID, SCM_BOOL_F);
 
     /* Get a wrapper class by:
      * 1. check for one attached to gtype
      * 2. looking up one in a typelib
      * 3. creating a new one
      */
-    ptr = g_type_get_qdata (gtype, gugenum_class_key);
+    ptr = g_type_get_qdata(gtype, gugenum_class_key);
     /* if (!ptr) */
-    /* 	ptr = gi_gtype_import_by_g_type (gtype); */
+    /*  ptr = gi_gtype_import_by_g_type (gtype); */
     if (ptr)
-	class = ptr;
+        class = ptr;
     else
-	class = gi_genum_add (g_type_name (gtype), NULL, gtype);
+        class = gi_genum_add(g_type_name(gtype), NULL, gtype);
 
-    values = gi_genumcollection_get_enum_values (class);
-    retval = scm_hash_ref (values, scm_from_int (value), SCM_BOOL_F);
-    if (scm_is_false (retval))
-	/* MLG - so in here, we're making an enum value that doesn't
-	   have a name attached? It is supposed to be inserted into
-	   the GEnumCollection?*/
-	retval = gi_genum_val_new (class, gtype, value);
+    values = gi_genumcollection_get_enum_values(class);
+    retval = scm_hash_ref(values, scm_from_int(value), SCM_BOOL_F);
+    if (scm_is_false(retval))
+        /* MLG - so in here, we're making an enum value that doesn't
+         * have a name attached? It is supposed to be inserted into
+         * the GEnumCollection? */
+        retval = gi_genum_val_new(class, gtype, value);
     return retval;
 }
 
@@ -63,42 +63,40 @@ gi_genum_from_gtype (GType gtype, int value)
    constants into the current module. */
 /* re pyg_enum_add */
 SCM
-gi_genum_add (const char *typename,
-	      const char *strip_prefix,
-	      GType gtype)
+gi_genum_add(const char *typename, const char *strip_prefix, GType gtype)
 {
     SCM values;
     SCM stub;
     GEnumClass *eclass;
-    
-    g_return_val_if_fail (typename != NULL, SCM_BOOL_F);
-    if (!g_type_is_a (gtype, G_TYPE_ENUM))
-	scm_misc_error ("gi_genum_add",
-			"Trying to register gtype '~S' as an enum when it is in face of type '~S'",
-			scm_list_2 (scm_from_utf8_string (g_type_name (gtype)),
-				    scm_from_utf8_string (g_type_name (G_TYPE_FUNDAMENTAL (gtype)))));
+
+    g_return_val_if_fail(typename != NULL, SCM_BOOL_F);
+    if (!g_type_is_a(gtype, G_TYPE_ENUM))
+        scm_misc_error("gi_genum_add",
+                       "Trying to register gtype '~S' as an enum when it is in face of type '~S'",
+                       scm_list_2(scm_from_utf8_string(g_type_name(gtype)),
+                                  scm_from_utf8_string(g_type_name(G_TYPE_FUNDAMENTAL(gtype)))));
 
     /* Create a new type derived from GEnum. */
     stub = scm_make_foreign_object_0(gi_genumcollection_type);
     values = scm_c_make_hash_table(10);
 
-    gi_genumcollection_set_gtype (stub, gtype);
-    gi_genumcollection_set_enum_values (stub, values);
+    gi_genumcollection_set_gtype(stub, gtype);
+    gi_genumcollection_set_enum_values(stub, values);
 
-    g_type_set_qdata (gtype, gugenum_class_key, SCM_UNPACK_POINTER (stub));
+    g_type_set_qdata(gtype, gugenum_class_key, SCM_UNPACK_POINTER(stub));
 
     /* Register enum values */
-    eclass = G_ENUM_CLASS (g_type_class_ref (gtype));
-    for (guint i = 0; i < eclass->n_values; i ++) {
-	SCM item, intval;
-	char *prefix;
-	
-	intval = scm_from_long (eclass->values[i].value);
-	item = gi_genum_val_new (stub, gtype, eclass->values[i].value);
-	scm_hash_set_x (values, intval, item);
-	prefix = g_strdup(gi_constant_strip_prefix (eclass->values[i].value_name, strip_prefix));
-	scm_permanent_object (scm_c_define (prefix, item));
-	g_free (prefix);
+    eclass = G_ENUM_CLASS(g_type_class_ref(gtype));
+    for (guint i = 0; i < eclass->n_values; i++) {
+        SCM item, intval;
+        char *prefix;
+
+        intval = scm_from_long(eclass->values[i].value);
+        item = gi_genum_val_new(stub, gtype, eclass->values[i].value);
+        scm_hash_set_x(values, intval, item);
+        prefix = g_strdup(gi_constant_strip_prefix(eclass->values[i].value_name, strip_prefix));
+        scm_permanent_object(scm_c_define(prefix, item));
+        g_free(prefix);
     }
 
     return stub;
@@ -124,43 +122,46 @@ gi_enum_get_value(GType enum_type, SCM obj, gint *val)
 
     g_return_val_if_fail(val != NULL, -1);
     if (!obj) {
-	*val = 0;
-	return 0;
-    } else if (scm_is_exact_integer (obj)) {
-	*val = scm_to_int (obj);
-	if (SCM_IS_A_P (obj, gi_genum_type) && gi_genum_get_gtype(obj) != enum_type) {
-	    g_warning("expected enumeration type %s, but got %s instead",
-		      g_type_name(enum_type),
-		      g_type_name(gi_genum_get_gtype(obj)));
-	    return -1;
-	}
-    } else if (scm_is_string (obj)) {
-	GEnumValue *info;
-	char *str = scm_to_utf8_string (obj);
+        *val = 0;
+        return 0;
+    }
+    else if (scm_is_exact_integer(obj)) {
+        *val = scm_to_int(obj);
+        if (SCM_IS_A_P(obj, gi_genum_type) && gi_genum_get_gtype(obj) != enum_type) {
+            g_warning("expected enumeration type %s, but got %s instead",
+                      g_type_name(enum_type), g_type_name(gi_genum_get_gtype(obj)));
+            return -1;
+        }
+    }
+    else if (scm_is_string(obj)) {
+        GEnumValue *info;
+        char *str = scm_to_utf8_string(obj);
 
-	if (enum_type != G_TYPE_NONE)
-	    eclass = G_ENUM_CLASS(g_type_class_ref(enum_type));
-	else {
-	    scm_misc_error ("gi_enum_get_value",
-			    "could not convert string '~S' to enum because there is no GType associated to look up the value",
-			    scm_list_1 (obj));
-	    return -1;
-	}
-	info = g_enum_get_value_by_name(eclass, str);
-	g_type_class_unref(eclass);
+        if (enum_type != G_TYPE_NONE)
+            eclass = G_ENUM_CLASS(g_type_class_ref(enum_type));
+        else {
+            scm_misc_error("gi_enum_get_value",
+                           "could not convert string '~S' to enum because there is no GType associated to look up the value",
+                           scm_list_1(obj));
+            return -1;
+        }
+        info = g_enum_get_value_by_name(eclass, str);
+        g_type_class_unref(eclass);
 
-	if (!info)
-	    info = g_enum_get_value_by_nick(eclass, str);
-	if (info) {
-	    *val = info->value;
-	    return 0;
-	} else {
-	    scm_misc_error ("gi_enum_get_value", "could not convert string", SCM_EOL);
-	    return -1;
-	}
-    } else {
-	scm_misc_error ("gi_enum_get_value", "enum values must by strings or ints", SCM_EOL);
-	return -1;
+        if (!info)
+            info = g_enum_get_value_by_nick(eclass, str);
+        if (info) {
+            *val = info->value;
+            return 0;
+        }
+        else {
+            scm_misc_error("gi_enum_get_value", "could not convert string", SCM_EOL);
+            return -1;
+        }
+    }
+    else {
+        scm_misc_error("gi_enum_get_value", "enum values must by strings or ints", SCM_EOL);
+        return -1;
     }
     return 0;
 }
@@ -169,7 +170,7 @@ gi_enum_get_value(GType enum_type, SCM obj, gint *val)
 void
 gi_init_genum(void)
 {
-  gi_init_genum_type();
-  gi_init_genumcollection_type();
-  gugenum_class_key = g_quark_from_static_string("guile-gi::genum");
+    gi_init_genum_type();
+    gi_init_genumcollection_type();
+    gugenum_class_key = g_quark_from_static_string("guile-gi::genum");
 }

--- a/src/gi_genum.h
+++ b/src/gi_genum.h
@@ -3,13 +3,11 @@
 #include "__gi_genum.h"
 #include "__gi_genumcollection.h"
 
-gboolean gi_genum_check (SCM x);
+gboolean gi_genum_check(SCM x);
 
-SCM gi_genum_from_gtype (GType gtype, int value);
+SCM gi_genum_from_gtype(GType gtype, int value);
 
-SCM gi_genum_add (const char *typename,
-		  const char *strip_prefix,
-		  GType gtype);
+SCM gi_genum_add(const char *typename, const char *strip_prefix, GType gtype);
 int gi_enum_get_value(GType enum_type, SCM obj, gint *val);
 
 void gi_init_genum(void);

--- a/src/gi_giargument.c
+++ b/src/gi_giargument.c
@@ -54,9 +54,7 @@ struct array_info
 };
 
 static void
-fill_array_info (struct array_info *ai,
-                 GITypeInfo *array_type_info,
-                 GITransfer array_transfer)
+fill_array_info(struct array_info *ai, GITypeInfo *array_type_info, GITransfer array_transfer)
 {
     // So there are layers to all this ArgInfo stuff
     // LAYER 1: Let's start on layer 1, where this GIArgInfo tells
@@ -84,10 +82,9 @@ fill_array_info (struct array_info *ai,
     ai->item_is_ptr = g_type_info_is_pointer(item_type_info);
 
     if (ai->item_is_ptr)
-        ai->item_size = sizeof (void *);
+        ai->item_size = sizeof(void *);
 
-    switch (ai->item_type_tag)
-    {
+    switch (ai->item_type_tag) {
     case GI_TYPE_TAG_INT8:
     case GI_TYPE_TAG_UINT8:
         ai->item_size = 1;
@@ -112,23 +109,22 @@ fill_array_info (struct array_info *ai,
         ai->item_size = sizeof(double);
         break;
     case GI_TYPE_TAG_GTYPE:
-        ai->item_size = sizeof (GType);
+        ai->item_size = sizeof(GType);
         break;
     case GI_TYPE_TAG_BOOLEAN:
-        ai->item_size = sizeof (gboolean);
+        ai->item_size = sizeof(gboolean);
         break;
     case GI_TYPE_TAG_INTERFACE:
     {
         GIBaseInfo *referenced_base_info = g_type_info_get_interface(item_type_info);
         ai->referenced_base_type = g_base_info_get_type(referenced_base_info);
 
-        switch (ai->referenced_base_type)
-        {
+        switch (ai->referenced_base_type) {
         case GI_INFO_TYPE_ENUM:
         case GI_INFO_TYPE_FLAGS:
 
-            g_assert_false (ai->item_is_ptr);
-            ai->item_size = sizeof (int);
+            g_assert_false(ai->item_is_ptr);
+            ai->item_size = sizeof(int);
             break;
         case GI_INFO_TYPE_STRUCT:
             ai->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
@@ -143,13 +139,13 @@ fill_array_info (struct array_info *ai,
         case GI_INFO_TYPE_OBJECT:
             ai->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
             if (!ai->item_is_ptr)
-                ai->item_size = sizeof (void *);
+                ai->item_size = sizeof(void *);
             break;
         default:
             g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
-            g_assert_not_reached ();
+            g_assert_not_reached();
         }
-        g_base_info_unref (referenced_base_info);
+        g_base_info_unref(referenced_base_info);
         break;
     }
     case GI_TYPE_TAG_UTF8:
@@ -160,49 +156,44 @@ fill_array_info (struct array_info *ai,
     case GI_TYPE_TAG_GLIST:
     case GI_TYPE_TAG_GSLIST:
     case GI_TYPE_TAG_GHASH:
-        g_critical ("do you seriously want to nest containers in such a manner?");
-        g_assert_not_reached ();
+        g_critical("do you seriously want to nest containers in such a manner?");
+        g_assert_not_reached();
         break;
 
     default:
         g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
-        g_assert_not_reached ();
+        g_assert_not_reached();
     }
 
-    g_base_info_unref (item_type_info);
+    g_base_info_unref(item_type_info);
 }
 
 static size_t
-array_length (struct array_info *ai,
-              GIArgument *arg)
+array_length(struct array_info *ai, GIArgument *arg)
 {
     if (ai->array_length != -1)
         return ai->array_length;
     else if (ai->array_fixed_size != -1)
         return ai->array_fixed_size;
-    else if (ai->array_is_zero_terminated)
-    {
+    else if (ai->array_is_zero_terminated) {
         gpointer array = arg->v_pointer;
         if (array == NULL)
             return 0;
 
         size_t length = 0;
 
-        if (ai->item_type_tag == GI_TYPE_TAG_UTF8 ||
-            ai->item_type_tag == GI_TYPE_TAG_FILENAME)
-        {
+        if (ai->item_type_tag == GI_TYPE_TAG_UTF8 || ai->item_type_tag == GI_TYPE_TAG_FILENAME) {
             char **ptr = array;
             while (ptr[length] != NULL)
                 length++;
             return length;
         }
 
-        switch (ai->item_size)
-        {
+        switch (ai->item_size) {
         case 0:
-            g_assert_not_reached ();
+            g_assert_not_reached();
         case 1:
-            return strlen (array);
+            return strlen(array);
         case 2:
         {
             gint16 *ptr = array;
@@ -229,13 +220,11 @@ array_length (struct array_info *ai,
             gchar *ptr = array;
             gboolean non_null;
             length = -1;
-            do
-            {
+            do {
                 length++;
                 non_null = FALSE;
                 for (size_t i = 0; i <= ai->item_size; i++)
-                    if (ptr + i != 0)
-                    {
+                    if (ptr + i != 0) {
                         non_null = TRUE;
                         break;
                     }
@@ -246,7 +235,7 @@ array_length (struct array_info *ai,
         }
         }
     }
-    g_assert_not_reached ();
+    g_assert_not_reached();
 }
 
 /*
@@ -270,24 +259,21 @@ array_length (struct array_info *ai,
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
-static const intmax_t intmin[GI_TYPE_TAG_N_TYPES] =
-{
+static const intmax_t intmin[GI_TYPE_TAG_N_TYPES] = {
     [GI_TYPE_TAG_INT8] = INT8_MIN,
     [GI_TYPE_TAG_INT16] = INT16_MIN,
     [GI_TYPE_TAG_INT32] = INT32_MIN,
     [GI_TYPE_TAG_INT64] = INT64_MIN
 };
 
-static const intmax_t intmax[GI_TYPE_TAG_N_TYPES] =
-{
+static const intmax_t intmax[GI_TYPE_TAG_N_TYPES] = {
     [GI_TYPE_TAG_INT8] = INT8_MAX,
     [GI_TYPE_TAG_INT16] = INT16_MAX,
     [GI_TYPE_TAG_INT32] = INT32_MAX,
     [GI_TYPE_TAG_INT64] = INT64_MAX
 };
 
-static const uintmax_t uintmax[GI_TYPE_TAG_N_TYPES] =
-{
+static const uintmax_t uintmax[GI_TYPE_TAG_N_TYPES] = {
     [GI_TYPE_TAG_UINT8] = UINT8_MAX,
     [GI_TYPE_TAG_UINT16] = UINT16_MAX,
     [GI_TYPE_TAG_UINT32] = UINT32_MAX,
@@ -332,78 +318,57 @@ TYPE_TAG_IS_REAL_NUMBER(GITypeTag x)
 static SCM boxes[26];
 
 static void object_to_c_immediate_arg(char *subr, int argpos,
-                                      SCM obj,
-                                      GITypeTag type_tag,
-                                      GIArgument *arg);
+                                      SCM obj, GITypeTag type_tag, GIArgument *arg);
 static void object_to_c_interface_arg(char *subr, int argpos,
-                                      SCM obj,
-                                      GITypeInfo *arg_info,
-                                      GIArgument *arg);
+                                      SCM obj, GITypeInfo *arg_info, GIArgument *arg);
 static void object_to_c_immediate_pointer_arg(char *subr, int argpos,
                                               SCM obj,
                                               GIArgInfo *arg_info,
-                                              unsigned *must_free,
-                                              GIArgument *arg);
+                                              unsigned *must_free, GIArgument *arg);
 static void object_to_c_string_arg(char *subr, int argpos,
                                    SCM obj,
-                                   GIArgInfo *arg_info,
-                                   unsigned *must_free,
-                                   GIArgument *arg);
+                                   GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg);
 static void object_to_c_void_pointer_arg(char *subr, int argpos, SCM obj, GIArgument *arg);
 static void object_to_c_interface_pointer_arg(char *subr, int argpos, SCM object,
                                               GIArgInfo *arg_info,
-                                              unsigned *must_free,
-                                              GIArgument *arg);
+                                              unsigned *must_free, GIArgument *arg);
 static void object_to_c_array_arg(char *subr, int argpos, SCM object,
                                   GITypeInfo *array_type_info,
-                                  GITransfer array_transfer,
-                                  unsigned *must_free,
-                                  GIArgument *arg);
+                                  GITransfer array_transfer, unsigned *must_free, GIArgument *arg);
 static void
 object_to_c_native_array_arg(char *subr, int argpos, SCM object,
-                             struct array_info *ai,
-                             GIArgument *arg);
+                             struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_native_immediate_array_arg(char *subr, int argpos, SCM object,
-                                       struct array_info *ai,
-                                       GIArgument *arg);
+                                       struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_native_string_array_arg(char *subr, int argpos, SCM object,
-                                    struct array_info *ai,
-                                    GIArgument *arg);
+                                    struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_native_interface_array_arg(char *subr, int argpos, SCM object,
-                                       struct array_info *ai,
-                                       GIArgument *arg);
+                                       struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_ptr_array_arg(char *subr, int argpos, SCM object,
-                          struct array_info *ai,
-                          GIArgument *arg);
+                          struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_garray_array_arg(char *subr, int argpos, SCM object,
-                             struct array_info *ai,
-                             GIArgument *arg);
+                             struct array_info *ai, GIArgument *arg);
 static void
 object_to_c_byte_array_arg(char *subr, int argpos, SCM object,
-                           struct array_info *ai,
-                           GIArgument *arg);
-static SCM
-object_from_c_native_array_arg(struct array_info *ai,
-                               GIArgument *arg);
+                           struct array_info *ai, GIArgument *arg);
+static SCM object_from_c_native_array_arg(struct array_info *ai, GIArgument *arg);
 
-static SCM
-object_from_c_byte_array_arg(struct array_info *ai,
-                             GIArgument *arg);
+static SCM object_from_c_byte_array_arg(struct array_info *ai, GIArgument *arg);
 
-static SCM
-object_from_c_garray_arg(struct array_info *ai,
-                         GIArgument *arg);
+static SCM object_from_c_garray_arg(struct array_info *ai, GIArgument *arg);
 
 static void convert_immediate_arg_to_object(GIArgument *arg, GITypeTag type_tag, SCM *obj);
 static void convert_interface_arg_to_object(GIArgument *arg, GITypeInfo *type_info, SCM *obj);
-static void convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag, GITransfer transfer, SCM *obj);
+static void convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag,
+                                                 GITransfer transfer, SCM *obj);
 static void convert_const_void_pointer_arg_to_object(GIArgument *arg, SCM *obj);
-static void convert_array_pointer_arg_to_object(GIArgument *arg, GITypeInfo *array_type_info, GITransfer array_transfer, SCM *obj);
+static void convert_array_pointer_arg_to_object(GIArgument *arg, GITypeInfo *array_type_info,
+                                                GITransfer array_transfer, SCM *obj);
 
 //////////////////////////////////////////////////////////
 // CONVERTING SCM OBJECTS TO GIARGUMENTS
@@ -413,14 +378,10 @@ static void convert_array_pointer_arg_to_object(GIArgument *arg, GITypeInfo *arr
 // GIArguments.
 void
 gi_giargument_object_to_c_arg(char *subr, int argpos,
-                              SCM obj,
-                              GIArgInfo *arg_info,
-                              unsigned *must_free,
-                              GIArgument *arg)
+                              SCM obj, GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg)
 {
     // SCM #f means either NULL or FALSE.  Here we handle NULL.
-    if (g_arg_info_may_be_null(arg_info) && scm_is_false(obj))
-    {
+    if (g_arg_info_may_be_null(arg_info) && scm_is_false(obj)) {
         arg->v_pointer = NULL;
         *must_free = GIR_FREE_NONE;
         return;
@@ -430,10 +391,8 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
     GITypeTag type_tag = g_type_info_get_tag(type_info);
     gboolean is_ptr = g_type_info_is_pointer(type_info);
 
-    if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -473,10 +432,8 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
             break;
         }
     }
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -489,11 +446,7 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
         case GI_TYPE_TAG_UINT64:
         case GI_TYPE_TAG_UINT8:
         case GI_TYPE_TAG_UNICHAR:
-            object_to_c_immediate_pointer_arg(subr, argpos,
-                                              obj,
-                                              arg_info,
-                                              must_free,
-                                              arg);
+            object_to_c_immediate_pointer_arg(subr, argpos, obj, arg_info, must_free, arg);
             break;
 
         case GI_TYPE_TAG_UTF8:
@@ -507,19 +460,13 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
             break;
 
         case GI_TYPE_TAG_GHASH:
-            scm_misc_error(subr,
-                           "marshalling to GHash is not implemented: ~S",
-                           scm_list_1(obj));
+            scm_misc_error(subr, "marshalling to GHash is not implemented: ~S", scm_list_1(obj));
             break;
         case GI_TYPE_TAG_GLIST:
-            scm_misc_error(subr,
-                           "marshalling to GList is not implemented: ~S",
-                           scm_list_1(obj));
+            scm_misc_error(subr, "marshalling to GList is not implemented: ~S", scm_list_1(obj));
             break;
         case GI_TYPE_TAG_GSLIST:
-            scm_misc_error(subr,
-                           "marshalling to GSList is not implemented: ~S",
-                           scm_list_1(obj));
+            scm_misc_error(subr, "marshalling to GSList is not implemented: ~S", scm_list_1(obj));
             break;
 
         case GI_TYPE_TAG_INTERFACE:
@@ -530,8 +477,7 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
         case GI_TYPE_TAG_GTYPE:
             // No GType pointer inputs as far as I can tell.
             scm_misc_error(subr,
-                           "marshalling to GType pointer is not implemented: ~S",
-                           scm_list_1(obj));
+                           "marshalling to GType pointer is not implemented: ~S", scm_list_1(obj));
             break;
 
         case GI_TYPE_TAG_ERROR:
@@ -544,11 +490,7 @@ gi_giargument_object_to_c_arg(char *subr, int argpos,
         case GI_TYPE_TAG_ARRAY:
         {
             GITransfer array_transfer = g_arg_info_get_ownership_transfer(arg_info);
-            object_to_c_array_arg(subr, argpos, obj,
-                                  type_info,
-                                  array_transfer,
-                                  must_free,
-                                  arg);
+            object_to_c_array_arg(subr, argpos, obj, type_info, array_transfer, must_free, arg);
             break;
         }
 
@@ -572,16 +514,15 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
     if (g_arg_info_may_be_null(arg_info))
         g_string_append(desc, "#f for NULL or ");
 
-    if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
             g_string_append(desc, "boolean");
             break;
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
-            g_string_append_printf(desc, "real number of size %s", g_type_tag_to_string(g_type_info_get_tag(type_info)));
+            g_string_append_printf(desc, "real number of size %s",
+                                   g_type_tag_to_string(g_type_info_get_tag(type_info)));
             break;
         case GI_TYPE_TAG_INT16:
         case GI_TYPE_TAG_INT32:
@@ -591,7 +532,8 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
         case GI_TYPE_TAG_UINT32:
         case GI_TYPE_TAG_UINT64:
         case GI_TYPE_TAG_UINT8:
-            g_string_append_printf(desc, "exact integer of size %s", g_type_tag_to_string(g_type_info_get_tag(type_info)));
+            g_string_append_printf(desc, "exact integer of size %s",
+                                   g_type_tag_to_string(g_type_info_get_tag(type_info)));
             break;
         case GI_TYPE_TAG_UNICHAR:
             g_string_append_printf(desc, "character");
@@ -617,11 +559,14 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
             GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
             GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
             if (referenced_base_type == GI_INFO_TYPE_ENUM)
-                g_string_printf(desc, "exact integer of enum type %s", g_base_info_get_name(referenced_base_info));
+                g_string_printf(desc, "exact integer of enum type %s",
+                                g_base_info_get_name(referenced_base_info));
             else if (referenced_base_type == GI_INFO_TYPE_FLAGS)
-                g_string_printf(desc, "exact integer of flags type %s", g_base_info_get_name(referenced_base_info));
+                g_string_printf(desc, "exact integer of flags type %s",
+                                g_base_info_get_name(referenced_base_info));
             else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-                g_string_printf(desc, "procedure of type %s", g_base_info_get_name(referenced_base_info));
+                g_string_printf(desc, "procedure of type %s",
+                                g_base_info_get_name(referenced_base_info));
             else
                 g_string_append_printf(desc, "Unhandled argument type tag %d", type_tag);
             g_base_info_unref(referenced_base_info);
@@ -632,10 +577,8 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
             break;
         }
     }
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_UNICHAR:
             g_string_append_printf(desc, "Unhandled argument type tag %d", type_tag);
@@ -650,7 +593,8 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
         case GI_TYPE_TAG_UINT32:
         case GI_TYPE_TAG_UINT64:
         case GI_TYPE_TAG_UINT8:
-            g_string_append_printf(desc, "bytevector containing elements %s", g_type_tag_to_string(type_tag));
+            g_string_append_printf(desc, "bytevector containing elements %s",
+                                   g_type_tag_to_string(type_tag));
             break;
 
         case GI_TYPE_TAG_UTF8:
@@ -678,10 +622,13 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
         {
             GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
             GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-            if (referenced_base_type == GI_INFO_TYPE_ENUM || referenced_base_type == GI_INFO_TYPE_FLAGS)
-                g_string_printf(desc, "bytevector containing %s", g_base_info_get_name(referenced_base_info));
+            if (referenced_base_type == GI_INFO_TYPE_ENUM ||
+                referenced_base_type == GI_INFO_TYPE_FLAGS)
+                g_string_printf(desc, "bytevector containing %s",
+                                g_base_info_get_name(referenced_base_info));
             else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-                g_string_printf(desc, "list of procedures of type %s", g_base_info_get_name(referenced_base_info));
+                g_string_printf(desc, "list of procedures of type %s",
+                                g_base_info_get_name(referenced_base_info));
             else if (referenced_base_type == GI_INFO_TYPE_STRUCT)
                 g_string_printf(desc, "struct %s", g_base_info_get_name(referenced_base_info));
             else if (referenced_base_type == GI_INFO_TYPE_UNION)
@@ -710,26 +657,34 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
             GIArrayType array_type = g_type_info_get_array_type(type_info);
             if (array_type == GI_ARRAY_TYPE_BYTE_ARRAY)
                 g_string_append_printf(desc, "A bytevector containing unspecified binary data");
-            else if (array_type == GI_ARRAY_TYPE_C)
-            {
+            else if (array_type == GI_ARRAY_TYPE_C) {
                 GITypeInfo *item_type_info = g_type_info_get_param_type(type_info, 0);
                 GITypeTag item_type_tag = g_type_info_get_tag(item_type_info);
-                if (item_type_tag == GI_TYPE_TAG_INTERFACE)
-                {
+                if (item_type_tag == GI_TYPE_TAG_INTERFACE) {
                     GIBaseInfo *referenced_base_info = g_type_info_get_interface(item_type_info);
                     GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
                     referenced_base_info = g_type_info_get_interface(item_type_info);
                     referenced_base_type = g_base_info_get_type(referenced_base_info);
                     if (referenced_base_type == GI_INFO_TYPE_ENUM)
-                        g_string_append_printf(desc, "A list of enum values of type %s as integers", g_base_info_get_name(referenced_base_info));
+                        g_string_append_printf(desc,
+                                               "A list of enum values of type %s as integers",
+                                               g_base_info_get_name(referenced_base_info));
                     else if (referenced_base_type == GI_INFO_TYPE_FLAGS)
-                        g_string_append_printf(desc, "A list of flag values of type %s as integers", g_base_info_get_name(referenced_base_info));
+                        g_string_append_printf(desc,
+                                               "A list of flag values of type %s as integers",
+                                               g_base_info_get_name(referenced_base_info));
                     else if (referenced_base_type == GI_INFO_TYPE_STRUCT)
-                        g_string_append_printf(desc, "A list of <GBox> containing structs of type %s", g_base_info_get_name(referenced_base_info));
+                        g_string_append_printf(desc,
+                                               "A list of <GBox> containing structs of type %s",
+                                               g_base_info_get_name(referenced_base_info));
                     else if (referenced_base_type == GI_INFO_TYPE_UNION)
-                        g_string_append_printf(desc, "A list of <GBox> containing unions of type %s", g_base_info_get_name(referenced_base_info));
+                        g_string_append_printf(desc,
+                                               "A list of <GBox> containing unions of type %s",
+                                               g_base_info_get_name(referenced_base_info));
                     else if (referenced_base_type == GI_INFO_TYPE_STRUCT)
-                        g_string_append_printf(desc, "A list of <GObject> containing objects of type %s", g_base_info_get_name(referenced_base_info));
+                        g_string_append_printf(desc,
+                                               "A list of <GObject> containing objects of type %s",
+                                               g_base_info_get_name(referenced_base_info));
                     g_base_info_unref(referenced_base_info);
                 }
                 else if (item_type_tag == GI_TYPE_TAG_BOOLEAN)
@@ -753,7 +708,7 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
                 else if (item_type_tag == GI_TYPE_TAG_FLOAT)
                     g_string_append_printf(desc,
                                            "A bytevector containing %d-byte floating-point numbers",
-                                           (int) sizeof(float));
+                                           (int)sizeof(float));
                 else if (item_type_tag == GI_TYPE_TAG_DOUBLE)
                     g_string_append_printf(desc,
                                            "A bytevector containing %d-byte floating-point numbers",
@@ -763,9 +718,10 @@ gi_giargument_describe_arg_in(GIArgInfo *arg_info)
                     g_string_append_printf(desc, "A list of strings");
                 else if (item_type_tag == GI_TYPE_TAG_GTYPE)
                     g_string_append_printf(desc, "A list of <GType>");
-                else
-                {
-                    g_string_append_printf(desc, "A bytevector containing some unknown type tag %d", item_type_tag);
+                else {
+                    g_string_append_printf(desc,
+                                           "A bytevector containing some unknown type tag %d",
+                                           item_type_tag);
                     g_critical("Unhandled array entry type in %s:%d", __FILE__, __LINE__);
                 }
             }
@@ -785,29 +741,23 @@ void
 gi_giargument_convert_return_type_object_to_arg(SCM obj,
                                                 GITypeInfo *type_info,
                                                 GITransfer transfer,
-                                                gboolean null_ok,
-                                                gboolean skip,
-                                                GIArgument *arg)
+                                                gboolean null_ok, gboolean skip, GIArgument *arg)
 {
 #define FUNC_NAME "%returned-object->c-arg"
     gboolean is_ptr = g_type_info_is_pointer(type_info);
     GITypeTag type_tag = g_type_info_get_tag(type_info);
     unsigned must_free;
 
-    if (skip)
-    {
+    if (skip) {
         arg->v_pointer = NULL;
         return;
     }
 
-    if (null_ok && scm_is_eq(obj, SCM_BOOL_F))
-    {
+    if (null_ok && scm_is_eq(obj, SCM_BOOL_F)) {
         arg->v_pointer = NULL;
     }
-    else if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    else if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -846,10 +796,8 @@ gi_giargument_convert_return_type_object_to_arg(SCM obj,
             break;
         }
     }
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -920,8 +868,7 @@ gi_giargument_convert_return_type_object_to_arg(SCM obj,
 static void
 object_to_c_immediate_arg(char *subr, int argpos, SCM object, GITypeTag type_tag, GIArgument *arg)
 {
-    switch (type_tag)
-    {
+    switch (type_tag) {
     case GI_TYPE_TAG_INT8:
         if (!scm_is_signed_integer(object, INT8_MIN, INT8_MAX))
             scm_wrong_type_arg_msg(subr, argpos, object, "int8");
@@ -971,7 +918,7 @@ object_to_c_immediate_arg(char *subr, int argpos, SCM object, GITypeTag type_tag
         double dtmp = scm_to_double(object);
         if (dtmp > FLT_MAX || dtmp < -FLT_MAX)
             scm_wrong_type_arg_msg(subr, argpos, object, "float32");
-        arg->v_float = (float) dtmp;
+        arg->v_float = (float)dtmp;
         break;
     case GI_TYPE_TAG_DOUBLE:
         if (!scm_is_real(object))
@@ -988,8 +935,7 @@ object_to_c_immediate_arg(char *subr, int argpos, SCM object, GITypeTag type_tag
             arg->v_uint32 = SCM_CHAR(object);
         else if (scm_is_unsigned_integer(object, 0, SCM_CODEPOINT_MAX))
             arg->v_uint32 = scm_to_uint32(object);
-        else
-        {
+        else {
             scm_wrong_type_arg_msg(subr, argpos, object, "char");
         }
 
@@ -1003,9 +949,7 @@ object_to_c_immediate_arg(char *subr, int argpos, SCM object, GITypeTag type_tag
 // Handle SCM conversion to non-pointer objects that aren't simple C
 // types.
 static void
-object_to_c_interface_arg(char *subr, int argpos, SCM obj,
-                          GITypeInfo *type_info,
-                          GIArgument *arg)
+object_to_c_interface_arg(char *subr, int argpos, SCM obj, GITypeInfo *type_info, GIArgument *arg)
 {
     GITypeTag type_tag = g_type_info_get_tag(type_info);
     g_assert(type_tag == GI_TYPE_TAG_INTERFACE);
@@ -1014,35 +958,29 @@ object_to_c_interface_arg(char *subr, int argpos, SCM obj,
     GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
 
     if ((referenced_base_type == GI_INFO_TYPE_ENUM)
-        || (referenced_base_type == GI_INFO_TYPE_FLAGS))
-    {
+        || (referenced_base_type == GI_INFO_TYPE_FLAGS)) {
         arg->v_uint32 = scm_to_uint32(obj);
     }
-    else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-    {
+    else if (referenced_base_type == GI_INFO_TYPE_CALLBACK) {
         GICallbackInfo *callback_info = referenced_base_info;
-        if (scm_is_true(scm_procedure_p(obj)))
-        {
+        if (scm_is_true(scm_procedure_p(obj))) {
             int arity = scm_to_int(scm_car(scm_procedure_minimum_arity(obj)));
             int n_args = g_callable_info_get_n_args(callback_info);
-            if (arity == n_args)
-            {
+            if (arity == n_args) {
                 arg->v_pointer = gir_callback_get_ptr(callback_info, obj);
                 g_assert(arg->v_pointer != NULL);
             }
-            else
-            {
+            else {
                 const char *msg = "a procedure requiring %d arguments";
                 char str[strlen(msg) + 20];
                 snprintf(str, sizeof(str), msg, n_args);
-                scm_wrong_type_arg_msg (subr, argpos, obj, str);
+                scm_wrong_type_arg_msg(subr, argpos, obj, str);
             }
         }
     }
     else if ((referenced_base_type == GI_INFO_TYPE_STRUCT)
              || (referenced_base_type == GI_INFO_TYPE_UNION)
-             || (referenced_base_type == GI_INFO_TYPE_OBJECT))
-    {
+             || (referenced_base_type == GI_INFO_TYPE_OBJECT)) {
         // This is uncommon case where a struct is used directly,
         // and not as a pointer, such as in gtk_text_buffer_get_bounds.
 
@@ -1055,9 +993,7 @@ object_to_c_interface_arg(char *subr, int argpos, SCM obj,
 static void
 object_to_c_immediate_pointer_arg(char *subr, int argpos,
                                   SCM obj,
-                                  GIArgInfo *arg_info,
-                                  unsigned *must_free,
-                                  GIArgument *arg)
+                                  GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg)
 {
     // Here we handle the uncommon case of converting an SCM to a
     // pointer to a simple C type like 'int *', but not objects or
@@ -1071,16 +1007,13 @@ object_to_c_immediate_pointer_arg(char *subr, int argpos,
 
     // We'll require an input of bytevectors, since they can apply to
     // most cases, and this case is underspecified anyway.
-    if (!scm_is_bytevector(obj))
-    {
+    if (!scm_is_bytevector(obj)) {
         scm_wrong_type_arg_msg(subr, argpos, obj, "a bytevector");
     }
-    else
-    {
+    else {
         // FIXME: add bytevector minimum length checks.
         if (g_arg_info_get_ownership_transfer(arg_info) == GI_TRANSFER_EVERYTHING)
-            arg->v_pointer = g_memdup(SCM_BYTEVECTOR_CONTENTS(obj),
-                                      SCM_BYTEVECTOR_LENGTH(obj));
+            arg->v_pointer = g_memdup(SCM_BYTEVECTOR_CONTENTS(obj), SCM_BYTEVECTOR_LENGTH(obj));
         else
             arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(obj);
         *must_free = GIR_FREE_NONE;
@@ -1089,40 +1022,34 @@ object_to_c_immediate_pointer_arg(char *subr, int argpos,
 
 static void
 object_to_c_string_arg(char *subr, int argpos,
-                       SCM obj,
-                       GIArgInfo *arg_info,
-                       unsigned *must_free,
-                       GIArgument *arg)
+                       SCM obj, GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg)
 {
     // Here we convert an input string into an argument.  The input
     // string is either UTF8 or locale encoded.
-    if (scm_is_bytevector(obj))
-    {
+    if (scm_is_bytevector(obj)) {
         // Some methods expect passed-in strings to be overwriteable,
         // like g_date_strftime(char *s, ...) expects 's' to be a
         // place to store an output.  Since Glib strings and Guile
         // strings have no encoding in common, we can use
         // bytevectors...
-        if (g_arg_info_get_ownership_transfer(arg_info) == GI_TRANSFER_NOTHING)
-        {
+        if (g_arg_info_get_ownership_transfer(arg_info) == GI_TRANSFER_NOTHING) {
             // But when we're using bytevectors as a possibly writable
             // location, they do need to be null terminated.
             gboolean terminated = FALSE;
-            for (int i = 0; i < SCM_BYTEVECTOR_LENGTH(obj); i ++)
+            for (int i = 0; i < SCM_BYTEVECTOR_LENGTH(obj); i++)
                 if (SCM_BYTEVECTOR_CONTENTS(obj)[i] == 0)
                     terminated = TRUE;
             if (!terminated)
                 scm_wrong_type_arg_msg(subr, argpos, obj, "null-terminated bytevector");
-            arg->v_string = (gchar *) SCM_BYTEVECTOR_CONTENTS(obj);
+            arg->v_string = (gchar *)SCM_BYTEVECTOR_CONTENTS(obj);
         }
         else
             // But when we're copying the contents of the string, the
             // null termination can be enforced here.
-            arg->v_string = g_strndup((const gchar *) SCM_BYTEVECTOR_CONTENTS(obj),
+            arg->v_string = g_strndup((const gchar *)SCM_BYTEVECTOR_CONTENTS(obj),
                                       SCM_BYTEVECTOR_LENGTH(obj));
     }
-    else if (scm_is_string(obj))
-    {
+    else if (scm_is_string(obj)) {
         // The scm_to_..._string always makes a new copy, so if
         // transfer isn't EVERYTHING, we'll have to free the string
         // later.
@@ -1155,8 +1082,7 @@ object_to_c_void_pointer_arg(char *subr, int argpos, SCM obj, GIArgument *arg)
 
 static void
 object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
-                                  GIArgInfo *arg_info,
-                                  unsigned *must_free, GIArgument *arg)
+                                  GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg)
 {
     // Usually STRUCT, UNION, INTERFACE, OBJECT.  Handle NULL_OK
     GITypeInfo *type_info = g_arg_info_get_type(arg_info);
@@ -1165,32 +1091,28 @@ object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
     GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
     g_base_info_unref(type_info);
 
-    GType obj_type = gir_type_get_gtype_from_obj (obj);
+    GType obj_type = gir_type_get_gtype_from_obj(obj);
     if (obj_type == G_TYPE_NONE || obj_type == G_TYPE_INVALID)
         scm_wrong_type_arg_msg(subr, argpos, obj, "a GObject struct, union, interface, or object");
 
     GType arg_type = g_registered_type_info_get_g_type(referenced_base_info);
-    if (!g_type_is_a(obj_type, arg_type))
-    {
+    if (!g_type_is_a(obj_type, arg_type)) {
         char msg[80];
         snprintf(msg, 80, "a GObject that is a type of %s", g_type_name(arg_type));
         scm_wrong_type_arg_msg(subr, argpos, obj, msg);
     }
     else if ((referenced_base_type == GI_INFO_TYPE_STRUCT)
              || (referenced_base_type == GI_INFO_TYPE_UNION)
-             || (referenced_base_type == GI_INFO_TYPE_OBJECT))
-    {
+             || (referenced_base_type == GI_INFO_TYPE_OBJECT)) {
         arg->v_pointer = scm_foreign_object_ref(obj, OBJ_SLOT);
         *must_free = GIR_FREE_NONE;
     }
-    else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-    {
+    else if (referenced_base_type == GI_INFO_TYPE_CALLBACK) {
         scm_misc_error(subr,
                        "Marshalling to C callback pointer args is unimplemented: ~S",
                        scm_list_1(obj));
     }
-    else if (referenced_base_type == GI_INFO_TYPE_INTERFACE)
-    {
+    else if (referenced_base_type == GI_INFO_TYPE_INTERFACE) {
         scm_misc_error(subr,
                        "Marshalling to C interface pointer args is unimplemented: ~S",
                        scm_list_1(obj));
@@ -1202,15 +1124,12 @@ object_to_c_interface_pointer_arg(char *subr, int argpos, SCM obj,
 static void
 object_to_c_array_arg(char *subr, int argpos, SCM object,
                       GITypeInfo *array_type_info,
-                      GITransfer array_transfer,
-                      unsigned *must_free,
-                      GIArgument *arg)
+                      GITransfer array_transfer, unsigned *must_free, GIArgument *arg)
 {
-    struct array_info ai = {0};
-    fill_array_info (&ai, array_type_info, array_transfer);
+    struct array_info ai = { 0 };
+    fill_array_info(&ai, array_type_info, array_transfer);
 
-    switch (ai.array_type)
-    {
+    switch (ai.array_type) {
     case GI_ARRAY_TYPE_C:
         object_to_c_native_array_arg(subr, argpos, object, &ai, arg);
         break;
@@ -1231,8 +1150,7 @@ object_to_c_array_arg(char *subr, int argpos, SCM object,
 
 static void
 object_to_c_native_array_arg(char *subr, int argpos, SCM object,
-                             struct array_info *ai,
-                             GIArgument *arg)
+                             struct array_info *ai, GIArgument *arg)
 {
     if (TYPE_TAG_IS_EXACT_INTEGER(ai->item_type_tag)
         || TYPE_TAG_IS_REAL_NUMBER(ai->item_type_tag))
@@ -1240,21 +1158,17 @@ object_to_c_native_array_arg(char *subr, int argpos, SCM object,
     else if ((ai->item_type_tag == GI_TYPE_TAG_UTF8)
              || (ai->item_type_tag == GI_TYPE_TAG_FILENAME))
         object_to_c_native_string_array_arg(subr, argpos, object, ai, arg);
-    else if (ai->item_type_tag == GI_TYPE_TAG_INTERFACE)
-    {
+    else if (ai->item_type_tag == GI_TYPE_TAG_INTERFACE) {
         object_to_c_native_interface_array_arg(subr, argpos, object, ai, arg);
     }
-    else
-    {
+    else {
         scm_misc_error(subr, "Unhandled array type", SCM_EOL);
     }
 }
 
 static void
 object_to_c_native_immediate_array_arg(char *subr, int argpos,
-                                       SCM object,
-                                       struct array_info *ai,
-                                       GIArgument *arg)
+                                       SCM object, struct array_info *ai, GIArgument *arg)
 {
 #define FUNC_NAME "%object->c-native-immediate-array-arg"
     // IMMEDIATE TYPES.  It seems only boolean, double, and 8 and
@@ -1265,19 +1179,15 @@ object_to_c_native_immediate_array_arg(char *subr, int argpos,
     // GI_TRANSFER_EVERYTHING, we need to make a deep copy.  If the
     // argument is NULL_OK and the SCM is #f, we pass NULL.
 
-    g_assert_cmpint (ai->item_size, !=, 0);
+    g_assert_cmpint(ai->item_size, !=, 0);
 
-    if (scm_is_bytevector(object))
-    {
-        if (ai->item_transfer == GI_TRANSFER_NOTHING)
-        {
-            if (!ai->array_is_zero_terminated)
-            {
+    if (scm_is_bytevector(object)) {
+        if (ai->item_transfer == GI_TRANSFER_NOTHING) {
+            if (!ai->array_is_zero_terminated) {
                 // The fast path
                 arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(object);
             }
-            else
-            {
+            else {
                 size_t len = SCM_BYTEVECTOR_LENGTH(object);
                 // Adding null terminator element.
                 arg->v_pointer = g_malloc0(len + ai->item_size);
@@ -1285,15 +1195,12 @@ object_to_c_native_immediate_array_arg(char *subr, int argpos,
                 ai->must_free = GIR_FREE_SIMPLE;
             }
         }
-        else if (ai->item_transfer == GI_TRANSFER_EVERYTHING)
-        {
-            if (!ai->array_is_zero_terminated)
-            {
+        else if (ai->item_transfer == GI_TRANSFER_EVERYTHING) {
+            if (!ai->array_is_zero_terminated) {
                 arg->v_pointer = g_memdup(SCM_BYTEVECTOR_CONTENTS(object),
                                           SCM_BYTEVECTOR_LENGTH(object));
             }
-            else
-            {
+            else {
                 size_t len = SCM_BYTEVECTOR_LENGTH(object);
                 // Note, null terminated here.
                 arg->v_pointer = g_malloc0(len + ai->item_size);
@@ -1308,11 +1215,9 @@ object_to_c_native_immediate_array_arg(char *subr, int argpos,
 
 static void
 object_to_c_byte_array_arg(char *subr, int argpos, SCM object,
-                           struct array_info *ai,
-                           GIArgument *arg)
+                           struct array_info *ai, GIArgument *arg)
 {
-    if (scm_is_bytevector(object))
-    {
+    if (scm_is_bytevector(object)) {
         void *contents = SCM_BYTEVECTOR_CONTENTS(object);
         size_t len = SCM_BYTEVECTOR_LENGTH(object);
         if (ai->array_transfer == GI_TRANSFER_EVERYTHING)
@@ -1346,10 +1251,12 @@ object_to_c_ptr_array_arg(char *subr, int argpos, SCM object, struct array_info 
 #undef FUNC_NAME
 }
 
-
-static void __attribute__((unused))
+/* *INDENT-OFF* */
+__attribute__((unused)) static void
 object_to_c_native_direct_struct_array_arg(char *subr, int argpos, SCM object,
                                            struct array_info *ai, GIArgument *arg)
+/* *INDENT-ON* */
+
 {
     // This is the uncommon case of the argument containing
     // an array of structs themselves, rather than an array
@@ -1368,17 +1275,18 @@ object_to_c_native_direct_struct_array_arg(char *subr, int argpos, SCM object,
         ai->must_free = GIR_FREE_SIMPLE;
 }
 
-static void __attribute__((unused))
+/* *INDENT-OFF* */
+__attribute__((unused)) static void
 object_to_c_native_indirect_object_array_arg(char *subr, int argpos, SCM object,
-                                             struct array_info *ai,
-                                             GIArgument *arg)
+                                             struct array_info *ai, GIArgument *arg)
+/* *INDENT-ON* */
+
 {
     // Arrays of pointers to OBJECTS.  The only example I could find
     // is g_socket_send_message.
     if ((ai->item_type_tag == GI_TYPE_TAG_INTERFACE)
         && (ai->referenced_base_type == G_TYPE_OBJECT)
-        && ai->item_is_ptr)
-    {
+        && ai->item_is_ptr) {
         // On the Scheme side, an array of pointers to objects will be
         // a list of GObjects.
         size_t len = scm_to_size_t(scm_length(object));
@@ -1387,16 +1295,14 @@ object_to_c_native_indirect_object_array_arg(char *subr, int argpos, SCM object,
             ptr = g_malloc0_n(sizeof(gpointer), len + 1);
         else
             ptr = g_malloc0_n(sizeof(gpointer), len);
-        for (gsize i = 0; i < len; i++)
-        {
+        for (gsize i = 0; i < len; i++) {
             SCM entry = scm_list_ref(object, scm_from_size_t(i));
             // Entry should be a GObject.  I guess we're not
             // increasing refcnt?  At least that is the case for
             // g_socket_send_message.
             ptr[i] = gi_gobject_get_obj(entry);
         }
-        if (ai->item_transfer == GI_TRANSFER_NOTHING)
-        {
+        if (ai->item_transfer == GI_TRANSFER_NOTHING) {
             if (ai->array_is_zero_terminated)
                 ai->must_free = GIR_FREE_STRV;
             else
@@ -1408,25 +1314,20 @@ object_to_c_native_indirect_object_array_arg(char *subr, int argpos, SCM object,
 static void
 object_to_c_native_interface_array_arg(char *subr,
                                        int argpos,
-                                       SCM object,
-                                       struct array_info *ai,
-                                       GIArgument *arg)
+                                       SCM object, struct array_info *ai, GIArgument *arg)
 {
 #define FUNC_NAME "%object->c-native-interface-array-arg"
     if ((ai->referenced_base_type == GI_INFO_TYPE_ENUM)
-        || (ai->referenced_base_type == GI_INFO_TYPE_FLAGS))
-    {
+        || (ai->referenced_base_type == GI_INFO_TYPE_FLAGS)) {
         // We haven't bothered to make a special flag or enum
         // class on the Scheme side of things.  On the scheme
         // side, enums and flags are just variables holding
         // integers.
-        object_to_c_native_immediate_array_arg(subr,argpos,object,
-                                               ai, arg);
+        object_to_c_native_immediate_array_arg(subr, argpos, object, ai, arg);
     }
     else if ((ai->referenced_base_type == GI_INFO_TYPE_STRUCT)
              || (ai->referenced_base_type == GI_INFO_TYPE_UNION)
-             || (ai->referenced_base_type == GI_INFO_TYPE_OBJECT))
-    {
+             || (ai->referenced_base_type == GI_INFO_TYPE_OBJECT)) {
         // If we are a Struct or Object, we need to look up
         // our actual GType.
         g_assert(ai->referenced_object_type != G_TYPE_NONE);
@@ -1451,8 +1352,7 @@ object_to_c_native_interface_array_arg(char *subr,
             object_to_c_native_indirect_object_array_arg(subr, argpos, object, ai, arg);
 #endif
     }
-    else
-    {
+    else {
         // Everything else is unhandled.
         g_critical("Unhandled argument type, %s: %d", __FILE__, __LINE__);
     }
@@ -1461,9 +1361,7 @@ object_to_c_native_interface_array_arg(char *subr,
 
 static void
 object_to_c_native_string_array_arg(char *subr, int argpos,
-                                    SCM object,
-                                    struct array_info *ai,
-                                    GIArgument *arg)
+                                    SCM object, struct array_info *ai, GIArgument *arg)
 {
     // UTF8 or FILENAME pointers.  It seems that arrays of type UTF8
     // can mean two things.
@@ -1478,12 +1376,10 @@ object_to_c_native_string_array_arg(char *subr, int argpos,
 
     // We're adding a zero termination despite the value of
     // array_is_zero_terminated, because it does no harm.
-    if (scm_is_true(scm_list_p(object)))
-    {
+    if (scm_is_true(scm_list_p(object))) {
         size_t len = scm_to_size_t(scm_length(object));
         gchar **strv = g_new0(gchar *, len + 1);
-        for (size_t i = 0; i < len; i++)
-        {
+        for (size_t i = 0; i < len; i++) {
             SCM entry = scm_list_ref(object, scm_from_size_t(i));
             if (ai->item_type_tag == GI_TYPE_TAG_FILENAME)
                 strv[i] = scm_to_locale_string(entry);
@@ -1501,24 +1397,21 @@ object_to_c_native_string_array_arg(char *subr, int argpos,
 
 
 
-void gi_giargument_free_args(int n, unsigned *must_free, GIArgument *args)
+void
+gi_giargument_free_args(int n, unsigned *must_free, GIArgument *args)
 {
-    for (int i = 0; i < n; i++)
-    {
+    for (int i = 0; i < n; i++) {
         if (must_free[i] == GIR_FREE_SIMPLE)
             g_free(args[i].v_pointer);
-        else if (must_free[i] == GIR_FREE_STRV)
-        {
+        else if (must_free[i] == GIR_FREE_STRV) {
             int j = 0;
-            while (((char **)(args[i].v_pointer))[j] != NULL)
-            {
+            while (((char **)(args[i].v_pointer))[j] != NULL) {
                 g_free(((char **)(args[i].v_pointer))[j]);
                 j++;
             }
             g_free(args[i].v_pointer);
         }
-        else if (must_free[i] & GIR_FREE_PTR_ARRAY)
-        {
+        else if (must_free[i] & GIR_FREE_PTR_ARRAY) {
             int count = GIR_FREE_PTR_COUNT(must_free[i]);
             for (int j = 0; j < count; j++)
                 g_free(((char **)(args[i].v_pointer))[j]);
@@ -1543,10 +1436,8 @@ gi_giargument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument 
     gboolean is_ptr = g_type_info_is_pointer(type_info);
 
     g_base_info_unref(type_info);
-    if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -1584,17 +1475,15 @@ gi_giargument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument 
             GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
             // GType referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
 
-            if (referenced_base_type == GI_INFO_TYPE_STRUCT)
-            {
+            if (referenced_base_type == GI_INFO_TYPE_STRUCT) {
                 // If OBJ is already set, we typecheck that it is
                 // a box holding a pointer for a struct of the
                 // right type.  If it isn't set, we allocate a new
                 // box.
-                if (!scm_is_eq(*obj, SCM_BOOL_F))
-                {
+                if (!scm_is_eq(*obj, SCM_BOOL_F)) {
                     gsize item_size = g_struct_info_get_size(referenced_base_info);
                     arg->v_pointer = g_malloc0(item_size);
-                    g_critical ("unhandled allocation");
+                    g_critical("unhandled allocation");
                     g_assert_not_reached();
                     //*obj = gir_new_struct_gbox(referenced_object_type, arg->v_pointer, TRUE);
                 }
@@ -1605,16 +1494,14 @@ gi_giargument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument 
             else
                 g_assert_not_reached();
         }
-        break;
+            break;
         default:
             g_assert_not_reached();
             break;
         }
     }
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -1636,8 +1523,7 @@ gi_giargument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument 
 
             // Uniquely, g_unichar_to_utf8 requires a pre-allocated UTF8
             // output buffer.
-            if (scm_is_bytevector(*obj))
-            {
+            if (scm_is_bytevector(*obj)) {
                 // FIXME: we're just hoping that this
                 // bytevector is big enough to hold the contents
                 // that are going to be copied into it.
@@ -1681,10 +1567,8 @@ gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *o
     GITransfer transfer = g_arg_info_get_ownership_transfer(arg_info);
     gboolean is_ptr = g_type_info_is_pointer(type_info);
 
-    if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_VOID:
             *obj = SCM_UNSPECIFIED;
             break;
@@ -1723,10 +1607,8 @@ gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *o
             break;
         }
     }
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -1784,10 +1666,7 @@ gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *o
 
         case GI_TYPE_TAG_ARRAY:
             // g_critical("Unhandled array argument type %s %d", __FILE__, __LINE__);
-            convert_array_pointer_arg_to_object(arg,
-                                                type_info,
-                                                GI_TRANSFER_EVERYTHING,
-                                                obj);
+            convert_array_pointer_arg_to_object(arg, type_info, GI_TRANSFER_EVERYTHING, obj);
             break;
 
         default:
@@ -1797,11 +1676,10 @@ gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *o
     g_base_info_unref(type_info);
 }
 
-SCM gi_giargument_convert_return_val_to_object(GIArgument *arg,
-                                               GITypeInfo *type_info,
-                                               GITransfer transfer,
-                                               gboolean null_ok,
-                                               gboolean skip)
+SCM
+gi_giargument_convert_return_val_to_object(GIArgument *arg,
+                                           GITypeInfo *type_info,
+                                           GITransfer transfer, gboolean null_ok, gboolean skip)
 {
     SCM obj = SCM_BOOL_F;
 
@@ -1813,10 +1691,8 @@ SCM gi_giargument_convert_return_val_to_object(GIArgument *arg,
     GITypeTag type_tag = g_type_info_get_tag(type_info);
     gboolean is_ptr = g_type_info_is_pointer(type_info);
 
-    if (!is_ptr)
-    {
-        switch (type_tag)
-        {
+    if (!is_ptr) {
+        switch (type_tag) {
         case GI_TYPE_TAG_VOID:
             obj = SCM_UNSPECIFIED;
             break;
@@ -1855,15 +1731,12 @@ SCM gi_giargument_convert_return_val_to_object(GIArgument *arg,
             break;
         }
     }
-    else
-    {
+    else {
         if (arg->v_pointer == NULL)
             scm_misc_error("%return-val->object",
-                           "Unexpected NULL pointer received from C procedure",
-                           SCM_EOL);
+                           "Unexpected NULL pointer received from C procedure", SCM_EOL);
 
-        switch (type_tag)
-        {
+        switch (type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -1905,16 +1778,18 @@ SCM gi_giargument_convert_return_val_to_object(GIArgument *arg,
             GType referenced_base_gtype = g_registered_type_info_get_g_type(referenced_base_info);
             g_base_info_unref(referenced_base_info);
 
-            if (referenced_base_type == GI_INFO_TYPE_STRUCT || referenced_base_type == GI_INFO_TYPE_UNION || referenced_base_type == GI_INFO_TYPE_OBJECT)
-            {
-                return gir_type_make_object(referenced_base_gtype, arg->v_pointer, transfer == GI_TRANSFER_EVERYTHING);
+            if (referenced_base_type == GI_INFO_TYPE_STRUCT ||
+                referenced_base_type == GI_INFO_TYPE_UNION ||
+                referenced_base_type == GI_INFO_TYPE_OBJECT) {
+                return gir_type_make_object(referenced_base_gtype, arg->v_pointer,
+                                            transfer == GI_TRANSFER_EVERYTHING);
             }
             else
                 g_critical("Unhandled argument type %s %d", __FILE__, __LINE__);
         }
-        // ret = convert_interface_pointer_object_to_arg(obj, arg_info, must_free, arg);
-        // *must_free = GIR_FREE_NONE;
-        break;
+            // ret = convert_interface_pointer_object_to_arg(obj, arg_info, must_free, arg);
+            // *must_free = GIR_FREE_NONE;
+            break;
 
         case GI_TYPE_TAG_GTYPE:
             // No GType pointer inputs as far as I can tell.
@@ -1946,8 +1821,7 @@ SCM gi_giargument_convert_return_val_to_object(GIArgument *arg,
 static void
 convert_immediate_arg_to_object(GIArgument *arg, GITypeTag type_tag, SCM *obj)
 {
-    switch (type_tag)
-    {
+    switch (type_tag) {
     case GI_TYPE_TAG_BOOLEAN:
         *obj = scm_from_bool(arg->v_boolean);
         break;
@@ -2002,17 +1876,14 @@ convert_interface_arg_to_object(GIArgument *arg, GITypeInfo *type_info, SCM *obj
 
     GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
     GIInfoType referenced_info_type = g_base_info_get_type(referenced_base_info);
-    if (referenced_info_type == GI_INFO_TYPE_ENUM || referenced_info_type == GI_INFO_TYPE_FLAGS)
-    {
+    if (referenced_info_type == GI_INFO_TYPE_ENUM || referenced_info_type == GI_INFO_TYPE_FLAGS) {
         *obj = scm_from_uint32(arg->v_uint32);
     }
-    else if (referenced_info_type == GI_INFO_TYPE_CALLBACK)
-    {
+    else if (referenced_info_type == GI_INFO_TYPE_CALLBACK) {
         gpointer callback_ptr = arg->v_pointer;
         *obj = scm_from_pointer(callback_ptr, NULL);
     }
-    else
-    {
+    else {
         // This case of returning a struct directly.
         // If the object is already an appropriate GBOX (like for output arguments), we memcpy the contents
         // of the argument into the gbox.
@@ -2023,25 +1894,23 @@ convert_interface_arg_to_object(GIArgument *arg, GITypeInfo *type_info, SCM *obj
 }
 
 static void
-convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag, GITransfer transfer, SCM *obj)
+convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag, GITransfer transfer,
+                                     SCM *obj)
 {
     // We can't transfer strings directly, since GObject and Guile use
     // different internal encodings.  So for GI_TRANSFER_EVERYTHGING,
     // we just free.
-    switch (type_tag)
-    {
+    switch (type_tag) {
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
         if (!arg->v_string)
             *obj = scm_c_make_string(0, SCM_MAKE_CHAR(0));
-        else
-        {
+        else {
             if (type_tag == GI_TYPE_TAG_UTF8)
                 *obj = scm_from_utf8_string(arg->v_string);
             else
                 *obj = scm_from_locale_string(arg->v_string);
-            if (transfer == GI_TRANSFER_EVERYTHING)
-            {
+            if (transfer == GI_TRANSFER_EVERYTHING) {
                 g_free(arg->v_string);
                 arg->v_string = NULL;
             }
@@ -2055,22 +1924,20 @@ convert_string_pointer_arg_to_object(GIArgument *arg, GITypeTag type_tag, GITran
 static void
 convert_array_pointer_arg_to_object(GIArgument *arg,
                                     GITypeInfo *array_type_info,
-                                    GITransfer array_transfer,
-                                    SCM *obj)
+                                    GITransfer array_transfer, SCM *obj)
 {
-    struct array_info ai = {0};
-    fill_array_info (&ai, array_type_info, array_transfer);
+    struct array_info ai = { 0 };
+    fill_array_info(&ai, array_type_info, array_transfer);
 
-    switch (ai.array_type)
-    {
+    switch (ai.array_type) {
     case GI_ARRAY_TYPE_BYTE_ARRAY:
-        *obj = object_from_c_byte_array_arg (&ai, arg);
+        *obj = object_from_c_byte_array_arg(&ai, arg);
         break;
     case GI_ARRAY_TYPE_C:
-        *obj = object_from_c_native_array_arg (&ai, arg);
+        *obj = object_from_c_native_array_arg(&ai, arg);
         break;
     case GI_ARRAY_TYPE_ARRAY:
-        *obj = object_from_c_garray_arg (&ai, arg);
+        *obj = object_from_c_garray_arg(&ai, arg);
         break;
     default:
         g_critical("Unhandled array type in %s:%d", __FILE__, __LINE__);
@@ -2082,13 +1949,11 @@ convert_array_pointer_arg_to_object(GIArgument *arg,
 }
 
 static SCM
-object_from_c_native_array_arg(struct array_info *ai,
-                               GIArgument *arg)
+object_from_c_native_array_arg(struct array_info *ai, GIArgument *arg)
 {
     SCM obj = SCM_UNDEFINED;
 
-    switch (ai->item_type_tag)
-    {
+    switch (ai->item_type_tag) {
     case GI_TYPE_TAG_INT8:
     case GI_TYPE_TAG_UINT8:
     case GI_TYPE_TAG_INT16:
@@ -2105,12 +1970,10 @@ object_from_c_native_array_arg(struct array_info *ai,
         // we already determined the item size earlier, nothing to do here
         break;
     case GI_TYPE_TAG_INTERFACE:
-        switch (ai->referenced_base_type)
-        {
+        switch (ai->referenced_base_type) {
         case GI_INFO_TYPE_ENUM:
         case GI_INFO_TYPE_FLAGS:
-            if (ai->item_is_ptr)
-            {
+            if (ai->item_is_ptr) {
                 // Don't think there are any output arrays of pointers to flags or enums
                 g_critical("Unhandled array type in %s:%d", __FILE__, __LINE__);
                 g_assert_not_reached();
@@ -2132,24 +1995,22 @@ object_from_c_native_array_arg(struct array_info *ai,
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
     {
-        size_t len = array_length (ai, arg);
+        size_t len = array_length(ai, arg);
         SCM out_iter;
 
-        obj = scm_make_list (scm_from_size_t (len), SCM_BOOL_F);
+        obj = scm_make_list(scm_from_size_t(len), SCM_BOOL_F);
         out_iter = obj;
-        for (int i = 0; i < len; i ++)
-        {
+        for (int i = 0; i < len; i++) {
             char *p = ((char **)arg->v_pointer)[i];
-            if (p)
-            {
+            if (p) {
                 SCM entry;
                 if (ai->item_type_tag == GI_TYPE_TAG_UTF8)
                     entry = scm_from_utf8_string(((char **)arg->v_pointer)[i]);
                 else
                     entry = scm_from_locale_string(((char **)arg->v_pointer)[i]);
-                scm_set_car_x (out_iter, entry);
+                scm_set_car_x(out_iter, entry);
             }
-            out_iter = scm_cdr (out_iter);
+            out_iter = scm_cdr(out_iter);
         }
         break;
     }
@@ -2158,10 +2019,9 @@ object_from_c_native_array_arg(struct array_info *ai,
         g_assert_not_reached();
     }
 
-    if (SCM_UNBNDP(obj) && ai->item_size)
-    {
-        size_t _array_length = array_length (ai, arg);
-        g_assert_cmpint (_array_length, !=, -1);
+    if (SCM_UNBNDP(obj) && ai->item_size) {
+        size_t _array_length = array_length(ai, arg);
+        g_assert_cmpint(_array_length, !=, -1);
         size_t len = _array_length * ai->item_size;
         // FIXME: maybe return a typed vector or list
         obj = scm_c_make_bytevector(len);
@@ -2172,8 +2032,7 @@ object_from_c_native_array_arg(struct array_info *ai,
 }
 
 static SCM
-object_from_c_byte_array_arg(struct array_info *ai,
-                             GIArgument *arg)
+object_from_c_byte_array_arg(struct array_info *ai, GIArgument *arg)
 {
     GByteArray *byte_array = arg->v_pointer;
     SCM obj = scm_c_make_bytevector(byte_array->len);
@@ -2186,8 +2045,7 @@ object_from_c_byte_array_arg(struct array_info *ai,
 }
 
 static SCM
-object_from_c_garray_arg(struct array_info *ai,
-                         GIArgument *arg)
+object_from_c_garray_arg(struct array_info *ai, GIArgument *arg)
 {
     GArray *array = arg->v_pointer;
     gpointer data = array->data;
@@ -2195,24 +2053,23 @@ object_from_c_garray_arg(struct array_info *ai,
 
     // We hopefully never have to deal with GArrays of pointer types,
     // given that GPtrArray exists.
-    g_assert_false (ai->item_is_ptr);
-    g_assert_cmpint (ai->item_size, !=, 0);
+    g_assert_false(ai->item_is_ptr);
+    g_assert_cmpint(ai->item_size, !=, 0);
 
-    obj = scm_c_make_vector (array->len, SCM_UNDEFINED);
+    obj = scm_c_make_vector(array->len, SCM_UNDEFINED);
 
     scm_t_array_handle handle;
     gsize len, inc, item_size = ai->item_size;
     SCM *elt;
 
-    elt = scm_vector_writable_elements (obj, &handle, &len, &inc);
-    g_assert (len == array->len);
+    elt = scm_vector_writable_elements(obj, &handle, &len, &inc);
+    g_assert(len == array->len);
 
-    for (gsize i = 0; i < len; i++, elt += inc, data += item_size)
-    {
-        *elt = scm_c_make_bytevector (item_size);
-        memcpy (SCM_BYTEVECTOR_CONTENTS(*elt), data, item_size);
+    for (gsize i = 0; i < len; i++, elt += inc, data += item_size) {
+        *elt = scm_c_make_bytevector(item_size);
+        memcpy(SCM_BYTEVECTOR_CONTENTS(*elt), data, item_size);
     }
-    scm_array_handle_release (&handle);
+    scm_array_handle_release(&handle);
 
     return obj;
 }
@@ -2222,14 +2079,12 @@ convert_const_void_pointer_arg_to_object(GIArgument *arg, SCM *obj)
 {
     // There are some boxes
     int i = 0;
-    while (i < 26)
-    {
-        if (arg->v_pointer == &(boxes[i]))
-        {
+    while (i < 26) {
+        if (arg->v_pointer == &(boxes[i])) {
             *obj = boxes[i];
             return;
         }
-        i ++;
+        i++;
     }
     *obj = scm_from_pointer(arg->v_pointer, NULL);
 }
@@ -2239,31 +2094,25 @@ static int
 arg_struct_to_scm(GIArgument *arg,
                   GIInterfaceInfo *interface_info,
                   GType g_type,
-                  GITransfer transfer,
-                  gboolean is_allocated,
-                  gboolean is_foreign,
-                  SCM obj)
+                  GITransfer transfer, gboolean is_allocated, gboolean is_foreign, SCM obj)
 {
     // Once we get here, INTERFACE_INFO says we are a struct or
     // union, and g_type is the GObject GType of that struct or
     // union.
-    if (arg->v_pointer == NULL)
-    {
+    if (arg->v_pointer == NULL) {
         obj = SCM_BOOL_F;
         return 0;
     }
 
     // A struct/union/box containing a simple value?  Let's just unbox
     // that now.
-    if (g_type_is_a(g_type, G_TYPE_VALUE))
-    {
+    if (g_type_is_a(g_type, G_TYPE_VALUE)) {
         obj = gi_gvalue_as_scm(arg->v_pointer, FALSE);
         return 0;
     }
 
     // All the foreign types.
-    else if (is_foreign)
-    {
+    else if (is_foreign) {
         // FIXME: this is where you look up a special handler for
         // Cairo types
         return GI_GIARGUMENT_UNHANDLED_FOREIGN_TYPE;
@@ -2271,40 +2120,35 @@ arg_struct_to_scm(GIArgument *arg,
 
     // All the rest of the boxed types get re-wrapped into a
     // Scheme-friendly refcounted box.
-    else
-    {
+    else {
         gboolean copy_boxed = FALSE;
         gboolean own_ref = FALSE;
-        if (g_type_is_a(g_type, G_TYPE_BOXED))
-        {
+        if (g_type_is_a(g_type, G_TYPE_BOXED)) {
             if (transfer == GI_TRANSFER_EVERYTHING || is_allocated)
                 copy_boxed = TRUE;
             if (is_allocated && g_struct_info_get_size(interface_info) > 0)
                 own_ref = TRUE;
             obj = gir_new_gbox(SPTR_HOLDS_GBOXED, g_type, arg->v_pointer, copy_boxed);
         }
-        else if (g_type_is_a(g_type, G_TYPE_POINTER))
-        {
+        else if (g_type_is_a(g_type, G_TYPE_POINTER)) {
             // Struct or union containing a pointer
-            obj = gir_new_gbox(SPTR_HOLDS_POINTER, g_type, arg->v_pointer, transfer == GI_TRANSFER_EVERYTHING);
+            obj =
+                gir_new_gbox(SPTR_HOLDS_POINTER, g_type, arg->v_pointer,
+                             transfer == GI_TRANSFER_EVERYTHING);
         }
-        else if (g_type_is_a(g_type, G_TYPE_VARIANT))
-        {
-            if (transfer == GI_TRANSFER_NOTHING)
-            {
+        else if (g_type_is_a(g_type, G_TYPE_VARIANT)) {
+            if (transfer == GI_TRANSFER_NOTHING) {
                 g_variant_ref_sink(arg->v_pointer);
             }
             obj = gir_new_gbox(SPTR_HOLDS_STRUCT, g_type, arg->v_pointer, FALSE);
         }
-        else if (g_type == G_TYPE_NONE)
-        {
+        else if (g_type == G_TYPE_NONE) {
             if (transfer == GI_TRANSFER_EVERYTHING || is_allocated)
                 obj = gir_new_gbox(SPTR_HOLDS_STRUCT, g_type, arg->v_pointer, TRUE);
             else
                 obj = gir_new_gbox(SPTR_HOLDS_STRUCT, g_type, arg->v_pointer, FALSE);
         }
-        else
-        {
+        else {
             g_critical("Unhandled argument type, %s: %d", __FILE__, __LINE__);
             return GI_GIARGUMENT_UNHANDLED_TYPE;
         }
@@ -2326,33 +2170,25 @@ gi_giargument_check_scm_type(SCM obj, GIArgInfo *ai, char **errstr)
 
     g_assert(dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT);
 
-    if (!is_ptr)
-    {
-        if (TYPE_TAG_IS_EXACT_INTEGER(type_tag))
-        {
-            if (!scm_is_exact_integer(obj))
-            {
+    if (!is_ptr) {
+        if (TYPE_TAG_IS_EXACT_INTEGER(type_tag)) {
+            if (!scm_is_exact_integer(obj)) {
                 *errstr = g_strdup_printf("expected exact integer");
                 ok = FALSE;
             }
-            else
-            {
-                if (TYPE_TAG_IS_SIGNED_INTEGER(type_tag))
-                {
+            else {
+                if (TYPE_TAG_IS_SIGNED_INTEGER(type_tag)) {
                     intmax_t val = scm_to_intmax(obj);
-                    if (val < intmin[type_tag] || val > intmax[type_tag])
-                    {
+                    if (val < intmin[type_tag] || val > intmax[type_tag]) {
                         *errstr = g_strdup_printf("integer out of range");
                         ok = FALSE;
                     }
                     else
                         ok = TRUE;
                 }
-                else
-                {
+                else {
                     uintmax_t val = scm_to_uintmax(obj);
-                    if (val > uintmax[type_tag])
-                    {
+                    if (val > uintmax[type_tag]) {
                         *errstr = g_strdup_printf("unsigned integer out of range");
                         ok = FALSE;
                     }
@@ -2361,23 +2197,18 @@ gi_giargument_check_scm_type(SCM obj, GIArgInfo *ai, char **errstr)
                 }
             }
         }
-        else if (TYPE_TAG_IS_REAL_NUMBER(type_tag))
-        {
-            if (!scm_is_real(obj))
-            {
+        else if (TYPE_TAG_IS_REAL_NUMBER(type_tag)) {
+            if (!scm_is_real(obj)) {
                 *errstr = g_strdup_printf("expected real number");
                 ok = FALSE;
             }
-            else
-            {
+            else {
                 // FIXME, if you really wanted to, you could make a
                 // scheme integer bigger than DBL_MAX, so this would
                 // throw.
                 double val = scm_to_double(obj);
-                if (type_tag == GI_TYPE_TAG_FLOAT)
-                {
-                    if (val < -G_MAXFLOAT || val > G_MAXFLOAT)
-                    {
+                if (type_tag == GI_TYPE_TAG_FLOAT) {
+                    if (val < -G_MAXFLOAT || val > G_MAXFLOAT) {
                         *errstr = g_strdup_printf("real number out of range");
                         ok = FALSE;
                     }
@@ -2388,48 +2219,40 @@ gi_giargument_check_scm_type(SCM obj, GIArgInfo *ai, char **errstr)
                     ok = TRUE;
             }
         }
-        else if (type_tag == GI_TYPE_TAG_BOOLEAN)
-        {
-            if (!scm_is_eq(obj, SCM_BOOL_F) && !scm_is_eq(obj, SCM_BOOL_T))
-            {
+        else if (type_tag == GI_TYPE_TAG_BOOLEAN) {
+            if (!scm_is_eq(obj, SCM_BOOL_F) && !scm_is_eq(obj, SCM_BOOL_T)) {
                 *errstr = g_strdup_printf("expected boolean");
                 ok = FALSE;
             }
             else
                 ok = TRUE;
         }
-        else
-        {
+        else {
             *errstr = g_strdup_printf("unhandled type %u", type_tag);
             ok = FALSE;
         }
     }
-    else /* is_ptr */
-    {
+    else {                      /* is_ptr */
+
         if (TYPE_TAG_IS_EXACT_INTEGER(type_tag)
             || TYPE_TAG_IS_REAL_NUMBER(type_tag)
             || (type_tag == GI_TYPE_TAG_UTF8)
             || (type_tag == GI_TYPE_TAG_FILENAME)
-            || (type_tag == GI_TYPE_TAG_VOID))
-        {
-            if (!scm_is_bytevector(obj) && !scm_is_string(obj))
-            {
+            || (type_tag == GI_TYPE_TAG_VOID)) {
+            if (!scm_is_bytevector(obj) && !scm_is_string(obj)) {
                 *errstr = g_strdup_printf("expected bytevector or string");
                 ok = FALSE;
             }
             else
                 ok = TRUE;
         }
-        else if (type_tag == GI_TYPE_TAG_INTERFACE)
-        {
+        else if (type_tag == GI_TYPE_TAG_INTERFACE) {
             ok = TRUE;
         }
-        else if (type_tag == GI_TYPE_TAG_ARRAY)
-        {
+        else if (type_tag == GI_TYPE_TAG_ARRAY) {
             ok = TRUE;
         }
-        else
-        {
+        else {
             *errstr = g_strdup_printf("unhandled pointer type %u", type_tag);
             ok = FALSE;
         }
@@ -2439,14 +2262,11 @@ gi_giargument_check_scm_type(SCM obj, GIArgInfo *ai, char **errstr)
 
 gboolean
 gi_giargument_to_gssize(const char *func,
-                        GIArgument *arg_in,
-                        GITypeTag type_tag,
-                        gssize *gssize_out)
+                        GIArgument *arg_in, GITypeTag type_tag, gssize *gssize_out)
 {
     const gchar *type_name = g_type_tag_to_string(type_tag);
 
-    switch (type_tag)
-    {
+    switch (type_tag) {
     case GI_TYPE_TAG_INT8:
         *gssize_out = arg_in->v_int8;
         return TRUE;
@@ -2466,8 +2286,7 @@ gi_giargument_to_gssize(const char *func,
         *gssize_out = arg_in->v_uint32;
         return TRUE;
     case GI_TYPE_TAG_INT64:
-        if (arg_in->v_int64 > G_MAXSSIZE || arg_in->v_int64 < G_MINSSIZE)
-        {
+        if (arg_in->v_int64 > G_MAXSSIZE || arg_in->v_int64 < G_MINSSIZE) {
             scm_misc_error(func,
                            "Unable to marshal ~A to gssize",
                            scm_list_1(scm_from_utf8_string(type_name)));
@@ -2476,8 +2295,7 @@ gi_giargument_to_gssize(const char *func,
         *gssize_out = (gssize)arg_in->v_int64;
         return TRUE;
     case GI_TYPE_TAG_UINT64:
-        if (arg_in->v_uint64 > G_MAXSSIZE)
-        {
+        if (arg_in->v_uint64 > G_MAXSSIZE) {
             scm_misc_error(func,
                            "Unable to marshal ~A to gssize",
                            scm_list_1(scm_from_utf8_string(type_name)));
@@ -2495,22 +2313,22 @@ gi_giargument_to_gssize(const char *func,
 
 #if 0
 static GITypeTag
-get_storage_type (GITypeInfo *type_info)
+get_storage_type(GITypeInfo *type_info)
 {
-    GITypeTag type_tag = g_type_info_get_tag (type_info);
+    GITypeTag type_tag = g_type_info_get_tag(type_info);
 
     if (type_tag == GI_TYPE_TAG_INTERFACE) {
-        GIBaseInfo *iface = g_type_info_get_interface (type_info);
-        switch (g_base_info_get_type (iface)) {
+        GIBaseInfo *iface = g_type_info_get_interface(type_info);
+        switch (g_base_info_get_type(iface)) {
         case GI_INFO_TYPE_ENUM:
         case GI_INFO_TYPE_FLAGS:
-            type_tag = g_enum_info_get_storage_type ((GIEnumInfo *)iface);
+            type_tag = g_enum_info_get_storage_type((GIEnumInfo *)iface);
             break;
         default:
             /* FIXME: we might have something to do for other types */
             break;
         }
-        g_base_info_unref (iface);
+        g_base_info_unref(iface);
     }
     return type_tag;
 }
@@ -2518,32 +2336,31 @@ get_storage_type (GITypeInfo *type_info)
 
 #if 0
 static void
-hash_pointer_to_arg (GIArgument *arg,
-                     GITypeInfo *type_info)
+hash_pointer_to_arg(GIArgument *arg, GITypeInfo *type_info)
 {
-    GITypeTag type_tag = get_storage_type (type_info);
+    GITypeTag type_tag = get_storage_type(type_info);
 
     switch (type_tag) {
     case GI_TYPE_TAG_INT8:
-        arg->v_int8 = (gint8)GPOINTER_TO_INT (arg->v_pointer);
+        arg->v_int8 = (gint8) GPOINTER_TO_INT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_INT16:
-        arg->v_int16 = (gint16)GPOINTER_TO_INT (arg->v_pointer);
+        arg->v_int16 = (gint16) GPOINTER_TO_INT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_INT32:
-        arg->v_int32 = (gint32)GPOINTER_TO_INT (arg->v_pointer);
+        arg->v_int32 = (gint32) GPOINTER_TO_INT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_UINT8:
-        arg->v_uint8 = (guint8)GPOINTER_TO_UINT (arg->v_pointer);
+        arg->v_uint8 = (guint8) GPOINTER_TO_UINT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_UINT16:
-        arg->v_uint16 = (guint16)GPOINTER_TO_UINT (arg->v_pointer);
+        arg->v_uint16 = (guint16) GPOINTER_TO_UINT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_UINT32:
-        arg->v_uint32 = (guint32)GPOINTER_TO_UINT (arg->v_pointer);
+        arg->v_uint32 = (guint32) GPOINTER_TO_UINT(arg->v_pointer);
         break;
     case GI_TYPE_TAG_GTYPE:
-        arg->v_size = GPOINTER_TO_SIZE (arg->v_pointer);
+        arg->v_size = GPOINTER_TO_SIZE(arg->v_pointer);
         break;
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
@@ -2551,38 +2368,37 @@ hash_pointer_to_arg (GIArgument *arg,
     case GI_TYPE_TAG_ARRAY:
         break;
     default:
-        g_critical ("Unsupported type %s", g_type_tag_to_string(type_tag));
+        g_critical("Unsupported type %s", g_type_tag_to_string(type_tag));
     }
 }
 
 static gpointer
-arg_to_hash_pointer (const GIArgument *arg,
-                     GITypeInfo       *type_info)
+arg_to_hash_pointer(const GIArgument *arg, GITypeInfo *type_info)
 {
-    GITypeTag type_tag = gi_get_storage_type (type_info);
+    GITypeTag type_tag = gi_get_storage_type(type_info);
 
     switch (type_tag) {
     case GI_TYPE_TAG_INT8:
-        return GINT_TO_POINTER (arg->v_int8);
+        return GINT_TO_POINTER(arg->v_int8);
     case GI_TYPE_TAG_UINT8:
-        return GINT_TO_POINTER (arg->v_uint8);
+        return GINT_TO_POINTER(arg->v_uint8);
     case GI_TYPE_TAG_INT16:
-        return GINT_TO_POINTER (arg->v_int16);
+        return GINT_TO_POINTER(arg->v_int16);
     case GI_TYPE_TAG_UINT16:
-        return GINT_TO_POINTER (arg->v_uint16);
+        return GINT_TO_POINTER(arg->v_uint16);
     case GI_TYPE_TAG_INT32:
-        return GINT_TO_POINTER (arg->v_int32);
+        return GINT_TO_POINTER(arg->v_int32);
     case GI_TYPE_TAG_UINT32:
-        return GINT_TO_POINTER (arg->v_uint32);
+        return GINT_TO_POINTER(arg->v_uint32);
     case GI_TYPE_TAG_GTYPE:
-        return GSIZE_TO_POINTER (arg->v_size);
+        return GSIZE_TO_POINTER(arg->v_size);
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
     case GI_TYPE_TAG_INTERFACE:
     case GI_TYPE_TAG_ARRAY:
         return arg->v_pointer;
     default:
-        g_critical ("Unsupported type %s", g_type_tag_to_string(type_tag));
+        g_critical("Unsupported type %s", g_type_tag_to_string(type_tag));
         return arg->v_pointer;
     }
 }
@@ -2599,9 +2415,7 @@ arg_to_hash_pointer (const GIArgument *arg,
  * Returns: The length of the array or -1 on failure.
  */
 gssize
-gi_argument_array_length_marshal(gsize length_arg_index,
-                                 void *user_data1,
-                                 void *user_data2)
+gi_argument_array_length_marshal(gsize length_arg_index, void *user_data1, void *user_data2)
 {
     GIArgInfo length_arg_info;
     GITypeInfo length_type_info;
@@ -2610,34 +2424,28 @@ gi_argument_array_length_marshal(gsize length_arg_index,
     GValue *values = (GValue *)user_data1;
     GICallableInfo *callable_info = (GICallableInfo *)user_data2;
 
-    g_callable_info_load_arg(callable_info,
-                             (gint)length_arg_index, &length_arg_info);
+    g_callable_info_load_arg(callable_info, (gint)length_arg_index, &length_arg_info);
     g_arg_info_load_type(&length_arg_info, &length_type_info);
 
-    length_arg = gi_giargument_from_g_value(&(values[length_arg_index]),
-                                            &length_type_info);
+    length_arg = gi_giargument_from_g_value(&(values[length_arg_index]), &length_type_info);
     if (!gi_giargument_to_gssize(NULL,
                                  &length_arg,
-                                 g_type_info_get_tag(&length_type_info),
-                                 &array_len))
-    {
+                                 g_type_info_get_tag(&length_type_info), &array_len)) {
         return -1;
     }
 
     return array_len;
 }
 
-void gi_giargument_release(GIArgument *arg,
-                           GITypeInfo *type_info,
-                           GITransfer transfer,
-                           GIDirection direction)
+void
+gi_giargument_release(GIArgument *arg,
+                      GITypeInfo *type_info, GITransfer transfer, GIDirection direction)
 {
     GITypeTag type_tag;
 
     type_tag = g_type_info_get_tag(type_info);
 
-    switch (type_tag)
-    {
+    switch (type_tag) {
     case GI_TYPE_TAG_VOID:
         /* Don't do anything, it's transparent to the C side */
         break;
@@ -2660,8 +2468,7 @@ void gi_giargument_release(GIArgument *arg,
         /* With allow-none support the string could be NULL */
         if ((arg->v_string != NULL &&
              (direction == GI_DIRECTION_IN && transfer == GI_TRANSFER_NOTHING)) ||
-            (direction == GI_DIRECTION_OUT && transfer == GI_TRANSFER_EVERYTHING))
-        {
+            (direction == GI_DIRECTION_OUT && transfer == GI_TRANSFER_EVERYTHING)) {
             g_free(arg->v_string);
         }
         break;
@@ -2677,20 +2484,20 @@ scm_box(SCM sym, SCM val)
 {
     SCM_ASSERT(scm_is_symbol(sym), sym, SCM_ARG1, "box");
     char *label = scm_to_utf8_string(scm_symbol_to_string(sym));
-    if (strlen(label) != 1 || label[0] < 'A' || label[0] > 'Z')
-    {
-        free (label);
+    if (strlen(label) != 1 || label[0] < 'A' || label[0] > 'Z') {
+        free(label);
         scm_misc_error("box", "unknown box label ~s", scm_list_1(sym));
-        g_return_val_if_reached (SCM_UNSPECIFIED);
+        g_return_val_if_reached(SCM_UNSPECIFIED);
     }
-    boxes[label[0]-'A'] = val;
-    return scm_from_pointer(&(boxes[label[0]-'A']), NULL);
+    boxes[label[0] - 'A'] = val;
+    return scm_from_pointer(&(boxes[label[0] - 'A']), NULL);
 }
 
 
-void gi_init_giargument(void)
+void
+gi_init_giargument(void)
 {
-    for (int i = 0; i < 26; i ++)
+    for (int i = 0; i < 26; i++)
         boxes[i] = SCM_UNSPECIFIED;
 
     SCONSTX(GI_TYPE_TAG_VOID);

--- a/src/gi_giargument.h
+++ b/src/gi_giargument.h
@@ -12,28 +12,23 @@
 
 void
 gi_giargument_object_to_c_arg(char *subr, int argnum,
-                              SCM obj,
-                              GIArgInfo *arg_info,
-                              unsigned *must_free,
-                              GIArgument *arg);
+                              SCM obj, GIArgInfo *arg_info, unsigned *must_free, GIArgument *arg);
 
 char *gi_giargument_describe_arg_in(GIArgInfo *arg_info);
 void
 gi_giargument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument *arg, SCM *obj);
-void
-gi_giargument_free_args(int n, unsigned *must_free, GIArgument *args);
-void
-gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *obj);
+void gi_giargument_free_args(int n, unsigned *must_free, GIArgument *args);
+void gi_giargument_convert_arg_to_object(GIArgument *arg, GIArgInfo *arg_info, SCM *obj);
 
 SCM
-gi_giargument_convert_return_val_to_object(GIArgument  *arg,
-    GITypeInfo *type_info,
-    GITransfer transfer, gboolean null_ok, gboolean skip);
+gi_giargument_convert_return_val_to_object(GIArgument *arg,
+                                           GITypeInfo *type_info,
+                                           GITransfer transfer, gboolean null_ok, gboolean skip);
 void
 gi_giargument_convert_return_type_object_to_arg(SCM obj,
-    GITypeInfo *type_info,
-    GITransfer transfer, gboolean null_ok, gboolean skip,
-    GIArgument *arg);
+                                                GITypeInfo *type_info,
+                                                GITransfer transfer, gboolean null_ok,
+                                                gboolean skip, GIArgument *arg);
 
 void gi_init_giargument(void);
 #endif

--- a/src/gi_gobject.c
+++ b/src/gi_gobject.c
@@ -24,7 +24,6 @@
 #include <glib.h>
 #include <girepository.h>
 #include <libguile.h>
-#include <errno.h>
 
 GQuark gi_gobject_instance_data_key;
 
@@ -780,19 +779,6 @@ scm_register_guile_specified_gobject_type (SCM s_type_name,
 
     gir_type_define(new_type);
     return gir_type_get_scheme_type (new_type);
-}
-
-static void*
-scm_dynwind_or_bust (char *subr, void *mem)
-{
-    if (mem)
-        scm_dynwind_free (mem);
-    else
-    {
-        errno = ENOMEM;
-        scm_syserror (subr);
-    }
-    return mem;
 }
 
 static SCM

--- a/src/gi_gobject.c
+++ b/src/gi_gobject.c
@@ -27,12 +27,14 @@
 
 GQuark gi_gobject_instance_data_key;
 
-typedef struct _GuileSpecifiedGObjectClassData {
+typedef struct _GuileSpecifiedGObjectClassData
+{
     SCM disposer;
     char padding[56];
 } GuileSpecifiedGObjectClassData;
 
-typedef struct _GuileSpecifiedGObjectInstanceData {
+typedef struct _GuileSpecifiedGObjectInstanceData
+{
     SCM obj;
     char padding[56];
 } GuileSpecifiedGObjectInstanceData;
@@ -56,38 +58,33 @@ static GQuark gi_gobject_custom_key;
 // static GQuark gi_gobject_class_key;
 
 static void
-set_guile_specified_property (GObject *object, guint property_id,
-                              const GValue *value, GParamSpec *pspec);
+set_guile_specified_property(GObject *object, guint property_id,
+                             const GValue *value, GParamSpec *pspec);
 static void
-get_guile_specified_property (GObject *object, guint property_id,
-                              GValue *value, GParamSpec *pspec);
-static void
-dispose (GObject *object);
-static void
-finalize (GObject *object);
-static SCM
-gi_get_property_value (const char *func, SCM instance, GParamSpec *pspec);
-static inline int
-gugobject_clear(SCM self);
+get_guile_specified_property(GObject *object, guint property_id, GValue *value, GParamSpec *pspec);
+static void dispose(GObject *object);
+static void finalize(GObject *object);
+static SCM gi_get_property_value(const char *func, SCM instance, GParamSpec *pspec);
+static inline int gugobject_clear(SCM self);
 
 
 
 /* re pygobject-object.c:61 gclosure from pyfunc */
 GClosure *
-gclosure_from_scm_func (SCM object, SCM func)
+gclosure_from_scm_func(SCM object, SCM func)
 {
     GSList *l;
     GuGObjectData *inst_data;
     GObject *obj;
 
-    obj = gi_gobject_get_obj (object);
+    obj = gi_gobject_get_obj(object);
     inst_data = gi_gobject_peek_inst_data(obj);
     if (inst_data) {
         for (l = inst_data->closures; l; l = l->next) {
             GuGClosure *guclosure = l->data;
-            int res = scm_is_eq (guclosure->callback, func);
+            int res = scm_is_eq(guclosure->callback, func);
             if (res) {
-                return (GClosure*)guclosure;
+                return (GClosure *)guclosure;
             }
         }
     }
@@ -103,8 +100,7 @@ gugobject_data_free(GuGObjectData *data)
     tmp = closures = data->closures;
     data->closures = NULL;
     data->type = SCM_BOOL_F;
-    while (tmp)
-    {
+    while (tmp) {
         GClosure *closure = tmp->data;
 
         /* we get next item first, because the current link gets
@@ -119,8 +115,11 @@ gugobject_data_free(GuGObjectData *data)
     g_free(data);
 }
 
-static inline GuGObjectData * __attribute__((malloc))
+/* *INDENT-OFF* */
+__attribute__((malloc)) static inline GuGObjectData *
 gugobject_data_new(void)
+/* *INDENT-ON* */
+
 {
     GuGObjectData *data;
     data = g_new0(GuGObjectData, 1);
@@ -133,12 +132,11 @@ gugobject_get_inst_data(SCM self)
     GObject *obj;
     GuGObjectData *inst_data;
 
-    obj = gi_gobject_get_obj (self);
+    obj = gi_gobject_get_obj(self);
     if (G_UNLIKELY(!obj))
         return NULL;
     inst_data = g_object_get_qdata(obj, gi_gobject_instance_data_key);
-    if (inst_data == NULL)
-    {
+    if (inst_data == NULL) {
         inst_data = gugobject_data_new();
 
         inst_data->type = self;
@@ -161,21 +159,18 @@ gi_gobject_new_full(GIObjectInfo *info, GObject *obj, gboolean steal, gpointer g
 
     /* Check if this obj is wrapped already. */
     ptr = g_object_get_qdata(obj, gi_gobject_wrapper_key);
-    if (ptr)
-    {
-        self = SCM_PACK_POINTER (ptr);
+    if (ptr) {
+        self = SCM_PACK_POINTER(ptr);
         if (steal)
             g_object_unref(obj);
     }
-    else
-    {
+    else {
         /* create wrapper */
         GuGObjectData *inst_data = gi_gobject_peek_inst_data(obj);
         SCM tp;
         if (inst_data)
             tp = inst_data->type;
-        else
-        {
+        else {
             /* if (g_class) */
             /*  tp = gugobject_lookup_class (G_OBJECT_CLASS_TYPE (g_class)); */
             /* else */
@@ -187,16 +182,11 @@ gi_gobject_new_full(GIObjectInfo *info, GObject *obj, gboolean steal, gpointer g
 
         //if (gi_gtype_get_flags (tp) & Gu_TPFLAGS_HEAPTYPE)
         //    Gu_INCREF(tp);
-        self = gir_type_make_object(G_OBJECT_TYPE(obj),
-                                    obj,
-                                    0);
+        self = gir_type_make_object(G_OBJECT_TYPE(obj), obj, 0);
 
         if (g_object_is_floating(obj))
-            scm_foreign_object_unsigned_set_x(self,
-                                              FLAGS_SLOT,
-                                              GI_GOBJECT_GOBJECT_WAS_FLOATING);
-        if (!steal
-            || (gi_gobject_get_flags(self) & GI_GOBJECT_GOBJECT_WAS_FLOATING))
+            scm_foreign_object_unsigned_set_x(self, FLAGS_SLOT, GI_GOBJECT_GOBJECT_WAS_FLOATING);
+        if (!steal || (gi_gobject_get_flags(self) & GI_GOBJECT_GOBJECT_WAS_FLOATING))
             g_object_ref_sink(obj);
     }
     return self;
@@ -204,9 +194,9 @@ gi_gobject_new_full(GIObjectInfo *info, GObject *obj, gboolean steal, gpointer g
 
 /* re pygobject-object.c: 1059 pygobject_new */
 SCM
-gi_gobject_new (GIObjectInfo *info, GObject *obj)
+gi_gobject_new(GIObjectInfo *info, GObject *obj)
 {
-    return gi_gobject_new_full (info, obj, FALSE, NULL);
+    return gi_gobject_new_full(info, obj, FALSE, NULL);
 }
 
 /* re pygobject-object.c: 1067 pygobject_unwatch_closure */
@@ -215,7 +205,7 @@ gugobject_unwatch_closure(gpointer data, GClosure *closure)
 {
     GuGObjectData *inst_data = data;
 
-    inst_data->closures = g_slist_remove (inst_data->closures, closure);
+    inst_data->closures = g_slist_remove(inst_data->closures, closure);
 }
 
 /* Adds a closure to the list of watched closures for the wrapper.
@@ -238,7 +228,7 @@ gugobject_watch_closure(SCM self, GClosure *closure)
 }
 
 static void
-gug_toggle_notify (gpointer data, GObject *object, gboolean is_last_ref)
+gug_toggle_notify(gpointer data, GObject *object, gboolean is_last_ref)
 {
     /* Avoid thread safety problems by using qdata for wrapper retrieval
      * instead of the user data argument.
@@ -255,15 +245,15 @@ gug_toggle_notify (gpointer data, GObject *object, gboolean is_last_ref)
 }
 
 static inline gboolean
-gugobject_toggle_ref_is_required (SCM self)
+gugobject_toggle_ref_is_required(SCM self)
 {
-    SCM dict = gi_gobject_get_inst_dict (self);
+    SCM dict = gi_gobject_get_inst_dict(self);
     // FIXME - maybe check if hash table is not empty
-    return scm_is_true (dict);
+    return scm_is_true(dict);
 }
 
 static inline gboolean
-gugobject_toggle_ref_is_active (SCM self)
+gugobject_toggle_ref_is_active(SCM self)
 {
     unsigned flags = gi_gobject_get_flags(self);
     return flags & GI_GOBJECT_USING_TOGGLE_REF;
@@ -276,7 +266,7 @@ gugobject_toggle_ref_is_active (SCM self)
 
 /* Compare with pygobject-object.c:1115 pygobject_dealloc */
 void
-gi_gobject_finalizer (SCM self)
+gi_gobject_finalizer(SCM self)
 {
     /* Clear out the weak reference vector, if it exists. */
     gi_gobject_set_weakreflist(self, SCM_BOOL_F);
@@ -290,14 +280,15 @@ gi_gobject_finalizer (SCM self)
 static inline int
 gugobject_clear(SCM self)
 {
-    GObject *obj = gi_gobject_get_obj (self);
+    GObject *obj = gi_gobject_get_obj(self);
     if (obj) {
         g_object_set_qdata_full(obj, gi_gobject_wrapper_key, NULL, NULL);
-        if (gugobject_toggle_ref_is_active (self)) {
+        if (gugobject_toggle_ref_is_active(self)) {
             g_object_remove_toggle_ref(obj, gug_toggle_notify, NULL);
-            unsigned flags = gi_gobject_get_flags (self);
-            gi_gobject_set_flags (self, flags & ~GI_GOBJECT_USING_TOGGLE_REF);
-        } else {
+            unsigned flags = gi_gobject_get_flags(self);
+            gi_gobject_set_flags(self, flags & ~GI_GOBJECT_USING_TOGGLE_REF);
+        }
+        else {
             g_object_unref(obj);
         }
         gi_gobject_set_obj(self, NULL);
@@ -307,8 +298,7 @@ gugobject_clear(SCM self)
 }
 
 static SCM
-connect_helper (SCM self, gchar *name, SCM callback, SCM extra_args,
-                SCM object, gboolean after)
+connect_helper(SCM self, gchar *name, SCM callback, SCM extra_args, SCM object, gboolean after)
 {
     guint sigid;
     GQuark detail = 0;
@@ -316,57 +306,46 @@ connect_helper (SCM self, gchar *name, SCM callback, SCM extra_args,
     gulong handlerid;
     GSignalQuery query_info;
 
-    GObject *obj = scm_foreign_object_ref (self, OBJ_SLOT);
+    GObject *obj = scm_foreign_object_ref(self, OBJ_SLOT);
     GType gtype = G_OBJECT_TYPE(obj);
 
-    if (!g_signal_parse_name(name, gtype,
-                             &sigid, &detail, TRUE))
-    {
-        scm_misc_error ("connect_helper",
-                        "~A: unknown signal name ~A",
-                        scm_list_2 (self, scm_from_utf8_string(name)));
+    if (!g_signal_parse_name(name, gtype, &sigid, &detail, TRUE)) {
+        scm_misc_error("connect_helper",
+                       "~A: unknown signal name ~A", scm_list_2(self, scm_from_utf8_string(name)));
     }
 
-    g_signal_query (sigid, &query_info);
-    if (g_type_get_qdata (gtype, gi_gobject_custom_key) == NULL)
-    {
+    g_signal_query(sigid, &query_info);
+    if (g_type_get_qdata(gtype, gi_gobject_custom_key) == NULL) {
         /* The signal is implemented by a non-Scheme class. */
-        closure = gi_signal_closure_new (self, query_info.itype,
-                                         query_info.signal_name, callback,
-                                         extra_args);
+        closure = gi_signal_closure_new(self, query_info.itype,
+                                        query_info.signal_name, callback, extra_args);
     }
 
-    if (!closure)
-    {
+    if (!closure) {
         /* The signal is implemented at the Scheme level, probably */
         // closure = gug_closure_new (callback, extra_args, object);
-        closure = gi_signal_closure_new (self, query_info.itype,
-                                         query_info.signal_name, callback,
-                                         extra_args);
+        closure = gi_signal_closure_new(self, query_info.itype,
+                                        query_info.signal_name, callback, extra_args);
         //g_critical ("unimplemented");
         //g_abort();
     }
 
-    gugobject_watch_closure (self, closure);
-    handlerid = g_signal_connect_closure_by_id (obj,
-                                                sigid, detail, closure,
-                                                after);
+    gugobject_watch_closure(self, closure);
+    handlerid = g_signal_connect_closure_by_id(obj, sigid, detail, closure, after);
 
-    return scm_from_ulong (handlerid);
+    return scm_from_ulong(handlerid);
 }
 
 static SCM
-scm_signal_connect (SCM self, SCM s_name, SCM proc, SCM rest)
+scm_signal_connect(SCM self, SCM s_name, SCM proc, SCM rest)
 {
     if (gir_type_get_gtype_from_obj(self) <= G_TYPE_INVALID)
-        scm_error (scm_arg_type_key, "signal-connect",
-                   "Wrong type in position 1: ~S",
-                   scm_list_1 (self),
-                   scm_list_1 (self));
+        scm_error(scm_arg_type_key, "signal-connect",
+                  "Wrong type in position 1: ~S", scm_list_1(self), scm_list_1(self));
 
-    char *name = scm_to_utf8_string (s_name);
-    SCM ret = connect_helper (self, name, proc, rest, SCM_BOOL_F, FALSE);
-    free (name);
+    char *name = scm_to_utf8_string(s_name);
+    SCM ret = connect_helper(self, name, proc, rest, SCM_BOOL_F, FALSE);
+    free(name);
     return ret;
 }
 
@@ -378,24 +357,19 @@ scm_gobject_disconnect_by_func(SCM self, SCM func)
     GObject *obj;
     guint retval;
 
-    SCM_ASSERT (gir_type_get_gtype_from_obj (self) > G_TYPE_INVALID,
-                self, SCM_ARG1, "gobject-disconnect-by-func");
-    SCM_ASSERT (scm_is_true (scm_procedure_p (func)), func, SCM_ARG2,
-                "gobject-disconnect-by-func");
+    SCM_ASSERT(gir_type_get_gtype_from_obj(self) > G_TYPE_INVALID,
+               self, SCM_ARG1, "gobject-disconnect-by-func");
+    SCM_ASSERT(scm_is_true(scm_procedure_p(func)), func, SCM_ARG2, "gobject-disconnect-by-func");
 
     closure = gclosure_from_scm_func(self, func);
     if (!closure)
-        scm_misc_error ("gobject-disconnect-by-func",
-                        "nothing connected to ~S",
-                        scm_list_1 (func));
+        scm_misc_error("gobject-disconnect-by-func", "nothing connected to ~S", scm_list_1(func));
 
-    obj = gi_gobject_get_obj (self);
+    obj = gi_gobject_get_obj(self);
     retval = g_signal_handlers_disconnect_matched(obj,
                                                   G_SIGNAL_MATCH_CLOSURE,
-                                                  0, 0,
-                                                  closure,
-                                                  NULL, NULL);
-    return scm_from_uint (retval);
+                                                  0, 0, closure, NULL, NULL);
+    return scm_from_uint(retval);
 }
 
 /* pygobject-object.c: 2098, pygobject_handler_block_by_func */
@@ -406,24 +380,20 @@ scm_gobject_handler_block_by_func(SCM self, SCM func)
     GObject *obj;
     guint retval;
 
-    SCM_ASSERT (gir_type_get_gtype_from_obj (self) > G_TYPE_INVALID,
-                self, SCM_ARG1, "gobject-handler-block-by-func");
-    SCM_ASSERT (scm_is_true (scm_procedure_p (func)), func, SCM_ARG2,
-                "gobject-handler-block-by-func");
+    SCM_ASSERT(gir_type_get_gtype_from_obj(self) > G_TYPE_INVALID,
+               self, SCM_ARG1, "gobject-handler-block-by-func");
+    SCM_ASSERT(scm_is_true(scm_procedure_p(func)), func, SCM_ARG2,
+               "gobject-handler-block-by-func");
 
     closure = gclosure_from_scm_func(self, func);
     if (!closure)
-        scm_misc_error ("gobject-handler-block-by-func",
-                        "nothing connected to ~S",
-                        scm_list_1 (func));
+        scm_misc_error("gobject-handler-block-by-func",
+                       "nothing connected to ~S", scm_list_1(func));
 
-    obj = scm_foreign_object_ref (self, OBJ_SLOT);
+    obj = scm_foreign_object_ref(self, OBJ_SLOT);
     retval = g_signal_handlers_block_matched(obj,
-                                             G_SIGNAL_MATCH_CLOSURE,
-                                             0, 0,
-                                             closure,
-                                             NULL, NULL);
-    return scm_from_uint (retval);
+                                             G_SIGNAL_MATCH_CLOSURE, 0, 0, closure, NULL, NULL);
+    return scm_from_uint(retval);
 }
 
 /* pygobject-object.c: 2032, pygobject_handler_unblock_by_func */
@@ -434,61 +404,50 @@ scm_gobject_handler_unblock_by_func(SCM self, SCM func)
     GObject *obj;
     guint retval;
 
-    SCM_ASSERT (gir_type_get_gtype_from_obj (self) > G_TYPE_INVALID,
-                self, SCM_ARG1, "gobject-handler-unblock-by-func");
-    SCM_ASSERT (scm_is_true (scm_procedure_p (func)), func, SCM_ARG2,
-                "gobject-handler-unblock-by-func");
+    SCM_ASSERT(gir_type_get_gtype_from_obj(self) > G_TYPE_INVALID,
+               self, SCM_ARG1, "gobject-handler-unblock-by-func");
+    SCM_ASSERT(scm_is_true(scm_procedure_p(func)), func, SCM_ARG2,
+               "gobject-handler-unblock-by-func");
 
     closure = gclosure_from_scm_func(self, func);
     if (!closure)
-        scm_misc_error ("gobject-handler-unblock-by-func",
-                        "nothing connected to ~S",
-                        scm_list_1 (func));
+        scm_misc_error("gobject-handler-unblock-by-func",
+                       "nothing connected to ~S", scm_list_1(func));
 
-    obj = scm_foreign_object_ref (self, OBJ_SLOT);
+    obj = scm_foreign_object_ref(self, OBJ_SLOT);
     retval = g_signal_handlers_unblock_matched(obj,
-                                               G_SIGNAL_MATCH_CLOSURE,
-                                               0, 0,
-                                               closure,
-                                               NULL, NULL);
-    return scm_from_uint (retval);
+                                               G_SIGNAL_MATCH_CLOSURE, 0, 0, closure, NULL, NULL);
+    return scm_from_uint(retval);
 }
 
 
 static void
-marshal_signals (GClosure *closure,
-                 GValue *return_value,
-                 guint n_param_values,
-                 const GValue *param_values,
-                 gpointer invocation_hint,
-                 gpointer marshal_data)
+marshal_signals(GClosure *closure,
+                GValue *return_value,
+                guint n_param_values,
+                const GValue *param_values, gpointer invocation_hint, gpointer marshal_data)
 {
 
 }
 
 static void
-make_new_signal (SignalSpec *signal_spec, gpointer user_data)
+make_new_signal(SignalSpec *signal_spec, gpointer user_data)
 {
-    GType instance_type = GPOINTER_TO_SIZE (user_data);
-    g_signal_newv (signal_spec->signal_name,
-                   instance_type,
-                   signal_spec->signal_flags,
-                   NULL, /* closure */
-                   signal_spec->accumulator,
-                   signal_spec->accu_data,
-                   marshal_signals,
-                   signal_spec->return_type,
-                   signal_spec->n_params,
-                   signal_spec->param_types);
+    GType instance_type = GPOINTER_TO_SIZE(user_data);
+    g_signal_newv(signal_spec->signal_name, instance_type, signal_spec->signal_flags, NULL,     /* closure */
+                  signal_spec->accumulator,
+                  signal_spec->accu_data,
+                  marshal_signals,
+                  signal_spec->return_type, signal_spec->n_params, signal_spec->param_types);
 }
 
 static void
 init_guile_specified_gobject_class(GObjectClass *class, gpointer class_info)
 {
-    GType type = G_TYPE_FROM_CLASS (class);
+    GType type = G_TYPE_FROM_CLASS(class);
     GuileSpecifiedGObjectClassInfo *init_info = class_info;
     size_t n_properties = init_info->properties->len;
-    GParamSpec **properties = (GParamSpec **) init_info->properties->pdata;
+    GParamSpec **properties = (GParamSpec **)init_info->properties->pdata;
     GuileSpecifiedGObjectClassData *self;
 
     class->set_property = set_guile_specified_property;
@@ -499,15 +458,13 @@ init_guile_specified_gobject_class(GObjectClass *class, gpointer class_info)
     /* Since the parent type could be anything, some pointer math is
      * required to figure out where our part of the object class is
      * located. */
-    self = (GuileSpecifiedGObjectClassData *) ((char *) class + init_info->parent_class_size);
+    self = (GuileSpecifiedGObjectClassData *) ((char *)class + init_info->parent_class_size);
     self->disposer = init_info->disposer;
 
-    g_ptr_array_foreach (init_info->signals,
-                         (GFunc) make_new_signal,
-                         GSIZE_TO_POINTER (type));
+    g_ptr_array_foreach(init_info->signals, (GFunc) make_new_signal, GSIZE_TO_POINTER(type));
 
-    for (size_t i = 1; i <= n_properties; i ++)
-        g_object_class_install_property (class, i, properties[i-1]);
+    for (size_t i = 1; i <= n_properties; i++)
+        g_object_class_install_property(class, i, properties[i - 1]);
 }
 
 
@@ -515,7 +472,7 @@ static void
 init_instance(GTypeInstance *instance, gpointer class_ptr)
 {
     GType type = G_TYPE_FROM_CLASS(class_ptr);
-    GType parent_type = g_type_parent (type);
+    GType parent_type = g_type_parent(type);
     guint n_properties;
     GParamSpec **properties;
     GTypeQuery query;
@@ -525,47 +482,42 @@ init_instance(GTypeInstance *instance, gpointer class_ptr)
 
     g_type_query(parent_type, &query);
 
-    instance_data = (GuileSpecifiedGObjectInstanceData *) ((char *) instance + query.instance_size);
-    properties = g_object_class_list_properties (class_ptr, &n_properties);
+    instance_data = (GuileSpecifiedGObjectInstanceData *) ((char *)instance + query.instance_size);
+    properties = g_object_class_list_properties(class_ptr, &n_properties);
 
     /* This is both the Guile-side representation of this object and
-       the location in memory where the properties are stored. */
-    obj = gir_type_make_object (type, instance, 0);
-    inst_dict = scm_make_hash_table (scm_from_int (10));
-    scm_foreign_object_set_x(obj, INST_DICT_SLOT, SCM_UNPACK_POINTER (inst_dict));
+     * the location in memory where the properties are stored. */
+    obj = gir_type_make_object(type, instance, 0);
+    inst_dict = scm_make_hash_table(scm_from_int(10));
+    scm_foreign_object_set_x(obj, INST_DICT_SLOT, SCM_UNPACK_POINTER(inst_dict));
 
     /* We're using a hash table as the property variable store for
-       this object. */
-    for (guint i = 0; i < n_properties; i ++)
-    {
+     * this object. */
+    for (guint i = 0; i < n_properties; i++) {
         SCM sval;
-        const GValue* _default;
+        const GValue *_default;
 
-        _default = g_param_spec_get_default_value (properties[i]);
-        sval = gi_gvalue_as_scm (_default, TRUE);
-        scm_hash_set_x (inst_dict,
-                        scm_from_utf8_string (g_param_spec_get_name (properties[i])),
-                        sval);
+        _default = g_param_spec_get_default_value(properties[i]);
+        sval = gi_gvalue_as_scm(_default, TRUE);
+        scm_hash_set_x(inst_dict,
+                       scm_from_utf8_string(g_param_spec_get_name(properties[i])), sval);
     }
 
     instance_data->obj = obj;
-    g_object_set_qdata (G_OBJECT(instance),
-                        gi_gobject_wrapper_key,
-                        SCM_UNPACK_POINTER (obj));
+    g_object_set_qdata(G_OBJECT(instance), gi_gobject_wrapper_key, SCM_UNPACK_POINTER(obj));
 }
 
 static void
-wrap_object (GObject *object)
+wrap_object(GObject *object)
 {
     /* Somehow, you managed to make a pointer to a Guile-defined class
      * object without actually making the Scheme wrapper.  Let's try
      * to add it now. */
-    g_assert_not_reached ();
+    g_assert_not_reached();
 }
 
 static void
-get_guile_specified_property (GObject *object, guint property_id,
-                              GValue *value, GParamSpec *pspec)
+get_guile_specified_property(GObject *object, guint property_id, GValue *value, GParamSpec *pspec)
 {
     gpointer ptr;
     SCM obj;
@@ -573,99 +525,93 @@ get_guile_specified_property (GObject *object, guint property_id,
     SCM svalue;
 
     /* Find the guile representation of OBJECT */
-    ptr = g_object_get_qdata (object, gi_gobject_wrapper_key);
-    if (!ptr)
-    {
-        wrap_object (object);
-        ptr = g_object_get_qdata (object, gi_gobject_wrapper_key);
-    }
-
-    obj = SCM_PACK_POINTER (ptr);
-
-    g_assert (scm_foreign_object_ref (obj, OBJ_SLOT) == object);
-
-    /* We're using a hash table as the property variable store for
-       this object. */
-    inst_dict = SCM_PACK_POINTER (scm_foreign_object_ref(obj, INST_DICT_SLOT));
-    svalue = scm_hash_ref (inst_dict,
-                           scm_from_utf8_string (g_param_spec_get_name (pspec)),
-                           SCM_BOOL_F);
-    gi_gvalue_from_scm (value, svalue);
-}
-
-static void
-set_guile_specified_property (GObject *object, guint property_id,
-                              const GValue *value, GParamSpec *pspec)
-{
-    gpointer ptr;
-    SCM obj;
-    SCM inst_dict;
-    SCM svalue;
-
-    /* Find the guile representation of OBJECT */
-    ptr = g_object_get_qdata (object, gi_gobject_wrapper_key);
+    ptr = g_object_get_qdata(object, gi_gobject_wrapper_key);
     if (!ptr) {
-        wrap_object (object);
-        ptr = g_object_get_qdata (object, gi_gobject_wrapper_key);
+        wrap_object(object);
+        ptr = g_object_get_qdata(object, gi_gobject_wrapper_key);
     }
 
-    obj = SCM_PACK_POINTER (ptr);
+    obj = SCM_PACK_POINTER(ptr);
 
-    g_assert (scm_foreign_object_ref(obj, OBJ_SLOT) == object);
+    g_assert(scm_foreign_object_ref(obj, OBJ_SLOT) == object);
 
     /* We're using a hash table as the property variable store for
-       this object. */
-    inst_dict = SCM_PACK_POINTER (scm_foreign_object_ref (obj, INST_DICT_SLOT));
-    svalue = gi_gvalue_as_scm (value, TRUE);
-    scm_hash_set_x (inst_dict,
-                    scm_from_utf8_string (g_param_spec_get_name (pspec)),
-                    svalue);
+     * this object. */
+    inst_dict = SCM_PACK_POINTER(scm_foreign_object_ref(obj, INST_DICT_SLOT));
+    svalue = scm_hash_ref(inst_dict,
+                          scm_from_utf8_string(g_param_spec_get_name(pspec)), SCM_BOOL_F);
+    gi_gvalue_from_scm(value, svalue);
 }
 
 static void
-dispose (GObject *object)
+set_guile_specified_property(GObject *object, guint property_id,
+                             const GValue *value, GParamSpec *pspec)
+{
+    gpointer ptr;
+    SCM obj;
+    SCM inst_dict;
+    SCM svalue;
+
+    /* Find the guile representation of OBJECT */
+    ptr = g_object_get_qdata(object, gi_gobject_wrapper_key);
+    if (!ptr) {
+        wrap_object(object);
+        ptr = g_object_get_qdata(object, gi_gobject_wrapper_key);
+    }
+
+    obj = SCM_PACK_POINTER(ptr);
+
+    g_assert(scm_foreign_object_ref(obj, OBJ_SLOT) == object);
+
+    /* We're using a hash table as the property variable store for
+     * this object. */
+    inst_dict = SCM_PACK_POINTER(scm_foreign_object_ref(obj, INST_DICT_SLOT));
+    svalue = gi_gvalue_as_scm(value, TRUE);
+    scm_hash_set_x(inst_dict, scm_from_utf8_string(g_param_spec_get_name(pspec)), svalue);
+}
+
+static void
+dispose(GObject *object)
 {
     GType type, parent_type;
     gpointer _parent_class;
     GObjectClass *parent_class;
 
-    type = G_OBJECT_TYPE (object);
-    parent_type = g_type_parent (type);
+    type = G_OBJECT_TYPE(object);
+    parent_type = g_type_parent(type);
 
-    g_assert (G_TYPE_IS_CLASSED (type));
-    g_assert (G_TYPE_IS_CLASSED (parent_type));
+    g_assert(G_TYPE_IS_CLASSED(type));
+    g_assert(G_TYPE_IS_CLASSED(parent_type));
 
-    g_info ("dispose is currently just calling the parent's dispose");
+    g_info("dispose is currently just calling the parent's dispose");
 
-    g_debug ("disposing parent type");
-    _parent_class = g_type_class_ref (parent_type);
-    parent_class = G_OBJECT_CLASS (_parent_class);
+    g_debug("disposing parent type");
+    _parent_class = g_type_class_ref(parent_type);
+    parent_class = G_OBJECT_CLASS(_parent_class);
 
-    parent_class->dispose (object);
+    parent_class->dispose(object);
 
-    g_type_class_unref (_parent_class);
+    g_type_class_unref(_parent_class);
 }
 
 static void
-finalize (GObject *object)
+finalize(GObject *object)
 {
-    g_info ("finalization is not yet implemented, this is a noop");
+    g_info("finalization is not yet implemented, this is a noop");
 }
 
 
 static GType
-register_guile_specified_gobject_type (const char *type_name,
-                                       GType parent_type,
-                                       GPtrArray *properties,
-                                       GPtrArray *signals,
-                                       SCM disposer)
+register_guile_specified_gobject_type(const char *type_name,
+                                      GType parent_type,
+                                      GPtrArray *properties, GPtrArray *signals, SCM disposer)
 {
     GTypeInfo type_info;
     GuileSpecifiedGObjectClassInfo *class_init_info;
     GTypeQuery query;
     GType new_type;
 
-    memset (&type_info, 0, sizeof (type_info));
+    memset(&type_info, 0, sizeof(type_info));
 
     /* This data will needed when the class is dynamically instantiated. */
     class_init_info = g_new0(GuileSpecifiedGObjectClassInfo, 1);
@@ -683,27 +629,20 @@ register_guile_specified_gobject_type (const char *type_name,
     class_init_info->parent_instance_size = query.instance_size;
     type_info.class_init = (GClassInitFunc) init_guile_specified_gobject_class;
     type_info.instance_init = init_instance;
-    new_type = g_type_register_static (parent_type,
-                                       type_name,
-                                       &type_info,
-                                       0);
+    new_type = g_type_register_static(parent_type, type_name, &type_info, 0);
     class_init_info->type = new_type;
 
     /* Mark this type as a Guile-specified type. */
-    g_type_set_qdata(new_type,
-                     gi_gobject_custom_key,
-                     GINT_TO_POINTER(1));
+    g_type_set_qdata(new_type, gi_gobject_custom_key, GINT_TO_POINTER(1));
     return new_type;
 }
 
 /* The procedure is the top-level entry point for defining a new
    GObject type in Guile. */
 static SCM
-scm_register_guile_specified_gobject_type (SCM s_type_name,
-                                           SCM s_parent_type,
-                                           SCM s_properties,
-                                           SCM s_signals,
-                                           SCM s_disposer)
+scm_register_guile_specified_gobject_type(SCM s_type_name,
+                                          SCM s_parent_type,
+                                          SCM s_properties, SCM s_signals, SCM s_disposer)
 {
     char *type_name;
     GType parent_type;
@@ -712,77 +651,62 @@ scm_register_guile_specified_gobject_type (SCM s_type_name,
     GPtrArray *properties;
     GPtrArray *signals;
 
-    SCM_ASSERT (scm_is_string (s_type_name),
-                s_type_name,
-                SCM_ARG1,
-                "register-type");
+    SCM_ASSERT(scm_is_string(s_type_name), s_type_name, SCM_ARG1, "register-type");
 
-    type_name = scm_to_utf8_string (s_type_name);
+    type_name = scm_to_utf8_string(s_type_name);
 
-    parent_type = scm_to_gtype (s_parent_type);
+    parent_type = scm_to_gtype(s_parent_type);
 
-    if (scm_is_false (gir_type_get_scheme_type (parent_type)))
-        scm_misc_error ("register-type",
-                        "type ~S lacks introspection",
-                        scm_list_1 (s_parent_type));
+    if (scm_is_false(gir_type_get_scheme_type(parent_type)))
+        scm_misc_error("register-type", "type ~S lacks introspection", scm_list_1(s_parent_type));
 
-    SCM_UNBND_TO_BOOL_F (s_properties);
-    SCM_UNBND_TO_BOOL_F (s_signals);
-    SCM_UNBND_TO_BOOL_F (s_disposer);
+    SCM_UNBND_TO_BOOL_F(s_properties);
+    SCM_UNBND_TO_BOOL_F(s_signals);
+    SCM_UNBND_TO_BOOL_F(s_disposer);
 
-    SCM_ASSERT_TYPE (scm_is_false (s_properties) ||
-                     scm_is_list (s_properties),
-                     s_properties, SCM_ARG3,
-                     "register-type", "list of param specs or #f");
+    SCM_ASSERT_TYPE(scm_is_false(s_properties) ||
+                    scm_is_list(s_properties),
+                    s_properties, SCM_ARG3, "register-type", "list of param specs or #f");
 
-    SCM_ASSERT_TYPE (scm_is_false (s_signals) ||
-                     scm_is_list (s_signals),
-                     s_signals, SCM_ARG4,
-                     "register-type", "list of signal specs or #f");
+    SCM_ASSERT_TYPE(scm_is_false(s_signals) ||
+                    scm_is_list(s_signals),
+                    s_signals, SCM_ARG4, "register-type", "list of signal specs or #f");
 
-    SCM_ASSERT_TYPE (scm_is_false (s_disposer) ||
-                     scm_is_true (scm_procedure_p (s_disposer)),
-                     s_disposer, SCM_ARG5,
-                     "register-type", "procedure or #f");
+    SCM_ASSERT_TYPE(scm_is_false(s_disposer) ||
+                    scm_is_true(scm_procedure_p(s_disposer)),
+                    s_disposer, SCM_ARG5, "register-type", "procedure or #f");
 
-    properties = g_ptr_array_new ();
-    signals = g_ptr_array_new_with_free_func ((GDestroyNotify) gi_free_signalspec);
+    properties = g_ptr_array_new();
+    signals = g_ptr_array_new_with_free_func((GDestroyNotify) gi_free_signalspec);
 
-    if (scm_is_list (s_properties))
-    {
-        n_properties = scm_to_size_t (scm_length (s_properties));
-        for (size_t i = 0; i < n_properties; i ++)
-        {
+    if (scm_is_list(s_properties)) {
+        n_properties = scm_to_size_t(scm_length(s_properties));
+        for (size_t i = 0; i < n_properties; i++) {
             GParamSpec *pspec;
-            pspec = gi_gparamspec_from_scm (scm_list_ref (s_properties, scm_from_size_t (i)));
-            g_ptr_array_add (properties, pspec);
+            pspec = gi_gparamspec_from_scm(scm_list_ref(s_properties, scm_from_size_t(i)));
+            g_ptr_array_add(properties, pspec);
         }
     }
 
-    if (scm_is_list (s_signals))
-    {
-        n_signals = scm_to_size_t (scm_length (s_signals));
-        for (size_t i = 0; i < n_signals; i ++)
-        {
+    if (scm_is_list(s_signals)) {
+        n_signals = scm_to_size_t(scm_length(s_signals));
+        for (size_t i = 0; i < n_signals; i++) {
             SignalSpec *sspec;
-            sspec = gi_signalspec_from_obj (scm_list_ref (s_signals , scm_from_size_t (i)));
-            g_ptr_array_add (signals, sspec);
+            sspec = gi_signalspec_from_obj(scm_list_ref(s_signals, scm_from_size_t(i)));
+            g_ptr_array_add(signals, sspec);
         }
 
     }
 
-    new_type = register_guile_specified_gobject_type (type_name,
-                                                      parent_type,
-                                                      properties,
-                                                      signals,
-                                                      s_disposer);
+    new_type = register_guile_specified_gobject_type(type_name,
+                                                     parent_type, properties, signals, s_disposer);
 
     gir_type_define(new_type);
-    return gir_type_get_scheme_type (new_type);
+    return gir_type_get_scheme_type(new_type);
 }
 
 static SCM
-scm_make_gobject (SCM s_gtype, SCM s_prop_alist)
+scm_make_gobject(SCM s_gtype, SCM s_prop_alist)
 {
     GType type;
     GObject *obj;
@@ -793,125 +717,111 @@ scm_make_gobject (SCM s_gtype, SCM s_prop_alist)
     const char **keys;
     GValue *values;
 
-    type = scm_to_gtype (s_gtype);
+    type = scm_to_gtype(s_gtype);
 
-    SCM_ASSERT_TYPE (G_TYPE_IS_CLASSED (type), s_gtype, SCM_ARG1,
-                     "make-gobject",
-                     "typeid derived from G_TYPE_OBJECT or "
-                     "scheme type derived from <GObject>");
+    SCM_ASSERT_TYPE(G_TYPE_IS_CLASSED(type), s_gtype, SCM_ARG1,
+                    "make-gobject",
+                    "typeid derived from G_TYPE_OBJECT or " "scheme type derived from <GObject>");
 
-    if (scm_is_false (gir_type_get_scheme_type (type)))
-        scm_misc_error ("make-gobject",
-                        "type ~S lacks introspection",
-                        scm_list_1 (s_gtype));
+    if (scm_is_false(gir_type_get_scheme_type(type)))
+        scm_misc_error("make-gobject", "type ~S lacks introspection", scm_list_1(s_gtype));
 
-    scm_dynwind_begin (0);
+    scm_dynwind_begin(0);
 
-    if (scm_is_true (scm_list_p (s_prop_alist))) {
-        class = g_type_class_ref (type);
-        scm_dynwind_unwind_handler (g_type_class_unref, class,
-                                    SCM_F_WIND_EXPLICITLY);
+    if (scm_is_true(scm_list_p(s_prop_alist))) {
+        class = g_type_class_ref(type);
+        scm_dynwind_unwind_handler(g_type_class_unref, class, SCM_F_WIND_EXPLICITLY);
 
-        n_prop = scm_to_int (scm_length (s_prop_alist));
-        keys = scm_dynwind_or_bust ("make-gobject",
-                                    calloc (n_prop, sizeof (char *)));
-        values = scm_dynwind_or_bust ("make-gobject",
-                                      calloc (n_prop, sizeof (GValue)));
+        n_prop = scm_to_int(scm_length(s_prop_alist));
+        keys = scm_dynwind_or_bust("make-gobject", calloc(n_prop, sizeof(char *)));
+        values = scm_dynwind_or_bust("make-gobject", calloc(n_prop, sizeof(GValue)));
 
         for (guint i = 0; i < n_prop; i++) {
-            SCM entry = scm_list_ref (s_prop_alist, scm_from_uint (i));
+            SCM entry = scm_list_ref(s_prop_alist, scm_from_uint(i));
 
-            SCM_ASSERT_TYPE (scm_is_true (scm_pair_p (entry)),
-                             s_prop_alist, SCM_ARG2,
-                             "make-gobject", "alist of strings to objects");
+            SCM_ASSERT_TYPE(scm_is_true(scm_pair_p(entry)),
+                            s_prop_alist, SCM_ARG2, "make-gobject", "alist of strings to objects");
 
-            SCM_ASSERT_TYPE (scm_is_string (scm_car (entry)),
-                             s_prop_alist, SCM_ARG2,
-                             "make-gobject", "alist of strings to objects");
+            SCM_ASSERT_TYPE(scm_is_string(scm_car(entry)),
+                            s_prop_alist, SCM_ARG2, "make-gobject", "alist of strings to objects");
 
-            keys[i] = scm_dynwind_or_bust ("make-gobject",
-                                           scm_to_utf8_string (scm_car (entry)));
-            GParamSpec *pspec = g_object_class_find_property (class, keys[i]);
+            keys[i] = scm_dynwind_or_bust("make-gobject", scm_to_utf8_string(scm_car(entry)));
+            GParamSpec *pspec = g_object_class_find_property(class, keys[i]);
             if (!pspec) {
-                scm_misc_error ("make-gobject",
-                                "unknown object parameter ~S",
-                                scm_list_1 (entry));
+                scm_misc_error("make-gobject", "unknown object parameter ~S", scm_list_1(entry));
             }
             else {
-                GValue* value = &values[i];
-                if (G_IS_PARAM_SPEC_CHAR (pspec)) {
-                    g_value_init (value, G_TYPE_CHAR);
-                    g_value_set_schar (value, scm_to_int8 (scm_cdr (entry)));
+                GValue *value = &values[i];
+                if (G_IS_PARAM_SPEC_CHAR(pspec)) {
+                    g_value_init(value, G_TYPE_CHAR);
+                    g_value_set_schar(value, scm_to_int8(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_UCHAR (pspec)) {
-                    g_value_init (value, G_TYPE_UCHAR);
-                    g_value_set_uchar (value, scm_to_uint8 (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_UCHAR(pspec)) {
+                    g_value_init(value, G_TYPE_UCHAR);
+                    g_value_set_uchar(value, scm_to_uint8(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_INT (pspec)) {
-                    g_value_init (value, G_TYPE_INT);
-                    g_value_set_int (value, scm_to_int (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_INT(pspec)) {
+                    g_value_init(value, G_TYPE_INT);
+                    g_value_set_int(value, scm_to_int(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_UINT (pspec)) {
-                    g_value_init (value, G_TYPE_UINT);
-                    g_value_set_uint (value, scm_to_uint (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_UINT(pspec)) {
+                    g_value_init(value, G_TYPE_UINT);
+                    g_value_set_uint(value, scm_to_uint(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_LONG (pspec)) {
-                    g_value_init (value, G_TYPE_LONG);
-                    g_value_set_uint (value, scm_to_long (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_LONG(pspec)) {
+                    g_value_init(value, G_TYPE_LONG);
+                    g_value_set_uint(value, scm_to_long(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_ULONG (pspec)) {
-                    g_value_init (value, G_TYPE_ULONG);
-                    g_value_set_ulong (value, scm_to_ulong (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_ULONG(pspec)) {
+                    g_value_init(value, G_TYPE_ULONG);
+                    g_value_set_ulong(value, scm_to_ulong(scm_cdr(entry)));
                 }
-                else if  (G_IS_PARAM_SPEC_INT64 (pspec)) {
-                    g_value_init (value, G_TYPE_INT64);
-                    g_value_set_int64 (value, scm_to_int64 (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_INT64(pspec)) {
+                    g_value_init(value, G_TYPE_INT64);
+                    g_value_set_int64(value, scm_to_int64(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_UINT64 (pspec)) {
-                    g_value_init (value, G_TYPE_UINT64);
-                    g_value_set_uint64 (value, scm_to_uint64 (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_UINT64(pspec)) {
+                    g_value_init(value, G_TYPE_UINT64);
+                    g_value_set_uint64(value, scm_to_uint64(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_FLOAT (pspec)) {
-                    g_value_init (value, G_TYPE_FLOAT);
-                    g_value_set_float (value, scm_to_double (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_FLOAT(pspec)) {
+                    g_value_init(value, G_TYPE_FLOAT);
+                    g_value_set_float(value, scm_to_double(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_DOUBLE (pspec)) {
-                    g_value_init (value, G_TYPE_DOUBLE);
-                    g_value_set_double (value, scm_to_double (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_DOUBLE(pspec)) {
+                    g_value_init(value, G_TYPE_DOUBLE);
+                    g_value_set_double(value, scm_to_double(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_ENUM (pspec)) {
-                    g_value_init (value, G_TYPE_ENUM);
-                    g_value_set_enum (value, scm_to_ulong (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_ENUM(pspec)) {
+                    g_value_init(value, G_TYPE_ENUM);
+                    g_value_set_enum(value, scm_to_ulong(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_FLAGS (pspec)) {
-                    g_value_init (value, G_PARAM_SPEC_VALUE_TYPE(pspec));
-                    g_value_set_flags (value, scm_to_ulong (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_FLAGS(pspec)) {
+                    g_value_init(value, G_PARAM_SPEC_VALUE_TYPE(pspec));
+                    g_value_set_flags(value, scm_to_ulong(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_STRING (pspec)) {
-                    g_value_init (value, G_TYPE_STRING);
-                    g_value_set_string (value, scm_to_utf8_string (scm_cdr (entry)));
+                else if (G_IS_PARAM_SPEC_STRING(pspec)) {
+                    g_value_init(value, G_TYPE_STRING);
+                    g_value_set_string(value, scm_to_utf8_string(scm_cdr(entry)));
                 }
-                else if (G_IS_PARAM_SPEC_OBJECT (pspec))
-                {
+                else if (G_IS_PARAM_SPEC_OBJECT(pspec)) {
                     SCM src = scm_cdr(entry);
                     GType src_type = gir_type_get_gtype_from_obj(src);
                     GType dest_type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-                    if (g_type_is_a (src_type, dest_type))
-                    {
-                        g_value_init (value, dest_type);
-                        g_value_set_object (value, scm_foreign_object_ref (src, OBJ_SLOT));
+                    if (g_type_is_a(src_type, dest_type)) {
+                        g_value_init(value, dest_type);
+                        g_value_set_object(value, scm_foreign_object_ref(src, OBJ_SLOT));
                     }
                     else
-                        scm_misc_error ("make-gobject",
-                                        "unable to convert parameter ~S of type ~S into a ~S",
-                                        scm_list_3 (src,
-                                                    scm_from_utf8_string(g_type_name(src_type)),
-                                                    scm_from_utf8_string(g_type_name(dest_type))));
+                        scm_misc_error("make-gobject",
+                                       "unable to convert parameter ~S of type ~S into a ~S",
+                                       scm_list_3(src,
+                                                  scm_from_utf8_string(g_type_name(src_type)),
+                                                  scm_from_utf8_string(g_type_name(dest_type))));
                 }
                 else
-                    scm_misc_error ("make-gobject",
-                                    "unable to convert parameter ~S",
-                                    scm_list_1 (entry));
+                    scm_misc_error("make-gobject",
+                                   "unable to convert parameter ~S", scm_list_1(entry));
             }
         }
     }
@@ -921,82 +831,81 @@ scm_make_gobject (SCM s_gtype, SCM s_prop_alist)
         values = NULL;
     }
 
-    obj = g_object_new_with_properties (type, n_prop, keys, values);
-    scm_dynwind_end ();
+    obj = g_object_new_with_properties(type, n_prop, keys, values);
+    scm_dynwind_end();
 
-    g_assert (obj);
+    g_assert(obj);
 
-    ptr = g_object_get_qdata (obj, gi_gobject_wrapper_key);
+    ptr = g_object_get_qdata(obj, gi_gobject_wrapper_key);
 
     if (ptr)
-        sobj = SCM_PACK_POINTER (ptr);
+        sobj = SCM_PACK_POINTER(ptr);
     else {
-        sobj = gir_type_make_object (type, obj, GI_TRANSFER_EVERYTHING);
-        g_object_set_qdata (G_OBJECT (obj), gi_gobject_wrapper_key,
-                            SCM_UNPACK_POINTER (sobj));
+        sobj = gir_type_make_object(type, obj, GI_TRANSFER_EVERYTHING);
+        g_object_set_qdata(G_OBJECT(obj), gi_gobject_wrapper_key, SCM_UNPACK_POINTER(sobj));
     }
 
-    g_assert (scm_foreign_object_ref (sobj, OBJ_SLOT) == obj);
+    g_assert(scm_foreign_object_ref(sobj, OBJ_SLOT) == obj);
     return sobj;
 }
 
 static SCM
-scm_gobject_is_object_p (SCM self)
+scm_gobject_is_object_p(SCM self)
 {
     GObject *obj;
     gboolean ret;
 
 
-    scm_assert_foreign_object_type (gi_gobject_type, self);
-    obj = gi_gobject_get_obj (self);
-    ret = G_IS_OBJECT (obj);
-    return scm_from_bool (ret);
+    scm_assert_foreign_object_type(gi_gobject_type, self);
+    obj = gi_gobject_get_obj(self);
+    ret = G_IS_OBJECT(obj);
+    return scm_from_bool(ret);
 }
 
 static SCM
-scm_gobject_type (SCM self)
+scm_gobject_type(SCM self)
 {
     GType type;
     GObject *obj;
 
-    scm_assert_foreign_object_type (gi_gobject_type, self);
+    scm_assert_foreign_object_type(gi_gobject_type, self);
 
-    obj = gi_gobject_get_obj (self);
-    type = G_OBJECT_TYPE (obj);
+    obj = gi_gobject_get_obj(self);
+    type = G_OBJECT_TYPE(obj);
 
     return scm_from_size_t(type);
     //return gi_gtype_c2g (type);
 }
 
 static SCM
-scm_gobject_type_name (SCM self)
+scm_gobject_type_name(SCM self)
 {
     const char *name;
     GObject *obj;
 
-    scm_assert_foreign_object_type (gi_gobject_type, self);
+    scm_assert_foreign_object_type(gi_gobject_type, self);
 
-    obj = gi_gobject_get_obj (self);
-    name = G_OBJECT_TYPE_NAME (obj);
+    obj = gi_gobject_get_obj(self);
+    name = G_OBJECT_TYPE_NAME(obj);
 
-    return scm_from_utf8_string (name);
+    return scm_from_utf8_string(name);
 }
 
 static SCM
-scm_gobject_is_floating_p (SCM self)
+scm_gobject_is_floating_p(SCM self)
 {
     GObject *obj;
     gboolean ret;
 
-    scm_assert_foreign_object_type (gi_gobject_type, self);
-    obj = gi_gobject_get_obj (self);
-    ret = g_object_is_floating (obj);
-    return scm_from_bool (ret);
+    scm_assert_foreign_object_type(gi_gobject_type, self);
+    obj = gi_gobject_get_obj(self);
+    ret = g_object_is_floating(obj);
+    return scm_from_bool(ret);
 }
 
 /* re pygobject_set_property */
 static SCM
-scm_gobject_set_property_x (SCM self, SCM sname, SCM svalue)
+scm_gobject_set_property_x(SCM self, SCM sname, SCM svalue)
 {
 #define FUNC_NAME "gobject-set-property!"
     GObject *obj;
@@ -1004,29 +913,27 @@ scm_gobject_set_property_x (SCM self, SCM sname, SCM svalue)
     GParamSpec *pspec;
     GValue value = { 0, };
 
-    SCM_ASSERT (G_TYPE_IS_CLASSED (gir_type_get_gtype_from_obj (self)),
-                self, SCM_ARG1, FUNC_NAME);
-    SCM_ASSERT (scm_is_string (sname), sname, SCM_ARG2, FUNC_NAME);
+    SCM_ASSERT(G_TYPE_IS_CLASSED(gir_type_get_gtype_from_obj(self)), self, SCM_ARG1, FUNC_NAME);
+    SCM_ASSERT(scm_is_string(sname), sname, SCM_ARG2, FUNC_NAME);
 
-    obj = gi_gobject_get_obj (self);
-    name = scm_to_utf8_string (sname);
-    pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (obj), name);
-    free (name);
+    obj = gi_gobject_get_obj(self);
+    name = scm_to_utf8_string(sname);
+    pspec = g_object_class_find_property(G_OBJECT_GET_CLASS(obj), name);
+    free(name);
     if (!pspec)
-        scm_misc_error (FUNC_NAME,
-                        "object of type ~S does not have property ~S",
-                        scm_list_2(scm_from_utf8_string (g_type_name (G_OBJECT_TYPE (obj))),
-                                   sname));
+        scm_misc_error(FUNC_NAME,
+                       "object of type ~S does not have property ~S",
+                       scm_list_2(scm_from_utf8_string(g_type_name(G_OBJECT_TYPE(obj))), sname));
 
     if (!(pspec->flags & G_PARAM_WRITABLE)) {
-        scm_misc_error (FUNC_NAME, "property ~S is not writable",
-                        scm_list_1 (scm_from_utf8_string (g_param_spec_get_name (pspec))));
+        scm_misc_error(FUNC_NAME, "property ~S is not writable",
+                       scm_list_1(scm_from_utf8_string(g_param_spec_get_name(pspec))));
     }
 
-    g_value_init (&value, G_PARAM_SPEC_VALUE_TYPE (pspec));
-    gi_gvalue_from_scm_with_error (FUNC_NAME, &value, svalue, SCM_ARG3);
+    g_value_init(&value, G_PARAM_SPEC_VALUE_TYPE(pspec));
+    gi_gvalue_from_scm_with_error(FUNC_NAME, &value, svalue, SCM_ARG3);
 
-    g_object_set_property (gi_gobject_get_obj(self), pspec->name, &value);
+    g_object_set_property(gi_gobject_get_obj(self), pspec->name, &value);
 
     return SCM_UNSPECIFIED;
 #undef FUNC_NAME
@@ -1034,60 +941,59 @@ scm_gobject_set_property_x (SCM self, SCM sname, SCM svalue)
 
 /* re pygi_get_property_value_by_name */
 static SCM
-gi_get_property_value_by_name (const char *func, SCM self, gchar *param_name)
+gi_get_property_value_by_name(const char *func, SCM self, gchar *param_name)
 {
     GParamSpec *pspec;
     GObjectClass *oclass;
     GObject *obj;
 
-    obj = gi_gobject_get_obj (self);
-    oclass = G_OBJECT_GET_CLASS (obj);
+    obj = gi_gobject_get_obj(self);
+    oclass = G_OBJECT_GET_CLASS(obj);
 
-    pspec = g_object_class_find_property (oclass, param_name);
+    pspec = g_object_class_find_property(oclass, param_name);
     if (!pspec) {
-        scm_misc_error (func,
-                        "object of type ~S does not have a property ~S",
-                        scm_list_2 (self,
-                                    scm_from_utf8_string (param_name)));
+        scm_misc_error(func,
+                       "object of type ~S does not have a property ~S",
+                       scm_list_2(self, scm_from_utf8_string(param_name)));
     }
-    return gi_get_property_value (func, self, pspec);
+    return gi_get_property_value(func, self, pspec);
 }
 
 /* re pygi_get_property_value */
 static SCM
-gi_get_property_value (const char *func, SCM instance, GParamSpec *pspec)
+gi_get_property_value(const char *func, SCM instance, GParamSpec *pspec)
 {
     GValue value = { 0, };
     SCM svalue = SCM_BOOL_F;
 
     if (!(pspec->flags & G_PARAM_READABLE)) {
-        scm_misc_error (func, "property ~S is not readable",
-                        scm_list_1 (scm_from_utf8_string (g_param_spec_get_name (pspec))));
+        scm_misc_error(func, "property ~S is not readable",
+                       scm_list_1(scm_from_utf8_string(g_param_spec_get_name(pspec))));
     }
 
-    g_value_init (&value, G_PARAM_SPEC_VALUE_TYPE (pspec));
-    g_object_get_property (gi_gobject_get_obj(instance), pspec->name, &value);
+    g_value_init(&value, G_PARAM_SPEC_VALUE_TYPE(pspec));
+    g_object_get_property(gi_gobject_get_obj(instance), pspec->name, &value);
 
-    svalue = gi_param_gvalue_as_scm (&value, TRUE, pspec);
+    svalue = gi_param_gvalue_as_scm(&value, TRUE, pspec);
 
-    g_value_unset (&value);
+    g_value_unset(&value);
     return svalue;
 }
 
 static SCM
-scm_gobject_get_property (SCM self, SCM sname)
+scm_gobject_get_property(SCM self, SCM sname)
 {
     char *param_name;
     SCM ret;
 
-    SCM_ASSERT (G_TYPE_IS_CLASSED (gir_type_get_gtype_from_obj (self)),
-                self, SCM_ARG1, "gobject-get-property");
-    SCM_ASSERT (scm_is_string (sname), sname, SCM_ARG2, "gobject-get-property");
-    param_name = scm_to_utf8_string (sname);
+    SCM_ASSERT(G_TYPE_IS_CLASSED(gir_type_get_gtype_from_obj(self)),
+               self, SCM_ARG1, "gobject-get-property");
+    SCM_ASSERT(scm_is_string(sname), sname, SCM_ARG2, "gobject-get-property");
+    param_name = scm_to_utf8_string(sname);
 
-    ret = gi_get_property_value_by_name ("gobject-get-property", self, param_name);
+    ret = gi_get_property_value_by_name("gobject-get-property", self, param_name);
 
-    free (param_name);
+    free(param_name);
 
     return ret;
 }
@@ -1095,93 +1001,93 @@ scm_gobject_get_property (SCM self, SCM sname)
 
 /* A procedure suitable as a record-type printer. */
 SCM
-scm_gobject_printer (SCM self, SCM port)
+scm_gobject_printer(SCM self, SCM port)
 {
-    scm_assert_foreign_object_type (gi_gobject_type, self);
-    scm_simple_format (port,
-                       scm_from_utf8_string("~s [~s] <~s>"),
-                       scm_list_3 (scm_from_utf8_string (g_type_name (gi_gobject_get_ob_type(self))),
-                                   scm_from_int (gi_gobject_get_ob_type (self)),
-                                   scm_from_uintmax ((uintmax_t)gi_gobject_get_obj(self))));
+    scm_assert_foreign_object_type(gi_gobject_type, self);
+    scm_simple_format(port,
+                      scm_from_utf8_string("~s [~s] <~s>"),
+                      scm_list_3(scm_from_utf8_string(g_type_name(gi_gobject_get_ob_type(self))),
+                                 scm_from_int(gi_gobject_get_ob_type(self)),
+                                 scm_from_uintmax((uintmax_t) gi_gobject_get_obj(self))));
     return SCM_UNSPECIFIED;
 }
 
 SCM
-gi_arg_gobject_to_scm (GIArgument *arg, GITransfer transfer)
+gi_arg_gobject_to_scm(GIArgument *arg, GITransfer transfer)
 {
     SCM s_obj;
 
     if (arg->v_pointer == NULL) {
         s_obj = SCM_BOOL_F;
-    } else if (G_IS_PARAM_SPEC(arg->v_pointer)) {
+    }
+    else if (G_IS_PARAM_SPEC(arg->v_pointer)) {
         // s_obj = gi_gparam_spec_new (arg->v_pointer);
-        g_assert_not_reached ();
+        g_assert_not_reached();
         if (transfer == GI_TRANSFER_EVERYTHING)
             //g_param_spec_unref (arg->v_pointer);
-            g_assert_not_reached ();
-    } else {
+            g_assert_not_reached();
+    }
+    else {
         g_assert_not_reached();
 #if 0
-        s_obj = gi_gobject_new_full (arg->v_pointer,
-                                     transfer == GI_TRANSFER_EVERYTHING, /* steal */
-                                     NULL); /* type */
+        s_obj = gi_gobject_new_full(arg->v_pointer, transfer == GI_TRANSFER_EVERYTHING, /* steal */
+                                    NULL);      /* type */
 #endif
     }
     return s_obj;
 }
 
 SCM
-gi_arg_gobject_to_scm_called_from_c (GIArgument *arg, GITransfer transfer)
+gi_arg_gobject_to_scm_called_from_c(GIArgument *arg, GITransfer transfer)
 {
     SCM object;
     /* IN pygobject, they say this is a hack to work around GTK+
-       sending signals with floating widgets in them.  Not sure if
-       that applies to us. */
+     * sending signals with floating widgets in them.  Not sure if
+     * that applies to us. */
     if (arg->v_pointer != NULL
-        && transfer == GI_TRANSFER_NOTHING
-        && !G_IS_PARAM_SPEC (arg->v_pointer)) {
-        g_object_ref (arg->v_pointer);
-        object = gi_arg_gobject_to_scm (arg, GI_TRANSFER_EVERYTHING);
-        g_object_force_floating (arg->v_pointer);
-    } else {
-        object = gi_arg_gobject_to_scm (arg, transfer);
+        && transfer == GI_TRANSFER_NOTHING && !G_IS_PARAM_SPEC(arg->v_pointer)) {
+        g_object_ref(arg->v_pointer);
+        object = gi_arg_gobject_to_scm(arg, GI_TRANSFER_EVERYTHING);
+        g_object_force_floating(arg->v_pointer);
+    }
+    else {
+        object = gi_arg_gobject_to_scm(arg, transfer);
     }
     return object;
 }
 
 void
-gi_init_gobject (void)
+gi_init_gobject(void)
 {
-    gi_init_gobject_type ();
-    gi_gobject_wrapper_key = g_quark_from_static_string ("GuGObject::wrapper");
-    gi_gobject_custom_key = g_quark_from_static_string ("GuGObject::custom");
+    gi_init_gobject_type();
+    gi_gobject_wrapper_key = g_quark_from_static_string("GuGObject::wrapper");
+    gi_gobject_custom_key = g_quark_from_static_string("GuGObject::custom");
     gi_gobject_instance_data_key = g_quark_from_static_string("GuGObject::instance-data");
 
-    scm_c_define_gsubr ("register-type", 2, 3, 0, scm_register_guile_specified_gobject_type);
-    scm_c_define_gsubr ("make-gobject", 1, 1, 0, scm_make_gobject);
-    scm_c_define_gsubr ("gobject-is-object?", 1, 0, 0, scm_gobject_is_object_p);
-    scm_c_define_gsubr ("gobject-type", 1, 0, 0, scm_gobject_type);
-    scm_c_define_gsubr ("gobject-type-name", 1, 0, 0, scm_gobject_type_name);
-    scm_c_define_gsubr ("gobject-is-floating?", 1, 0, 0, scm_gobject_is_floating_p);
-    scm_c_define_gsubr ("gobject-set-property!", 3, 0, 0, scm_gobject_set_property_x);
-    scm_c_define_gsubr ("gobject-get-property", 2, 0, 0, scm_gobject_get_property);
-    scm_c_define_gsubr ("gobject-disconnect-by-func", 2, 0, 0, scm_gobject_disconnect_by_func);
-    scm_c_define_gsubr ("gobject-handler-block-by-func", 2, 0, 0, scm_gobject_handler_block_by_func);
-    scm_c_define_gsubr ("gobject-handler-unblock-by-func", 2, 0, 0, scm_gobject_handler_unblock_by_func);
-    scm_c_define_gsubr ("gobject-printer", 2, 0, 0, scm_gobject_printer);
-    scm_c_define_gsubr ("signal-connect", 3, 0, 1, scm_signal_connect);
-    scm_c_export ("register-type",
-                  "make-gobject",
-                  "gobject-is-object?",
-                  "gobject-type",
-                  "gobject-type-name",
-                  "gobject-is-floating?",
-                  "gobject-set-property!",
-                  "gobject-get-property",
-                  "gobject-disconnect-by-func",
-                  "gobject-handler-block-by-func",
-                  "gobject-handler-unblock-by-func",
-                  "gobject-printer",
-                  "signal-connect",
-                  NULL);
+    scm_c_define_gsubr("register-type", 2, 3, 0, scm_register_guile_specified_gobject_type);
+    scm_c_define_gsubr("make-gobject", 1, 1, 0, scm_make_gobject);
+    scm_c_define_gsubr("gobject-is-object?", 1, 0, 0, scm_gobject_is_object_p);
+    scm_c_define_gsubr("gobject-type", 1, 0, 0, scm_gobject_type);
+    scm_c_define_gsubr("gobject-type-name", 1, 0, 0, scm_gobject_type_name);
+    scm_c_define_gsubr("gobject-is-floating?", 1, 0, 0, scm_gobject_is_floating_p);
+    scm_c_define_gsubr("gobject-set-property!", 3, 0, 0, scm_gobject_set_property_x);
+    scm_c_define_gsubr("gobject-get-property", 2, 0, 0, scm_gobject_get_property);
+    scm_c_define_gsubr("gobject-disconnect-by-func", 2, 0, 0, scm_gobject_disconnect_by_func);
+    scm_c_define_gsubr("gobject-handler-block-by-func", 2, 0, 0,
+                       scm_gobject_handler_block_by_func);
+    scm_c_define_gsubr("gobject-handler-unblock-by-func", 2, 0, 0,
+                       scm_gobject_handler_unblock_by_func);
+    scm_c_define_gsubr("gobject-printer", 2, 0, 0, scm_gobject_printer);
+    scm_c_define_gsubr("signal-connect", 3, 0, 1, scm_signal_connect);
+    scm_c_export("register-type",
+                 "make-gobject",
+                 "gobject-is-object?",
+                 "gobject-type",
+                 "gobject-type-name",
+                 "gobject-is-floating?",
+                 "gobject-set-property!",
+                 "gobject-get-property",
+                 "gobject-disconnect-by-func",
+                 "gobject-handler-block-by-func",
+                 "gobject-handler-unblock-by-func", "gobject-printer", "signal-connect", NULL);
 }

--- a/src/gi_gobject.h
+++ b/src/gi_gobject.h
@@ -6,19 +6,21 @@
 #include "__gi_gobject.h"
 
 G_BEGIN_DECLS
+    typedef void (*GuClosureExceptionHandler)(GValue *ret, guint n_param_values,
+                                              const GValue *params);
 
-typedef void (* GuClosureExceptionHandler) (GValue *ret, guint n_param_values, const GValue *params);
-
-typedef struct _GuGClosure {
+typedef struct _GuGClosure
+{
     GClosure closure;
     SCM callback;
-    SCM extra_args; /* tuple of extra args to pass to callback */
-    SCM swap_data; /* other object for gtk_signal_connect__object */
+    SCM extra_args;             /* tuple of extra args to pass to callback */
+    SCM swap_data;              /* other object for gtk_signal_connect__object */
     GuClosureExceptionHandler exception_handler;
     GISignalInfo *signal_info;
 } GuGClosure;
 
-typedef enum {
+typedef enum
+{
     GI_GOBJECT_USING_TOGGLE_REF = 1 << 0,
     GI_GOBJECT_IS_FLOATING_REF = 1 << 1,
     GI_GOBJECT_GOBJECT_WAS_FLOATING = 1 << 2
@@ -26,8 +28,9 @@ typedef enum {
 
 /* Data that belongs to the GObject instance, not the Python wrapper */
 /* re pygobject-object.h: 10, _PyGObjectData */
-typedef struct _GuGObjectData {
-    SCM type; /* wrapper type for this instance */
+typedef struct _GuGObjectData
+{
+    SCM type;                   /* wrapper type for this instance */
     GSList *closures;
 } GuGObjectData;
 
@@ -41,14 +44,13 @@ gi_gobject_peek_inst_data(GObject *obj)
             g_object_get_qdata(obj, gi_gobject_instance_data_key));
 }
 
-void gi_init_gobject (void);
+void gi_init_gobject(void);
 GClosure *gclosure_from_scm_func(SCM object, SCM func);
 SCM gi_gobject_lookup_class(GType);
 SCM gi_gobject_new(GIObjectInfo *info, GObject *obj);
-SCM gi_arg_gobject_to_scm (GIArgument *arg, GITransfer transfer);
-SCM gi_arg_gobject_to_scm_called_from_c (GIArgument *arg, GITransfer transfer);
-SCM scm_gobject_printer (SCM self, SCM port);
+SCM gi_arg_gobject_to_scm(GIArgument *arg, GITransfer transfer);
+SCM gi_arg_gobject_to_scm_called_from_c(GIArgument *arg, GITransfer transfer);
+SCM scm_gobject_printer(SCM self, SCM port);
 
 G_END_DECLS
-
 #endif

--- a/src/gi_gparamspec.c
+++ b/src/gi_gparamspec.c
@@ -4,24 +4,23 @@
 #include "gi_gparamspec.h"
 #include "gi_util.h"
 
-static GParamSpec * gi_gparamspec_from_list (SCM x);
+static GParamSpec *gi_gparamspec_from_list(SCM x);
 
 GParamSpec *
-gi_gparamspec_from_scm (SCM x)
+gi_gparamspec_from_scm(SCM x)
 {
-    SCM_ASSERT_TYPE (scm_is_list (x) ||
-                     scm_is_true (gi_gparamspec_p (x)),
-                     x, SCM_ARG1, "%scm->gparamspec",
-                     "list or param spec object");
+    SCM_ASSERT_TYPE(scm_is_list(x) ||
+                    scm_is_true(gi_gparamspec_p(x)),
+                    x, SCM_ARG1, "%scm->gparamspec", "list or param spec object");
 
-    if (scm_is_list (x))
-        return gi_gparamspec_from_list (x);
+    if (scm_is_list(x))
+        return gi_gparamspec_from_list(x);
     else
-        return gi_gparamspec_get_spec (x);
+        return gi_gparamspec_get_spec(x);
 }
 
 static GParamSpec *
-gi_gparamspec_from_list (SCM x)
+gi_gparamspec_from_list(SCM x)
 {
     char *prop_name;
     GType prop_type;
@@ -31,10 +30,10 @@ gi_gparamspec_from_list (SCM x)
     GParamSpec *pspec;
     size_t i;
 
-    prop_name = scm_to_utf8_string (scm_c_list_ref (x, 0));
-    prop_type = scm_to_gtype (scm_c_list_ref (x, 1));
-    nick = scm_to_utf8_string (scm_c_list_ref (x, 2));
-    blurb = scm_to_utf8_string (scm_c_list_ref (x, 3));
+    prop_name = scm_to_utf8_string(scm_c_list_ref(x, 0));
+    prop_type = scm_to_gtype(scm_c_list_ref(x, 1));
+    nick = scm_to_utf8_string(scm_c_list_ref(x, 2));
+    blurb = scm_to_utf8_string(scm_c_list_ref(x, 3));
     i = 4;
 
 #define NUMBER_TYPE(ftype,ctype,gtype,scmtype)                          \
@@ -50,7 +49,7 @@ gi_gparamspec_from_list (SCM x)
     }                                                                   \
     break
 
-    switch (G_TYPE_FUNDAMENTAL (prop_type)) {
+    switch (G_TYPE_FUNDAMENTAL(prop_type)) {
         NUMBER_TYPE(CHAR, gint8, char, int8);
         NUMBER_TYPE(UCHAR, guint8, uchar, uint8);
         NUMBER_TYPE(INT, gint, int, int);
@@ -64,40 +63,36 @@ gi_gparamspec_from_list (SCM x)
     case G_TYPE_BOOLEAN:
     {
         gboolean _default;
-        _default = scm_to_bool (scm_c_list_ref (x, i++));
-        flags = scm_to_ulong (scm_c_list_ref (x, i++));
-        pspec = g_param_spec_boolean (prop_name, nick, blurb,
-                                      _default, flags);
+        _default = scm_to_bool(scm_c_list_ref(x, i++));
+        flags = scm_to_ulong(scm_c_list_ref(x, i++));
+        pspec = g_param_spec_boolean(prop_name, nick, blurb, _default, flags);
     }
-    break;
+        break;
     case G_TYPE_ENUM:
     {
         gint _default;
-        _default = scm_to_uint (scm_c_list_ref (x, i++));
-        flags = scm_to_ulong (scm_c_list_ref (x, i++));
-        pspec = g_param_spec_enum (prop_name, nick, blurb,
-                                   prop_type, _default, flags);
+        _default = scm_to_uint(scm_c_list_ref(x, i++));
+        flags = scm_to_ulong(scm_c_list_ref(x, i++));
+        pspec = g_param_spec_enum(prop_name, nick, blurb, prop_type, _default, flags);
     }
-    break;
+        break;
     case G_TYPE_FLAGS:
     {
         guint _default;
-        _default = scm_to_uint (scm_c_list_ref (x, i++));
-        flags = scm_to_ulong (scm_c_list_ref (x, i++));
-        pspec = g_param_spec_flags (prop_name, nick, blurb,
-                                    prop_type, _default, flags);
+        _default = scm_to_uint(scm_c_list_ref(x, i++));
+        flags = scm_to_ulong(scm_c_list_ref(x, i++));
+        pspec = g_param_spec_flags(prop_name, nick, blurb, prop_type, _default, flags);
     }
-    break;
+        break;
     case G_TYPE_STRING:
     {
         char *_default;
-        _default = scm_to_utf8_string (scm_c_list_ref (x, i++));
-        flags = scm_to_ulong (scm_c_list_ref (x, i++));
-        pspec = g_param_spec_string (prop_name, nick, blurb,
-                                     _default, flags);
-        free (_default);
+        _default = scm_to_utf8_string(scm_c_list_ref(x, i++));
+        flags = scm_to_ulong(scm_c_list_ref(x, i++));
+        pspec = g_param_spec_string(prop_name, nick, blurb, _default, flags);
+        free(_default);
     }
-    break;
+        break;
     default:
         return NULL;
     }
@@ -105,82 +100,81 @@ gi_gparamspec_from_list (SCM x)
 }
 
 static SCM
-scm_list_to_gparamspec (SCM x)
+scm_list_to_gparamspec(SCM x)
 {
     SCM obj;
-    SCM_ASSERT_TYPE (scm_is_list (x), x, SCM_ARG1, "list->gparamspec",
-                     "list");
-    GParamSpec *spec = gi_gparamspec_from_list (x);
+    SCM_ASSERT_TYPE(scm_is_list(x), x, SCM_ARG1, "list->gparamspec", "list");
+    GParamSpec *spec = gi_gparamspec_from_list(x);
 
     if (spec) {
-        obj = scm_make_foreign_object_0 (gi_gparamspec_type);
-        gi_gparamspec_set_spec (obj, spec);
+        obj = scm_make_foreign_object_0(gi_gparamspec_type);
+        gi_gparamspec_set_spec(obj, spec);
         return obj;
     }
     return SCM_BOOL_F;
 }
 
 static SCM
-scm_gparam_value_is_valid_p (SCM self, SCM gval)
+scm_gparam_value_is_valid_p(SCM self, SCM gval)
 {
     GParamSpec *spec;
     GValue *val;
     gboolean ret;
 
-    scm_assert_foreign_object_type (gi_gparamspec_type, self);
-    scm_assert_foreign_object_type (gi_gvalue_type, gval);
+    scm_assert_foreign_object_type(gi_gparamspec_type, self);
+    scm_assert_foreign_object_type(gi_gvalue_type, gval);
 
-    spec = gi_gparamspec_get_spec (self);
-    val = gi_gvalue_get_value (gval);
+    spec = gi_gparamspec_get_spec(self);
+    val = gi_gvalue_get_value(gval);
     if (spec && val) {
-        ret = g_param_value_validate (spec, val);
-        return scm_from_bool (ret);
+        ret = g_param_value_validate(spec, val);
+        return scm_from_bool(ret);
     }
     return SCM_BOOL_F;
 }
 
 static SCM
-scm_gparamspec_get_default_value (SCM self)
+scm_gparamspec_get_default_value(SCM self)
 {
     GParamSpec *spec;
     const GValue *val;
     GValue *val2;
     GType type;
 
-    scm_assert_foreign_object_type (gi_gparamspec_type, self);
-    spec = gi_gparamspec_get_spec (self);
+    scm_assert_foreign_object_type(gi_gparamspec_type, self);
+    spec = gi_gparamspec_get_spec(self);
     if (spec) {
-        val = g_param_spec_get_default_value (spec);
-        type = G_VALUE_TYPE (val);
+        val = g_param_spec_get_default_value(spec);
+        type = G_VALUE_TYPE(val);
         val2 = g_new0(GValue, 1);
-        g_value_init (val2, type);
-        g_value_copy (val, val2);
-        return gi_gvalue_c2g (val2);
+        g_value_init(val2, type);
+        g_value_copy(val, val2);
+        return gi_gvalue_c2g(val2);
     }
     return SCM_BOOL_F;
 }
 
 static SCM
-scm_gparamspec_unref (SCM self)
+scm_gparamspec_unref(SCM self)
 {
     GParamSpec *spec;
 
-    scm_assert_foreign_object_type (gi_gparamspec_type, self);
-    spec = gi_gparamspec_get_spec (self);
+    scm_assert_foreign_object_type(gi_gparamspec_type, self);
+    spec = gi_gparamspec_get_spec(self);
     if (spec)
-        g_param_spec_unref (spec);
+        g_param_spec_unref(spec);
     return SCM_UNSPECIFIED;
 }
 
 static SCM
-scm_gparamspec_ref (SCM self)
+scm_gparamspec_ref(SCM self)
 {
     GParamSpec *spec;
 
-    scm_assert_foreign_object_type (gi_gparamspec_type, self);
-    spec = gi_gparamspec_get_spec (self);
+    scm_assert_foreign_object_type(gi_gparamspec_type, self);
+    spec = gi_gparamspec_get_spec(self);
     if (spec)
-        g_param_spec_ref (spec);
+        g_param_spec_ref(spec);
     return SCM_UNSPECIFIED;
 }
 
@@ -191,8 +185,7 @@ scm_gparamspec_value_type(SCM self)
 
     scm_assert_foreign_object_type(gi_gparamspec_type, self);
     spec = gi_gparamspec_get_spec(self);
-    if (spec)
-    {
+    if (spec) {
         gir_type_register(G_PARAM_SPEC_VALUE_TYPE(spec));
         return scm_from_size_t(G_PARAM_SPEC_VALUE_TYPE(spec));
     }
@@ -207,8 +200,7 @@ scm_gparamspec_type(SCM self)
 
     scm_assert_foreign_object_type(gi_gparamspec_type, self);
     spec = gi_gparamspec_get_spec(self);
-    if (spec)
-    {
+    if (spec) {
         gir_type_register(G_PARAM_SPEC_TYPE(spec));
         return scm_from_size_t(G_PARAM_SPEC_TYPE(spec));
     }
@@ -228,21 +220,21 @@ scm_gparamspec_type_name(SCM self)
 }
 
 void
-gi_gparamspec_finalizer (SCM self)
+gi_gparamspec_finalizer(SCM self)
 {
     GParamSpec *spec;
 
-    spec = gi_gparamspec_get_spec (self);
+    spec = gi_gparamspec_get_spec(self);
     if (spec)
-        g_param_spec_unref (spec);
-    g_free (spec);
-    gi_gparamspec_set_spec (self, NULL);
+        g_param_spec_unref(spec);
+    g_free(spec);
+    gi_gparamspec_set_spec(self, NULL);
 }
 
 void
-gi_init_gparamspec (void)
+gi_init_gparamspec(void)
 {
-    gi_init_gparamspec_type ();
+    gi_init_gparamspec_type();
 
 #define D(x) scm_permanent_object(scm_c_define(#x, scm_from_ulong(x)))
     D(G_PARAM_READABLE);
@@ -260,18 +252,15 @@ gi_init_gparamspec (void)
     scm_c_define_gsubr("gparamspec-value-type", 1, 0, 0, scm_gparamspec_value_type);
     scm_c_define_gsubr("gparamspec-type", 1, 0, 0, scm_gparamspec_type);
     scm_c_define_gsubr("gparamspec-type-name", 1, 0, 0, scm_gparamspec_type_name);
-    scm_c_export ("G_PARAM_READABLE",
-                  "G_PARAM_WRITABLE",
-                  "G_PARAM_READWRITE",
-                  "G_PARAM_CONSTRUCT",
-                  "G_PARAM_CONSTRUCT_ONLY",
-                  "list->gparamspec",
-                  "gparam-value-is-valid?",
-                  "gparamspec-get-default-value",
-                  "gparamspec-ref",
-                  "gparamspec-unref",
-                  "gparamspec-value-type",
-                  "gparamspec-type",
-                  "gparamspec-type-name",
-                  NULL);
+    scm_c_export("G_PARAM_READABLE",
+                 "G_PARAM_WRITABLE",
+                 "G_PARAM_READWRITE",
+                 "G_PARAM_CONSTRUCT",
+                 "G_PARAM_CONSTRUCT_ONLY",
+                 "list->gparamspec",
+                 "gparam-value-is-valid?",
+                 "gparamspec-get-default-value",
+                 "gparamspec-ref",
+                 "gparamspec-unref",
+                 "gparamspec-value-type", "gparamspec-type", "gparamspec-type-name", NULL);
 }

--- a/src/gi_gparamspec.h
+++ b/src/gi_gparamspec.h
@@ -2,9 +2,9 @@
 #define _GI_GPARAMSPEC_H_
 
 #include "__gi_gparamspec.h"
-GParamSpec *gi_gparamspec_from_scm (SCM x);
+GParamSpec *gi_gparamspec_from_scm(SCM x);
 
-void gi_paramspec_finalizer (SCM self);
-void gi_init_gparamspec (void);
+void gi_paramspec_finalizer(SCM self);
+void gi_init_gparamspec(void);
 
 #endif

--- a/src/gi_gsignal.c
+++ b/src/gi_gsignal.c
@@ -2,7 +2,8 @@
 #include "gi_gsignal.h"
 #include "gir_type.h"
 
-SignalSpec *gi_signalspec_from_obj (SCM obj)
+SignalSpec *
+gi_signalspec_from_obj(SCM obj)
 {
     char *name;
     GType return_type;
@@ -12,15 +13,15 @@ SignalSpec *gi_signalspec_from_obj (SCM obj)
     GSignalFlags flags;
     SignalSpec *spec = NULL;
 
-    name = scm_to_utf8_string (scm_list_ref (obj, scm_from_int (0)));
-    return_type = scm_to_gtype (scm_list_ref (obj, scm_from_int (1)));
-    sparams = scm_list_ref (obj, scm_from_int (2));
-    n_params = scm_to_uint (scm_length (sparams));
+    name = scm_to_utf8_string(scm_list_ref(obj, scm_from_int(0)));
+    return_type = scm_to_gtype(scm_list_ref(obj, scm_from_int(1)));
+    sparams = scm_list_ref(obj, scm_from_int(2));
+    n_params = scm_to_uint(scm_length(sparams));
     params = g_new0(GType, n_params);
 
-    for (guint i = 0; i < n_params; i ++)
-	params[i] = scm_to_size_t (scm_list_ref (sparams, scm_from_int (i)));
-    flags = scm_to_uint (scm_list_ref (obj, scm_from_int (3)));
+    for (guint i = 0; i < n_params; i++)
+        params[i] = scm_to_size_t(scm_list_ref(sparams, scm_from_int(i)));
+    flags = scm_to_uint(scm_list_ref(obj, scm_from_int(3)));
 
     spec = g_new0(SignalSpec, 1);
     spec->signal_name = name;
@@ -34,19 +35,19 @@ SignalSpec *gi_signalspec_from_obj (SCM obj)
 }
 
 void
-gi_free_signalspec (SignalSpec *spec)
+gi_free_signalspec(SignalSpec *spec)
 {
     if (spec) {
-	if (spec->param_types) {
-	    g_free (spec->param_types);
-	    spec->param_types = NULL;
-	}
-	g_free (spec);
+        if (spec->param_types) {
+            g_free(spec->param_types);
+            spec->param_types = NULL;
+        }
+        g_free(spec);
     }
 }
 
 void
-gi_init_gsignal (void)
+gi_init_gsignal(void)
 {
 
 #define D(x) scm_permanent_object(scm_c_define(#x, scm_from_ulong(x)))
@@ -60,14 +61,11 @@ gi_init_gsignal (void)
     D(G_SIGNAL_MUST_COLLECT);
     D(G_SIGNAL_DEPRECATED);
 #undef D
-    scm_c_export ("G_SIGNAL_RUN_FIRST",
-		  "G_SIGNAL_RUN_LAST",
-		  "G_SIGNAL_RUN_CLEANUP",
-		  "G_SIGNAL_NO_RECURSE",
-		  "G_SIGNAL_DETAILED",
-		  "G_SIGNAL_ACTION",
-		  "G_SIGNAL_NO_HOOKS",
-		  "G_SIGNAL_MUST_COLLECT",
-		  "G_SIGNAL_DEPRECATED",
-		  NULL);
+    scm_c_export("G_SIGNAL_RUN_FIRST",
+                 "G_SIGNAL_RUN_LAST",
+                 "G_SIGNAL_RUN_CLEANUP",
+                 "G_SIGNAL_NO_RECURSE",
+                 "G_SIGNAL_DETAILED",
+                 "G_SIGNAL_ACTION",
+                 "G_SIGNAL_NO_HOOKS", "G_SIGNAL_MUST_COLLECT", "G_SIGNAL_DEPRECATED", NULL);
 }

--- a/src/gi_gsignal.h
+++ b/src/gi_gsignal.h
@@ -15,8 +15,8 @@ typedef struct _SignalSpec
     GType *param_types;
 } SignalSpec;
 
-SignalSpec *gi_signalspec_from_obj (SCM obj);
-void gi_free_signalspec (SignalSpec *spec);
-void gi_init_gsignal (void);
+SignalSpec *gi_signalspec_from_obj(SCM obj);
+void gi_free_signalspec(SignalSpec *spec);
+void gi_init_gsignal(void);
 
 #endif

--- a/src/gi_gvalue.c
+++ b/src/gi_gvalue.c
@@ -27,20 +27,21 @@
 #define GI_GVALUE_WRONG_TYPE -1
 #define GI_GVALUE_OUT_OF_RANGE -2
 
-SCM gi_gvalue_c2g(GValue *val)
+SCM
+gi_gvalue_c2g(GValue *val)
 {
     if (val)
         return scm_make_foreign_object_1(gi_gvalue_type, val);
 
-    g_return_val_if_reached (SCM_BOOL_F);
+    g_return_val_if_reached(SCM_BOOL_F);
 }
 
-void gi_gvalue_finalizer(SCM self)
+void
+gi_gvalue_finalizer(SCM self)
 {
     GValue *val;
     val = gi_gvalue_get_value(self);
-    if (val)
-    {
+    if (val) {
         g_value_unset(val);
         g_free(val);
         gi_gvalue_set_value(self, (GValue *)NULL);
@@ -62,165 +63,165 @@ void gi_gvalue_finalizer(SCM self)
 int
 gi_gvalue_from_scm(GValue *value, SCM obj)
 {
-    g_assert (value != NULL);
+    g_assert(value != NULL);
 
     GType value_type = G_VALUE_TYPE(value);
 
     switch (G_TYPE_FUNDAMENTAL(value_type)) {
     case G_TYPE_CHAR:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_signed_integer (obj, G_MININT8, G_MAXINT8))
+        if (!scm_is_signed_integer(obj, G_MININT8, G_MAXINT8))
             return GI_GVALUE_OUT_OF_RANGE;
-        gint8 temp = scm_to_int8 (obj);
-        g_value_set_schar (value, temp);
+        gint8 temp = scm_to_int8(obj);
+        g_value_set_schar(value, temp);
         return 0;
     }
     case G_TYPE_UCHAR:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXUINT8))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXUINT8))
             return GI_GVALUE_OUT_OF_RANGE;
         guchar temp;
-        temp = scm_to_uint8 (obj);
-        g_value_set_uchar (value, temp);
+        temp = scm_to_uint8(obj);
+        g_value_set_uchar(value, temp);
         return 0;
     }
     case G_TYPE_BOOLEAN:
     {
-        if (!scm_is_eq (obj, SCM_BOOL_T) && !scm_is_eq (obj, SCM_BOOL_F))
+        if (!scm_is_eq(obj, SCM_BOOL_T) && !scm_is_eq(obj, SCM_BOOL_F))
             return GI_GVALUE_WRONG_TYPE;
         gboolean temp;
-        temp = scm_is_true (obj);
-        g_value_set_boolean (value, temp);
+        temp = scm_is_true(obj);
+        g_value_set_boolean(value, temp);
         return 0;
     }
     case G_TYPE_INT:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_signed_integer (obj, G_MININT, G_MAXINT))
+        if (!scm_is_signed_integer(obj, G_MININT, G_MAXINT))
             return GI_GVALUE_OUT_OF_RANGE;
         gint temp;
-        temp = scm_to_int (obj);
-        g_value_set_int (value, temp);
+        temp = scm_to_int(obj);
+        g_value_set_int(value, temp);
         return 0;
     }
     case G_TYPE_UINT:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXUINT))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXUINT))
             return GI_GVALUE_OUT_OF_RANGE;
         guint temp;
-        temp = scm_to_uint (obj);
-        g_value_set_uint (value, temp);
+        temp = scm_to_uint(obj);
+        g_value_set_uint(value, temp);
         return 0;
     }
     case G_TYPE_LONG:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_signed_integer (obj, G_MINLONG, G_MAXLONG))
+        if (!scm_is_signed_integer(obj, G_MINLONG, G_MAXLONG))
             return GI_GVALUE_OUT_OF_RANGE;
         glong temp;
-        temp = scm_to_long (obj);
-        g_value_set_long (value, temp);
+        temp = scm_to_long(obj);
+        g_value_set_long(value, temp);
         return 0;
     }
     case G_TYPE_ULONG:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXULONG))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXULONG))
             return GI_GVALUE_OUT_OF_RANGE;
         gulong temp;
-        temp = scm_to_ulong (obj);
-        g_value_set_ulong (value, temp);
+        temp = scm_to_ulong(obj);
+        g_value_set_ulong(value, temp);
         return 0;
     }
     case G_TYPE_INT64:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_signed_integer (obj, G_MININT64, G_MAXINT64))
+        if (!scm_is_signed_integer(obj, G_MININT64, G_MAXINT64))
             return GI_GVALUE_OUT_OF_RANGE;
         gint64 temp;
-        temp = scm_to_int64 (obj);
-        g_value_set_int64 (value, temp);
+        temp = scm_to_int64(obj);
+        g_value_set_int64(value, temp);
         return 0;
     }
     case G_TYPE_UINT64:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXUINT64))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXUINT64))
             return GI_GVALUE_OUT_OF_RANGE;
         guint64 temp;
-        temp = scm_to_uint64 (obj);
-        g_value_set_uint64 (value, temp);
+        temp = scm_to_uint64(obj);
+        g_value_set_uint64(value, temp);
         return 0;
     }
     case G_TYPE_ENUM:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXULONG))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXULONG))
             return GI_GVALUE_OUT_OF_RANGE;
         gint val;
         val = scm_to_ulong(obj);
         g_value_set_enum(value, val);
     }
-    break;
+        break;
     case G_TYPE_FLAGS:
     {
-        if (!scm_is_exact_integer (obj))
+        if (!scm_is_exact_integer(obj))
             return GI_GVALUE_WRONG_TYPE;
-        if (!scm_is_unsigned_integer (obj, 0, G_MAXULONG))
+        if (!scm_is_unsigned_integer(obj, 0, G_MAXULONG))
             return GI_GVALUE_OUT_OF_RANGE;
         guint val = 0;
         val = scm_to_ulong(obj);
         g_value_set_flags(value, val);
         return 0;
     }
-    break;
+        break;
     case G_TYPE_FLOAT:
     {
-        if (!scm_is_true (scm_real_p (obj)))
+        if (!scm_is_true(scm_real_p(obj)))
             return GI_GVALUE_WRONG_TYPE;
-        gdouble dval = scm_to_double (obj);
+        gdouble dval = scm_to_double(obj);
         if (dval < -G_MAXFLOAT || dval > G_MAXFLOAT)
             return GI_GVALUE_OUT_OF_RANGE;
-        g_value_set_float (value, dval);
+        g_value_set_float(value, dval);
         return 0;
     }
     case G_TYPE_DOUBLE:
     {
-        if (!scm_is_true (scm_real_p (obj)))
+        if (!scm_is_true(scm_real_p(obj)))
             return GI_GVALUE_WRONG_TYPE;
         gdouble temp;
-        temp = scm_to_double (obj);
-        g_value_set_double (value, temp);
+        temp = scm_to_double(obj);
+        g_value_set_double(value, temp);
         return 0;
     }
     case G_TYPE_STRING:
     {
-        if (!scm_is_string (obj))
+        if (!scm_is_string(obj))
             return GI_GVALUE_WRONG_TYPE;
-        gchar *temp = scm_to_utf8_string (obj);
-        g_value_take_string (value, temp);
+        gchar *temp = scm_to_utf8_string(obj);
+        g_value_take_string(value, temp);
         return 0;
     }
     case G_TYPE_POINTER:
     {
-        if (SCM_POINTER_P (obj))
-            g_value_set_pointer (value, scm_to_pointer (obj));
-        else if (scm_is_true (scm_bytevector_p (obj)))
-            g_value_set_pointer (value, SCM_BYTEVECTOR_CONTENTS (obj));
+        if (SCM_POINTER_P(obj))
+            g_value_set_pointer(value, scm_to_pointer(obj));
+        else if (scm_is_true(scm_bytevector_p(obj)))
+            g_value_set_pointer(value, SCM_BYTEVECTOR_CONTENTS(obj));
         else if (gir_type_get_gtype_from_obj(obj) > G_TYPE_INVALID)
-            g_value_set_object (value, scm_foreign_object_ref (obj, OBJ_SLOT));
+            g_value_set_object(value, scm_foreign_object_ref(obj, OBJ_SLOT));
         else
             return GI_GVALUE_WRONG_TYPE;
     }
@@ -228,24 +229,24 @@ gi_gvalue_from_scm(GValue *value, SCM obj)
     case G_TYPE_INTERFACE:
         /* we only handle interface types that have a GObject prereq */
         if (g_type_is_a(value_type, G_TYPE_OBJECT)) {
-            if (scm_is_false (obj)) {
+            if (scm_is_false(obj)) {
                 g_value_set_object(value, NULL);
                 return 0;
             }
-            else if (!SCM_IS_A_P (obj, gi_gobject_type))
+            else if (!SCM_IS_A_P(obj, gi_gobject_type))
                 return GI_GVALUE_WRONG_TYPE;
-            else if (!G_TYPE_CHECK_INSTANCE_TYPE(gi_gobject_get_obj(obj),
-                                                 value_type))
+            else if (!G_TYPE_CHECK_INSTANCE_TYPE(gi_gobject_get_obj(obj), value_type))
                 return GI_GVALUE_WRONG_TYPE;
             else {
                 g_value_set_object(value, gi_gobject_get_obj(obj));
                 return 0;
             }
-        } else
+        }
+        else
             return GI_GVALUE_WRONG_TYPE;
         break;
     default:
-        g_critical ("unhandled value type");
+        g_critical("unhandled value type");
         return GI_GVALUE_WRONG_TYPE;
         break;
     }
@@ -254,173 +255,171 @@ gi_gvalue_from_scm(GValue *value, SCM obj)
 }
 
 void
-gi_gvalue_from_scm_with_error (const char *subr, GValue *value, SCM obj, int pos)
+gi_gvalue_from_scm_with_error(const char *subr, GValue *value, SCM obj, int pos)
 {
-    int res = gi_gvalue_from_scm (value, obj);
-    switch (res)
-    {
+    int res = gi_gvalue_from_scm(value, obj);
+    switch (res) {
     case 0:
         return;
     case GI_GVALUE_WRONG_TYPE:
-        scm_wrong_type_arg (subr, pos, obj);
+        scm_wrong_type_arg(subr, pos, obj);
         break;
     case GI_GVALUE_OUT_OF_RANGE:
-        scm_out_of_range_pos (subr, obj, scm_from_int (pos));
+        scm_out_of_range_pos(subr, obj, scm_from_int(pos));
     }
 }
 
 
 SCM
-gi_param_gvalue_as_scm (const GValue *gvalue,
-                        gboolean copy_boxed,
-                        const GParamSpec *pspec)
+gi_param_gvalue_as_scm(const GValue *gvalue, gboolean copy_boxed, const GParamSpec *pspec)
 {
-    if (G_IS_PARAM_SPEC_UNICHAR(pspec))
-    {
+    if (G_IS_PARAM_SPEC_UNICHAR(pspec)) {
         scm_t_wchar u;
 
-        u = g_value_get_uint (gvalue);
-        return SCM_MAKE_CHAR (u);
+        u = g_value_get_uint(gvalue);
+        return SCM_MAKE_CHAR(u);
     }
     else
-        return gi_gvalue_as_scm (gvalue, copy_boxed);
+        return gi_gvalue_as_scm(gvalue, copy_boxed);
 
 }
 
 
 GIArgument
-gi_giargument_from_g_value(const GValue *value,
-                           GITypeInfo *type_info)
+gi_giargument_from_g_value(const GValue *value, GITypeInfo *type_info)
 {
     GIArgument arg = { 0, };
 
-    GITypeTag type_tag = g_type_info_get_tag (type_info);
+    GITypeTag type_tag = g_type_info_get_tag(type_info);
 
     /* For the long handling: long can be equivalent to
-       int32 or int64, depending on the architecture, but
-       gi doesn't tell us (and same for ulong)
-    */
+     * int32 or int64, depending on the architecture, but
+     * gi doesn't tell us (and same for ulong)
+     */
     switch (type_tag) {
     case GI_TYPE_TAG_BOOLEAN:
-        arg.v_boolean = g_value_get_boolean (value);
+        arg.v_boolean = g_value_get_boolean(value);
         break;
     case GI_TYPE_TAG_INT8:
-        arg.v_int8 = g_value_get_schar (value);
+        arg.v_int8 = g_value_get_schar(value);
         break;
     case GI_TYPE_TAG_INT16:
     case GI_TYPE_TAG_INT32:
-        if (g_type_is_a (G_VALUE_TYPE (value), G_TYPE_LONG))
-            arg.v_int32 = (gint32)g_value_get_long (value);
+        if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_LONG))
+            arg.v_int32 = (gint32) g_value_get_long(value);
         else
-            arg.v_int32 = (gint32)g_value_get_int (value);
+            arg.v_int32 = (gint32) g_value_get_int(value);
         break;
     case GI_TYPE_TAG_INT64:
-        if (g_type_is_a (G_VALUE_TYPE (value), G_TYPE_LONG))
-            arg.v_int64 = g_value_get_long (value);
+        if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_LONG))
+            arg.v_int64 = g_value_get_long(value);
         else
-            arg.v_int64 = g_value_get_int64 (value);
+            arg.v_int64 = g_value_get_int64(value);
         break;
     case GI_TYPE_TAG_UINT8:
-        arg.v_uint8 = g_value_get_uchar (value);
+        arg.v_uint8 = g_value_get_uchar(value);
         break;
     case GI_TYPE_TAG_UINT16:
     case GI_TYPE_TAG_UINT32:
-        if (g_type_is_a (G_VALUE_TYPE (value), G_TYPE_ULONG))
-            arg.v_uint32 = (guint32)g_value_get_ulong (value);
+        if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_ULONG))
+            arg.v_uint32 = (guint32) g_value_get_ulong(value);
         else
-            arg.v_uint32 = (guint32)g_value_get_uint (value);
+            arg.v_uint32 = (guint32) g_value_get_uint(value);
         break;
     case GI_TYPE_TAG_UINT64:
-        if (g_type_is_a (G_VALUE_TYPE (value), G_TYPE_ULONG))
-            arg.v_uint64 = g_value_get_ulong (value);
+        if (g_type_is_a(G_VALUE_TYPE(value), G_TYPE_ULONG))
+            arg.v_uint64 = g_value_get_ulong(value);
         else
-            arg.v_uint64 = g_value_get_uint64 (value);
+            arg.v_uint64 = g_value_get_uint64(value);
         break;
     case GI_TYPE_TAG_UNICHAR:
-        arg.v_uint32 = g_value_get_schar (value);
+        arg.v_uint32 = g_value_get_schar(value);
         break;
     case GI_TYPE_TAG_FLOAT:
-        arg.v_float = g_value_get_float (value);
+        arg.v_float = g_value_get_float(value);
         break;
     case GI_TYPE_TAG_DOUBLE:
-        arg.v_double = g_value_get_double (value);
+        arg.v_double = g_value_get_double(value);
         break;
     case GI_TYPE_TAG_GTYPE:
-        arg.v_size = g_value_get_gtype (value);
+        arg.v_size = g_value_get_gtype(value);
         break;
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
         /* Callers are responsible for ensuring the GValue stays alive
          * long enough for the string to be copied. */
-        arg.v_string = (char *)g_value_get_string (value);
+        arg.v_string = (char *)g_value_get_string(value);
         break;
     case GI_TYPE_TAG_GLIST:
     case GI_TYPE_TAG_GSLIST:
     case GI_TYPE_TAG_ARRAY:
     case GI_TYPE_TAG_GHASH:
-        if (G_VALUE_HOLDS_BOXED (value))
-            arg.v_pointer = g_value_get_boxed (value);
+        if (G_VALUE_HOLDS_BOXED(value))
+            arg.v_pointer = g_value_get_boxed(value);
         else
             /* e. g. GSettings::change-event */
-            arg.v_pointer = g_value_get_pointer (value);
+            arg.v_pointer = g_value_get_pointer(value);
         break;
     case GI_TYPE_TAG_INTERFACE:
     {
         GIBaseInfo *info;
         GIInfoType info_type;
 
-        info = g_type_info_get_interface (type_info);
-        info_type = g_base_info_get_type (info);
+        info = g_type_info_get_interface(type_info);
+        info_type = g_base_info_get_type(info);
 
-        g_base_info_unref (info);
+        g_base_info_unref(info);
 
         switch (info_type) {
         case GI_INFO_TYPE_FLAGS:
-            arg.v_uint = g_value_get_flags (value);
+            arg.v_uint = g_value_get_flags(value);
             break;
         case GI_INFO_TYPE_ENUM:
-            arg.v_int = g_value_get_enum (value);
+            arg.v_int = g_value_get_enum(value);
             break;
         case GI_INFO_TYPE_INTERFACE:
         case GI_INFO_TYPE_OBJECT:
-            if (G_VALUE_HOLDS_PARAM (value))
-                arg.v_pointer = g_value_get_param (value);
+            if (G_VALUE_HOLDS_PARAM(value))
+                arg.v_pointer = g_value_get_param(value);
             else
-                arg.v_pointer = g_value_get_object (value);
+                arg.v_pointer = g_value_get_object(value);
             break;
         case GI_INFO_TYPE_BOXED:
         case GI_INFO_TYPE_STRUCT:
         case GI_INFO_TYPE_UNION:
-            if (G_VALUE_HOLDS (value, G_TYPE_BOXED)) {
-                arg.v_pointer = g_value_get_boxed (value);
-            } else if (G_VALUE_HOLDS (value, G_TYPE_VARIANT)) {
-                arg.v_pointer = g_value_get_variant (value);
-            } else if (G_VALUE_HOLDS (value, G_TYPE_POINTER)) {
-                arg.v_pointer = g_value_get_pointer (value);
-            } else {
+            if (G_VALUE_HOLDS(value, G_TYPE_BOXED)) {
+                arg.v_pointer = g_value_get_boxed(value);
+            }
+            else if (G_VALUE_HOLDS(value, G_TYPE_VARIANT)) {
+                arg.v_pointer = g_value_get_variant(value);
+            }
+            else if (G_VALUE_HOLDS(value, G_TYPE_POINTER)) {
+                arg.v_pointer = g_value_get_pointer(value);
+            }
+            else {
                 /* PyErr_Format (PyExc_NotImplementedError, */
                 /*               "Converting GValue's of type '%s' is not implemented.", */
                 /*               g_type_name (G_VALUE_TYPE (value))); */
-                g_error ("Converting GValue's of type '%s' is not implemented.",
-                         g_type_name (G_VALUE_TYPE (value)));
+                g_error("Converting GValue's of type '%s' is not implemented.",
+                        g_type_name(G_VALUE_TYPE(value)));
             }
             break;
         default:
             /* PyErr_Format (PyExc_NotImplementedError, */
             /*               "Converting GValue's of type '%s' is not implemented.", */
             /*               g_info_type_to_string (info_type)); */
-            g_error ("Converting GValue's of type '%s' is not implemented.",
-                     g_info_type_to_string (info_type));
+            g_error("Converting GValue's of type '%s' is not implemented.",
+                    g_info_type_to_string(info_type));
 
             break;
         }
         break;
     }
     case GI_TYPE_TAG_ERROR:
-        arg.v_pointer = g_value_get_boxed (value);
+        arg.v_pointer = g_value_get_boxed(value);
         break;
     case GI_TYPE_TAG_VOID:
-        arg.v_pointer = g_value_get_pointer (value);
+        arg.v_pointer = g_value_get_pointer(value);
         break;
     default:
         break;
@@ -435,16 +434,16 @@ gi_gvalue_array_from_scm_list(GValue *value, SCM list)
     ssize_t len, i;
     GArray *array;
 
-    len = scm_to_size_t (scm_length (list));
+    len = scm_to_size_t(scm_length(list));
 
     array = g_array_new(FALSE, TRUE, sizeof(GValue));
 
     for (i = 0; i < len; ++i) {
-        SCM item = scm_list_ref (list, scm_from_size_t (i));
+        SCM item = scm_list_ref(list, scm_from_size_t(i));
         GType type;
         GValue item_value = { 0, };
 
-        type = gir_type_get_gtype_from_obj (item);
+        type = gir_type_get_gtype_from_obj(item);
 
         g_value_init(&item_value, type);
         gi_gvalue_from_scm(&item_value, item);
@@ -468,11 +467,11 @@ gi_gvalue_array_from_scm_list(GValue *value, SCM list)
  *
  * Returns: a PyObject representing the value.
  */
-SCM gi_gvalue_to_scm_basic_type(const GValue *value, GType fundamental, gboolean *handled)
+SCM
+gi_gvalue_to_scm_basic_type(const GValue *value, GType fundamental, gboolean *handled)
 {
     *handled = TRUE;
-    switch (fundamental)
-    {
+    switch (fundamental) {
     case G_TYPE_CHAR:
         return scm_from_int8(g_value_get_schar(value));
     case G_TYPE_UCHAR:
@@ -521,8 +520,7 @@ SCM gi_gvalue_to_scm_basic_type(const GValue *value, GType fundamental, gboolean
 // This function creates and returns a Scheme value that
 // represents the GValue passed as an argument.
 static SCM
-gi_gvalue_to_scm_structured_type (const GValue *value, GType fundamental,
-                                  gboolean copy_boxed)
+gi_gvalue_to_scm_structured_type(const GValue *value, GType fundamental, gboolean copy_boxed)
 {
     switch (fundamental) {
     case G_TYPE_INTERFACE:
@@ -538,14 +536,12 @@ gi_gvalue_to_scm_structured_type (const GValue *value, GType fundamental,
     case G_TYPE_POINTER:
         // If we get a simple pointer with no context information,
         // what can we do other than return a dumb pointer?
-        return scm_from_pointer (g_value_get_pointer (value), NULL);
+        return scm_from_pointer(g_value_get_pointer(value), NULL);
     case G_TYPE_PARAM:
     {
         GParamSpec *pspec = g_value_get_param(value);
         if (pspec)
-            return gir_type_make_object(G_VALUE_TYPE(value),
-                                        pspec,
-                                        0);
+            return gir_type_make_object(G_VALUE_TYPE(value), pspec, 0);
         else
             return SCM_BOOL_F;
     }
@@ -553,15 +549,15 @@ gi_gvalue_to_scm_structured_type (const GValue *value, GType fundamental,
     case G_TYPE_BOXED:
     {
         if (G_VALUE_HOLDS(value, G_TYPE_VALUE)) {
-            GValue *n_value = g_value_get_boxed (value);
+            GValue *n_value = g_value_get_boxed(value);
             return gi_gvalue_as_scm(n_value, copy_boxed);
-        } else if (G_VALUE_HOLDS(value, G_TYPE_GSTRING)) {
+        }
+        else if (G_VALUE_HOLDS(value, G_TYPE_GSTRING)) {
             GString *string = (GString *) g_value_get_boxed(value);
             return scm_from_utf8_stringn(string->str, string->len);
-        } else {
-            return gir_type_make_object(G_VALUE_TYPE(value),
-                                        g_value_get_boxed(value),
-                                        copy_boxed);
+        }
+        else {
+            return gir_type_make_object(G_VALUE_TYPE(value), g_value_get_boxed(value), copy_boxed);
         }
     }
 
@@ -582,7 +578,7 @@ gi_gvalue_to_scm_structured_type (const GValue *value, GType fundamental,
             Py_INCREF(Py_None);
             return Py_None;
         }
-        return pygi_struct_new_from_g_type (G_TYPE_VARIANT, g_variant_ref(v), FALSE);
+        return pygi_struct_new_from_g_type(G_TYPE_VARIANT, g_variant_ref(v), FALSE);
     }
 #endif
     default:
@@ -595,121 +591,111 @@ gi_gvalue_to_scm_structured_type (const GValue *value, GType fundamental,
     }
     }
 
-    const char *type_name = g_type_name (G_VALUE_TYPE (value));
+    const char *type_name = g_type_name(G_VALUE_TYPE(value));
     if (type_name == NULL)
         type_name = "(null)";
-    scm_misc_error ("gi_gvalue_to_scm", "unknown type ~S",
-                    scm_list_1 (scm_from_utf8_string (type_name)));
-    g_return_val_if_reached (SCM_BOOL_F);
+    scm_misc_error("gi_gvalue_to_scm", "unknown type ~S",
+                   scm_list_1(scm_from_utf8_string(type_name)));
+    g_return_val_if_reached(SCM_BOOL_F);
 }
 
 
 /* Returns an SCM version of the GValue.  If COPY_BOXED,
    try to make a deep copy of the object. */
 SCM
-gi_gvalue_as_scm (const GValue *value, gboolean copy_boxed)
+gi_gvalue_as_scm(const GValue *value, gboolean copy_boxed)
 {
     SCM guobj;
     gboolean handled;
-    GType fundamental = G_TYPE_FUNDAMENTAL (G_VALUE_TYPE (value));
+    GType fundamental = G_TYPE_FUNDAMENTAL(G_VALUE_TYPE(value));
 
 #if 0
     if (fundamental == G_TYPE_CHAR)
-        return SCM_MAKE_CHAR (g_value_get_schar (value));
+        return SCM_MAKE_CHAR(g_value_get_schar(value));
     else if (fundamental == G_TYPE_UCHAR)
-        return SCM_MAKE_CHAR (g_value_get_uchar (value));
+        return SCM_MAKE_CHAR(g_value_get_uchar(value));
 #endif
 
-    guobj = gi_gvalue_to_scm_basic_type (value, fundamental, &handled);
+    guobj = gi_gvalue_to_scm_basic_type(value, fundamental, &handled);
     if (!handled)
-        guobj = gi_gvalue_to_scm_structured_type (value, fundamental, copy_boxed);
+        guobj = gi_gvalue_to_scm_structured_type(value, fundamental, copy_boxed);
     return guobj;
 }
 
 
 static SCM
-scm_gvalue_set_x (SCM self, SCM x)
+scm_gvalue_set_x(SCM self, SCM x)
 {
     GValue *val;
 
-    if (!SCM_IS_A_P (self, gi_gvalue_type))
-        scm_wrong_type_arg_msg ("gvalue-set!",
-                                SCM_ARG1,
-                                self,
-                                "GValue");
+    if (!SCM_IS_A_P(self, gi_gvalue_type))
+        scm_wrong_type_arg_msg("gvalue-set!", SCM_ARG1, self, "GValue");
 
-    val = gi_gvalue_get_value (self);
+    val = gi_gvalue_get_value(self);
     if (val)
-        gi_gvalue_from_scm_with_error ("gvalue_set!", val, x, SCM_ARG2);
+        gi_gvalue_from_scm_with_error("gvalue_set!", val, x, SCM_ARG2);
     return SCM_UNSPECIFIED;
 }
 
 static SCM
-scm_gvalue_get (SCM self)
+scm_gvalue_get(SCM self)
 {
     GValue *val;
 
-    scm_assert_foreign_object_type (gi_gvalue_type, self);
-    val = gi_gvalue_get_value (self);
-    return gi_gvalue_as_scm (val, TRUE);
+    scm_assert_foreign_object_type(gi_gvalue_type, self);
+    val = gi_gvalue_get_value(self);
+    return gi_gvalue_as_scm(val, TRUE);
 }
 
 static SCM
-scm_make_gvalue (SCM gtype)
+scm_make_gvalue(SCM gtype)
 {
     GType type;
     GValue *val;
 
     //scm_assert_foreign_object_type (gi_gtype_type, gtype);
 
-    type = scm_to_gtype (gtype);
-    val = g_new0(GValue,1);
-    g_value_init (val, type);
-    return gi_gvalue_c2g (val);
+    type = scm_to_gtype(gtype);
+    val = g_new0(GValue, 1);
+    g_value_init(val, type);
+    return gi_gvalue_c2g(val);
 
 }
 
 static SCM
-scm_gvalue_type_name (SCM self)
+scm_gvalue_type_name(SCM self)
 {
     GValue *val;
     const gchar *name;
 
-    if (!SCM_IS_A_P (self, gi_gvalue_type))
-        scm_wrong_type_arg_msg ("gvalue-type-name",
-                                SCM_ARG1,
-                                self,
-                                "GValue");
+    if (!SCM_IS_A_P(self, gi_gvalue_type))
+        scm_wrong_type_arg_msg("gvalue-type-name", SCM_ARG1, self, "GValue");
 
-    val = gi_gvalue_get_value (self);
+    val = gi_gvalue_get_value(self);
     if (val) {
-        name = G_VALUE_TYPE_NAME (val);
+        name = G_VALUE_TYPE_NAME(val);
         if (name)
-            return scm_from_utf8_string (name);
+            return scm_from_utf8_string(name);
         else
-            return scm_from_utf8_string ("(unknown)");
+            return scm_from_utf8_string("(unknown)");
     }
-    g_return_val_if_reached (SCM_BOOL_F);
+    g_return_val_if_reached(SCM_BOOL_F);
 }
 
 static SCM
-scm_gvalue_to_gtype (SCM self)
+scm_gvalue_to_gtype(SCM self)
 {
     GValue *val;
     GType type;
 
-    if (!SCM_IS_A_P (self, gi_gvalue_type))
-        scm_wrong_type_arg_msg ("gvalue->gtype",
-                                SCM_ARG1,
-                                self,
-                                "GValue");
+    if (!SCM_IS_A_P(self, gi_gvalue_type))
+        scm_wrong_type_arg_msg("gvalue->gtype", SCM_ARG1, self, "GValue");
 
-    val = gi_gvalue_get_value (self);
-    if (val)
-    {
-        type = G_VALUE_TYPE (val);
+    val = gi_gvalue_get_value(self);
+    if (val) {
+        type = G_VALUE_TYPE(val);
         gir_type_register(type);
-        return scm_from_size_t (type);
+        return scm_from_size_t(type);
     }
     return SCM_BOOL_F;
 }
@@ -721,53 +707,46 @@ scm_gvalue_holds_p(SCM self, SCM gtype)
     GType type;
     gboolean ret;
 
-    if (!SCM_IS_A_P (self, gi_gvalue_type))
-        scm_wrong_type_arg_msg ("gvalue-holds?",
-                                SCM_ARG1,
-                                self,
-                                "GValue");
+    if (!SCM_IS_A_P(self, gi_gvalue_type))
+        scm_wrong_type_arg_msg("gvalue-holds?", SCM_ARG1, self, "GValue");
 
-    val = gi_gvalue_get_value (self);
-    type = scm_to_gtype (gtype);
+    val = gi_gvalue_get_value(self);
+    type = scm_to_gtype(gtype);
     if (val) {
-        ret = G_VALUE_HOLDS (val, type);
-        return scm_from_bool (ret);
+        ret = G_VALUE_HOLDS(val, type);
+        return scm_from_bool(ret);
     }
     return SCM_BOOL_F;
 }
 
 static SCM
-scm_gvalue_valid_p (SCM self)
+scm_gvalue_valid_p(SCM self)
 {
     GValue *val;
     gboolean ret;
 
-    scm_assert_foreign_object_type (gi_gvalue_type, self);
-    val = gi_gvalue_get_value (self);
+    scm_assert_foreign_object_type(gi_gvalue_type, self);
+    val = gi_gvalue_get_value(self);
     if (val) {
-        ret = G_IS_VALUE (val);
-        return scm_from_bool (ret);
+        ret = G_IS_VALUE(val);
+        return scm_from_bool(ret);
     }
     return SCM_BOOL_F;
 }
 
 void
-gi_init_gvalue (void)
+gi_init_gvalue(void)
 {
-    gi_init_gvalue_type ();
+    gi_init_gvalue_type();
 
-    scm_c_define_gsubr ("gvalue-get", 1, 0, 0, scm_gvalue_get);
-    scm_c_define_gsubr ("gvalue-set!", 2, 0, 0, scm_gvalue_set_x);
-    scm_c_define_gsubr ("make-gvalue", 1, 0, 0, scm_make_gvalue);
-    scm_c_define_gsubr ("gvalue-type-name", 1, 0, 0, scm_gvalue_type_name);
-    scm_c_define_gsubr ("gvalue->gtype", 1, 0, 0, scm_gvalue_to_gtype);
-    scm_c_define_gsubr ("gvalue-holds?", 2, 0, 0, scm_gvalue_holds_p);
-    scm_c_define_gsubr ("gvalue-valid?", 1, 0, 0, scm_gvalue_valid_p);
+    scm_c_define_gsubr("gvalue-get", 1, 0, 0, scm_gvalue_get);
+    scm_c_define_gsubr("gvalue-set!", 2, 0, 0, scm_gvalue_set_x);
+    scm_c_define_gsubr("make-gvalue", 1, 0, 0, scm_make_gvalue);
+    scm_c_define_gsubr("gvalue-type-name", 1, 0, 0, scm_gvalue_type_name);
+    scm_c_define_gsubr("gvalue->gtype", 1, 0, 0, scm_gvalue_to_gtype);
+    scm_c_define_gsubr("gvalue-holds?", 2, 0, 0, scm_gvalue_holds_p);
+    scm_c_define_gsubr("gvalue-valid?", 1, 0, 0, scm_gvalue_valid_p);
 
-    scm_c_export ("make-gvalue",
-                  "gvalue-type-name",
-                  "gvalue->gtype",
-                  "gvalue-holds?",
-                  "gvalue-valid?",
-                  NULL);
+    scm_c_export("make-gvalue",
+                 "gvalue-type-name", "gvalue->gtype", "gvalue-holds?", "gvalue-valid?", NULL);
 }

--- a/src/gi_gvalue.h
+++ b/src/gi_gvalue.h
@@ -7,20 +7,17 @@
 #include <girepository.h>
 #include "__gi_gvalue.h"
 
-SCM gi_gvalue_c2g (GValue *val);
+SCM gi_gvalue_c2g(GValue *val);
 
-SCM gi_gvalue_to_scm_basic_type (const GValue *value, GType fundamental, gboolean *handled);
+SCM gi_gvalue_to_scm_basic_type(const GValue *value, GType fundamental, gboolean *handled);
 
 
-SCM gi_param_gvalue_as_scm (const GValue *gvalue,
-			    gboolean copy_boxed,
-			    const GParamSpec *pspec);
+SCM gi_param_gvalue_as_scm(const GValue *gvalue, gboolean copy_boxed, const GParamSpec *pspec);
 
-SCM gi_gvalue_as_scm (const GValue *value, gboolean copy_boxed);
+SCM gi_gvalue_as_scm(const GValue *value, gboolean copy_boxed);
 void gi_gvalue_from_scm_with_error(const char *subr, GValue *value, SCM obj, int pos);
-int gi_gvalue_from_scm (GValue *value, SCM obj);
-GIArgument gi_giargument_from_g_value(const GValue *value,
-				      GITypeInfo *type_info);
+int gi_gvalue_from_scm(GValue *value, SCM obj);
+GIArgument gi_giargument_from_g_value(const GValue *value, GITypeInfo *type_info);
 
-void gi_init_gvalue (void);
+void gi_init_gvalue(void);
 #endif

--- a/src/gi_signal_closure.h
+++ b/src/gi_signal_closure.h
@@ -2,10 +2,7 @@
 #define _GI_SIGNAL_CLOSURE_H_
 #include <girepository.h>
 #include <libguile.h>
-GClosure *
-gi_signal_closure_new (SCM instance,
-                         GType g_type,
-                         const gchar *signal_name,
-                         SCM callback,
-                         SCM extra_args);
+GClosure *gi_signal_closure_new(SCM instance, GType g_type, const gchar *signal_name,
+                                 SCM callback, SCM extra_args);
+
 #endif

--- a/src/gi_struct.c
+++ b/src/gi_struct.c
@@ -23,34 +23,29 @@ scm_make_gstruct(SCM s_gtype)
 {
     GType type;
 
-    type = scm_to_gtype (s_gtype);
+    type = scm_to_gtype(s_gtype);
 
-    if (scm_is_false (gir_type_get_scheme_type (type)))
-        scm_misc_error ("make-struct",
-                        "type ~S lacks introspection",
-                        scm_list_1 (s_gtype));
+    if (scm_is_false(gir_type_get_scheme_type(type)))
+        scm_misc_error("make-struct", "type ~S lacks introspection", scm_list_1(s_gtype));
 
     SCM scm_type = gir_type_get_scheme_type(type);
     if (scm_is_false(scm_type))
-        scm_misc_error ("make-struct",
-                        "unknown type ~S",
-                        scm_list_1 (s_gtype));
+        scm_misc_error("make-struct", "unknown type ~S", scm_list_1(s_gtype));
 
     GQuark size_quark = g_quark_from_string("size");
-    size_t size = GPOINTER_TO_SIZE (g_type_get_qdata(type, size_quark));
+    size_t size = GPOINTER_TO_SIZE(g_type_get_qdata(type, size_quark));
 
     if (size == 0)
-        scm_misc_error ("make-struct",
-                        "Type ~S has unknown size",
-                        scm_list_1 (s_gtype));
+        scm_misc_error("make-struct", "Type ~S has unknown size", scm_list_1(s_gtype));
 
     gpointer obj = g_malloc0(size);
-    void *params[6] = {GSIZE_TO_POINTER(type),
-                       GINT_TO_POINTER(1),
-                       obj,
-                       NULL,
-                       NULL,
-                       GINT_TO_POINTER(0)};
+    void *params[6] = { GSIZE_TO_POINTER(type),
+        GINT_TO_POINTER(1),
+        obj,
+        NULL,
+        NULL,
+        GINT_TO_POINTER(0)
+    };
 
     return scm_make_foreign_object_n(scm_type, 6, params);
 }
@@ -60,34 +55,29 @@ scm_make_gunion(SCM s_gtype)
 {
     GType type;
 
-    type = scm_to_gtype (s_gtype);
+    type = scm_to_gtype(s_gtype);
 
-    if (scm_is_false (gir_type_get_scheme_type (type)))
-        scm_misc_error ("make-union",
-                        "type ~S lacks introspection",
-                        scm_list_1 (s_gtype));
+    if (scm_is_false(gir_type_get_scheme_type(type)))
+        scm_misc_error("make-union", "type ~S lacks introspection", scm_list_1(s_gtype));
 
     SCM scm_type = gir_type_get_scheme_type(type);
     if (scm_is_false(scm_type))
-        scm_misc_error ("make-union",
-                        "unknown type ~S",
-                        scm_list_1 (s_gtype));
+        scm_misc_error("make-union", "unknown type ~S", scm_list_1(s_gtype));
 
     GQuark size_quark = g_quark_from_string("size");
-    size_t size = GPOINTER_TO_SIZE (g_type_get_qdata(type, size_quark));
+    size_t size = GPOINTER_TO_SIZE(g_type_get_qdata(type, size_quark));
 
     if (size == 0)
-        scm_misc_error ("make-union",
-                        "Type ~S has unknown size",
-                        scm_list_1 (s_gtype));
+        scm_misc_error("make-union", "Type ~S has unknown size", scm_list_1(s_gtype));
 
     gpointer obj = g_malloc0(size);
-    void *params[6] = {GSIZE_TO_POINTER(type),
-                       GINT_TO_POINTER(1),
-                       obj,
-                       NULL,
-                       NULL,
-                       GINT_TO_POINTER(0)};
+    void *params[6] = { GSIZE_TO_POINTER(type),
+        GINT_TO_POINTER(1),
+        obj,
+        NULL,
+        NULL,
+        GINT_TO_POINTER(0)
+    };
 
     return scm_make_foreign_object_n(scm_type, 6, params);
 }
@@ -98,7 +88,5 @@ gi_init_struct(void)
 {
     scm_c_define_gsubr("make-gstruct", 1, 0, 0, scm_make_gstruct);
     scm_c_define_gsubr("make-gunion", 1, 0, 0, scm_make_gunion);
-    scm_c_export("make-gstruct",
-                 "make-gunion",
-                 NULL);
+    scm_c_export("make-gstruct", "make-gunion", NULL);
 }

--- a/src/gi_util.c
+++ b/src/gi_util.c
@@ -100,7 +100,7 @@ scm_is_list (SCM obj)
 }
 
 void*
-scm_dynwind_or_bust (char *subr, void *mem)
+scm_dynwind_or_bust (const char *subr, void *mem)
 {
     if (mem)
         scm_dynwind_free (mem);

--- a/src/gi_util.c
+++ b/src/gi_util.c
@@ -46,38 +46,32 @@ gi_constant_strip_prefix(const gchar *name, const gchar *strip_prefix)
 char *
 gname_to_scm_name(const char *gname)
 {
-    g_assert (gname != NULL);
-    g_assert (strlen(gname) > 0);
+    g_assert(gname != NULL);
+    g_assert(strlen(gname) > 0);
 
     size_t len = strlen(gname);
     GString *str = g_string_new(NULL);
     gboolean was_lower = FALSE;
 
-    for (size_t i = 0; i < len; i++)
-    {
-        if (g_ascii_islower(gname[i]))
-        {
+    for (size_t i = 0; i < len; i++) {
+        if (g_ascii_islower(gname[i])) {
             g_string_append_c(str, gname[i]);
             was_lower = TRUE;
         }
-        else if (gname[i] == '_' || gname[i] == '-')
-        {
+        else if (gname[i] == '_' || gname[i] == '-') {
             g_string_append_c(str, '-');
             was_lower = FALSE;
         }
-        else if (gname[i] == '?')
-        {
+        else if (gname[i] == '?') {
             // does this even occur?
             g_string_append_c(str, '?');
             was_lower = FALSE;
         }
-        else if (g_ascii_isdigit(gname[i]))
-        {
+        else if (g_ascii_isdigit(gname[i])) {
             g_string_append_c(str, gname[i]);
             was_lower = FALSE;
         }
-        else if (g_ascii_isupper(gname[i]))
-        {
+        else if (g_ascii_isupper(gname[i])) {
             if (was_lower)
                 g_string_append_c(str, '-');
             g_string_append_c(str, g_ascii_tolower(gname[i]));
@@ -88,26 +82,25 @@ gname_to_scm_name(const char *gname)
 }
 
 SCM
-scm_c_list_ref (SCM list, size_t k)
+scm_c_list_ref(SCM list, size_t k)
 {
-    return scm_list_ref (list, scm_from_size_t (k));
+    return scm_list_ref(list, scm_from_size_t(k));
 }
 
 int
-scm_is_list (SCM obj)
+scm_is_list(SCM obj)
 {
-    return scm_is_true (scm_list_p (obj));
+    return scm_is_true(scm_list_p(obj));
 }
 
-void*
-scm_dynwind_or_bust (const char *subr, void *mem)
+void *
+scm_dynwind_or_bust(const char *subr, void *mem)
 {
     if (mem)
-        scm_dynwind_free (mem);
-    else
-    {
+        scm_dynwind_free(mem);
+    else {
         errno = ENOMEM;
-        scm_syserror (subr);
+        scm_syserror(subr);
     }
     return mem;
 }

--- a/src/gi_util.c
+++ b/src/gi_util.c
@@ -1,6 +1,7 @@
 #include <libguile.h>
 #include <glib.h>
 #include <glib-object.h>
+#include <errno.h>
 #include "gi_util.h"
 
 /**
@@ -96,4 +97,17 @@ int
 scm_is_list (SCM obj)
 {
     return scm_is_true (scm_list_p (obj));
+}
+
+void*
+scm_dynwind_or_bust (char *subr, void *mem)
+{
+    if (mem)
+        scm_dynwind_free (mem);
+    else
+    {
+        errno = ENOMEM;
+        scm_syserror (subr);
+    }
+    return mem;
 }

--- a/src/gi_util.h
+++ b/src/gi_util.h
@@ -7,7 +7,7 @@ const gchar *gi_constant_strip_prefix(const gchar *name, const gchar *strip_pref
 char * gname_to_scm_name(const char *gname);
 SCM scm_c_list_ref (SCM list, size_t k);
 int scm_is_list (SCM obj);
-void* scm_dynwind_or_bust (char *subr, void *mem);
+void* scm_dynwind_or_bust (const char *subr, void *mem);
 
 #define SCM_UNBND_TO_BOOL_F(obj) \
     do {                         \

--- a/src/gi_util.h
+++ b/src/gi_util.h
@@ -7,6 +7,7 @@ const gchar *gi_constant_strip_prefix(const gchar *name, const gchar *strip_pref
 char * gname_to_scm_name(const char *gname);
 SCM scm_c_list_ref (SCM list, size_t k);
 int scm_is_list (SCM obj);
+void* scm_dynwind_or_bust (char *subr, void *mem);
 
 #define SCM_UNBND_TO_BOOL_F(obj) \
     do {                         \

--- a/src/gi_util.h
+++ b/src/gi_util.h
@@ -4,10 +4,10 @@
 #include <glib.h>
 
 const gchar *gi_constant_strip_prefix(const gchar *name, const gchar *strip_prefix);
-char * gname_to_scm_name(const char *gname);
-SCM scm_c_list_ref (SCM list, size_t k);
-int scm_is_list (SCM obj);
-void* scm_dynwind_or_bust (const char *subr, void *mem);
+char *gname_to_scm_name(const char *gname);
+SCM scm_c_list_ref(SCM list, size_t k);
+int scm_is_list(SCM obj);
+void *scm_dynwind_or_bust(const char *subr, void *mem);
 
 #define SCM_UNBND_TO_BOOL_F(obj) \
     do {                         \

--- a/src/gir.c
+++ b/src/gir.c
@@ -47,20 +47,17 @@ void __gcov_dump(void);
 
 void
 gir_log_handler(const gchar *log_domain,
-    GLogLevelFlags log_level,
-    const gchar *message,
-    gpointer user_data)
+                GLogLevelFlags log_level, const gchar *message, gpointer user_data)
 {
     time_t timer;
     char buffer[26];
-    struct tm* tm_info;
+    struct tm *tm_info;
     time(&timer);
     tm_info = localtime(&timer);
     strftime(buffer, 26, "%Y-%m-%d %H:%M:%S", tm_info);
 
     // Opening and closing files as append in Win32 is noticeably slow.
-    if (log_level == G_LOG_LEVEL_DEBUG && !_win32)
-    {
+    if (log_level == G_LOG_LEVEL_DEBUG && !_win32) {
         FILE *fp = fopen("gir-debug-log.xt", "at");
         fprintf(fp, "%s: %s %d %s\n", buffer, log_domain, log_level, message);
         fclose(fp);
@@ -72,7 +69,7 @@ gir_log_handler(const gchar *log_domain,
 
 #ifdef ENABLE_GCOV
 static SCM
-scm_gcov_reset (void)
+scm_gcov_reset(void)
 {
     __gcov_reset();
     return SCM_UNSPECIFIED;
@@ -80,7 +77,7 @@ scm_gcov_reset (void)
 
 
 static SCM
-scm_gcov_dump (void)
+scm_gcov_dump(void)
 {
     __gcov_dump();
     return SCM_UNSPECIFIED;
@@ -120,7 +117,8 @@ gir_init(void)
 #endif
 }
 
-int main(int argc, char **argv)
+int
+main(int argc, char **argv)
 {
     scm_init_guile();
 

--- a/src/gir_callback.c
+++ b/src/gir_callback.c
@@ -3,36 +3,34 @@
 #include "gir_callback.h"
 #include "gi_giargument.h"
 
-static SCM gir_callback_call_proc (void *user_data);
-static SCM gir_callback_handler_proc (void *user_data, SCM key, SCM params);
+static SCM gir_callback_call_proc(void *user_data);
+static SCM gir_callback_handler_proc(void *user_data, SCM key, SCM params);
 
 GSList *callback_list = NULL;
 
-static ffi_type *
-type_info_to_ffi_type(GITypeInfo *type_info);
+static ffi_type *type_info_to_ffi_type(GITypeInfo *type_info);
 
 // This is the core of a dynamically generated callback funcion.
 // It converts FFI arguments to SCM arguments, calls a SCM function
 // and then returns the result.
-void callback_binding(ffi_cif *cif, void *ret, void **ffi_args,
-    void *user_data)
+void
+callback_binding(ffi_cif *cif, void *ret, void **ffi_args, void *user_data)
 {
     GirCallback *gcb = user_data;
     SCM s_args = SCM_EOL;
     SCM s_ret;
 
-    g_assert (cif != NULL);
-    g_assert (ret != NULL);
-    g_assert (ffi_args != NULL);
-    g_assert (user_data != NULL);
+    g_assert(cif != NULL);
+    g_assert(ret != NULL);
+    g_assert(ffi_args != NULL);
+    g_assert(user_data != NULL);
 
     g_debug("in callback C->SCM binding");
     unsigned int n_args = cif->nargs;
 
-    g_assert (n_args >= 0);
+    g_assert(n_args >= 0);
 
-    for (unsigned int i = 0; i < n_args; i++)
-    {
+    for (unsigned int i = 0; i < n_args; i++) {
         SCM s_entry = SCM_BOOL_F;
         GIArgument giarg;
         GIArgInfo *arg_info;
@@ -47,35 +45,32 @@ void callback_binding(ffi_cif *cif, void *ret, void **ffi_args,
         else if (cif->arg_types[i] == &ffi_type_sint)
             giarg.v_int = (int)ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_sint8)
-            giarg.v_int8 = (gint8)ffi_args[i];
+            giarg.v_int8 = (gint8) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_uint8)
-            giarg.v_uint8 = (guint8)ffi_args[i];
+            giarg.v_uint8 = (guint8) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_sint16)
-            giarg.v_int16 = (gint16)ffi_args[i];
+            giarg.v_int16 = (gint16) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_uint16)
-            giarg.v_uint16 = (guint16)ffi_args[i];
+            giarg.v_uint16 = (guint16) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_sint32)
-            giarg.v_int32 = (gint32)ffi_args[i];
+            giarg.v_int32 = (gint32) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_uint32)
-            giarg.v_uint32 = (guint32)ffi_args[i];
+            giarg.v_uint32 = (guint32) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_sint64)
-            giarg.v_int64 = (gint64)ffi_args[i];
+            giarg.v_int64 = (gint64) ffi_args[i];
         else if (cif->arg_types[i] == &ffi_type_uint64)
-            giarg.v_uint64 = (guint64)ffi_args[i];
-        else if (cif->arg_types[i] == &ffi_type_float)
-        {
+            giarg.v_uint64 = (guint64) ffi_args[i];
+        else if (cif->arg_types[i] == &ffi_type_float) {
             float val;
             val = *(float *)ffi_args[i];
             giarg.v_float = val;
         }
-        else if (cif->arg_types[i] == &ffi_type_double)
-        {
+        else if (cif->arg_types[i] == &ffi_type_double) {
             float val;
             val = *(double *)ffi_args[i];
             giarg.v_double = val;
         }
-        else
-        {
+        else {
             g_critical("Unhandled FFI type in %s: %d", __FILE__, __LINE__);
             giarg.v_pointer = ffi_args[i];
         }
@@ -87,38 +82,39 @@ void callback_binding(ffi_cif *cif, void *ret, void **ffi_args,
     }
 
     s_ret = scm_c_catch(SCM_BOOL_T,
-        gir_callback_call_proc, SCM_UNPACK_POINTER(scm_cons (gcb->s_func, s_args)),
-        gir_callback_handler_proc, NULL, NULL, NULL);
+                        gir_callback_call_proc, SCM_UNPACK_POINTER(scm_cons(gcb->s_func, s_args)),
+                        gir_callback_handler_proc, NULL, NULL, NULL);
     if (scm_is_false(s_ret))
-        *(ffi_arg *)ret = FALSE;
-    else
-    {
+        *(ffi_arg *) ret = FALSE;
+    else {
         GIArgument giarg;
         GITypeInfo *ret_type_info = g_callable_info_get_return_type(gcb->callback_info);
 
         gi_giargument_convert_return_type_object_to_arg(s_ret,
-                                                               ret_type_info,
-                                                               g_callable_info_get_caller_owns(gcb->callback_info),
-                                                               g_callable_info_may_return_null(gcb->callback_info),
-                                                               g_callable_info_skip_return(gcb->callback_info),
-                                                               &giarg);
+                                                        ret_type_info,
+                                                        g_callable_info_get_caller_owns
+                                                        (gcb->callback_info),
+                                                        g_callable_info_may_return_null
+                                                        (gcb->callback_info),
+                                                        g_callable_info_skip_return
+                                                        (gcb->callback_info), &giarg);
         g_base_info_unref(ret_type_info);
 
         // I'm pretty sure I don't need a big type case/switch block here.
         // I'll try brutally coercing the data, and see what happens.
-        *(ffi_arg *)ret = giarg.v_uint64;
+        *(ffi_arg *) ret = giarg.v_uint64;
     }
 }
 
 static SCM
-gir_callback_call_proc (void *user_data)
+gir_callback_call_proc(void *user_data)
 {
     SCM func_args_pair = SCM_PACK_POINTER(user_data);
     return scm_apply_0(scm_car(func_args_pair), scm_cdr(func_args_pair));
 }
 
 static SCM
-gir_callback_handler_proc (void *user_data, SCM key, SCM params)
+gir_callback_handler_proc(void *user_data, SCM key, SCM params)
 {
     g_critical("scheme procedure threw error in C callback");
     return SCM_BOOL_F;
@@ -126,7 +122,8 @@ gir_callback_handler_proc (void *user_data, SCM key, SCM params)
 
 // This procedure uses CALLBACK_INFO to create a dynamic FFI C closure
 // to use as an entry point to the scheme procedure S_FUNC.
-GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
+GirCallback *
+gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
 {
     GirCallback *gcb = g_new0(GirCallback, 1);
     ffi_type **ffi_args = NULL;
@@ -135,8 +132,7 @@ GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
 
     {
         SCM s_name = scm_procedure_name(s_func);
-        if (scm_is_string(s_name))
-        {
+        if (scm_is_string(s_name)) {
             char *name = scm_to_utf8_string(scm_symbol_to_string(s_name));
             g_debug("Constructing C Callback for %s", name);
             free(name);
@@ -152,8 +148,7 @@ GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
     // STEP 1
     // Allocate the block of memory that FFI uses to hold a closure object,
     // and set a pointer to the corresponding executable address.
-    gcb->closure = ffi_closure_alloc(sizeof(ffi_closure),
-        &(gcb->callback_ptr));
+    gcb->closure = ffi_closure_alloc(sizeof(ffi_closure), &(gcb->callback_ptr));
 
     g_return_val_if_fail(gcb->closure != NULL, NULL);
     g_return_val_if_fail(gcb->callback_ptr != NULL, NULL);
@@ -164,8 +159,7 @@ GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
     // Initialize the argument info vectors.
     if (n_args > 0)
         ffi_args = g_new0(ffi_type *, n_args);
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         GIArgInfo *cb_arg_info = g_callable_info_get_arg(callback_info, i);
         GITypeInfo *cb_type_info = g_arg_info_get_type(cb_arg_info);
         ffi_args[i] = type_info_to_ffi_type(cb_type_info);
@@ -179,30 +173,23 @@ GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
 
     // Initialize the CIF Call Interface Struct.
     ffi_status prep_ok;
-    prep_ok = ffi_prep_cif(&(gcb->cif),
-        FFI_DEFAULT_ABI,
-        n_args,
-        ffi_ret_type,
-        ffi_args);
+    prep_ok = ffi_prep_cif(&(gcb->cif), FFI_DEFAULT_ABI, n_args, ffi_ret_type, ffi_args);
 
     if (prep_ok != FFI_OK)
         scm_misc_error("gir-callback-new",
-            "closure call interface preparation error #~A",
-            scm_list_1(scm_from_int(prep_ok)));
+                       "closure call interface preparation error #~A",
+                       scm_list_1(scm_from_int(prep_ok)));
 
     // STEP 3
     // Initialize the closure
     ffi_status closure_ok;
-    closure_ok = ffi_prep_closure_loc(gcb->closure,
-        &(gcb->cif),
-        callback_binding,
-        gcb,                 // The 'user-data' passed to the function
-        gcb->callback_ptr);
+    closure_ok = ffi_prep_closure_loc(gcb->closure, &(gcb->cif), callback_binding, gcb, // The 'user-data' passed to the function
+                                      gcb->callback_ptr);
 
     if (closure_ok != FFI_OK)
         scm_misc_error("gir-callback-new",
-            "closure location preparation error #~A",
-            scm_list_1(scm_from_int(closure_ok)));
+                       "closure location preparation error #~A",
+                       scm_list_1(scm_from_int(closure_ok)));
 
 #ifdef DEBUG_CALLBACKS
     gcb->callback_info_ptr_as_uint = GPOINTER_TO_UINT(gcb->callback_ptr);
@@ -213,7 +200,8 @@ GirCallback *gir_callback_new(GICallbackInfo *callback_info, SCM s_func)
     return gcb;
 }
 
-void *gir_callback_get_ptr(GICallbackInfo *cb_info, SCM s_func)
+void *
+gir_callback_get_ptr(GICallbackInfo *cb_info, SCM s_func)
 {
     g_assert(cb_info != NULL);
     g_assert(scm_is_true(scm_procedure_p(s_func)));
@@ -226,11 +214,9 @@ void *gir_callback_get_ptr(GICallbackInfo *cb_info, SCM s_func)
 
     // A callback is only a 'match' if it is the same Scheme produre
     // as well as the same GObject C Callback type.
-    while (x != NULL)
-    {
+    while (x != NULL) {
         gcb = x->data;
-        if (scm_is_eq(gcb->s_func, s_func))
-        {
+        if (scm_is_eq(gcb->s_func, s_func)) {
             gcb_typeinfo = g_base_info_get_type(gcb->callback_info);
             if (cb_typeinfo == gcb_typeinfo)
                 return gcb->callback_ptr;
@@ -253,10 +239,8 @@ type_info_to_ffi_type(GITypeInfo *type_info)
     ffi_type *rettype = NULL;
     if (is_ptr)
         return &ffi_type_pointer;
-    else
-    {
-        switch (type_tag)
-        {
+    else {
+        switch (type_tag) {
         case GI_TYPE_TAG_VOID:
             rettype = &ffi_type_void;
             break;
@@ -313,8 +297,7 @@ type_info_to_ffi_type(GITypeInfo *type_info)
                 rettype = &ffi_type_sint;
             else if (base_info_type == GI_INFO_TYPE_FLAGS)
                 rettype = &ffi_type_uint;
-            else
-            {
+            else {
                 g_critical("Unhandled FFI type in %s: %d", __FILE__, __LINE__);
                 g_abort();
             }
@@ -331,8 +314,7 @@ type_info_to_ffi_type(GITypeInfo *type_info)
         case GI_TYPE_TAG_UNICHAR:
             if (sizeof(gunichar) == sizeof(guint32))
                 rettype = &ffi_type_uint32;
-            else
-            {
+            else {
                 g_critical("Unhandled FFI type in %s: %d", __FILE__, __LINE__);
                 g_abort();
             }
@@ -349,18 +331,16 @@ type_info_to_ffi_type(GITypeInfo *type_info)
 static SCM
 scm_is_registered_callback_p(SCM s_proc)
 {
-    if (!scm_is_true(scm_procedure_p (s_proc)))
+    if (!scm_is_true(scm_procedure_p(s_proc)))
         scm_wrong_type_arg_msg("is-registered-callback?", 0, s_proc, "procedure");
 
     // Lookup s_func in the callback cache.
     GSList *x = callback_list;
-    GirCallback *gcb;    
+    GirCallback *gcb;
 
-    while (x != NULL)
-    {
+    while (x != NULL) {
         gcb = x->data;
-        if (scm_is_eq(gcb->s_func, s_proc))
-        {
+        if (scm_is_eq(gcb->s_func, s_proc)) {
             return SCM_BOOL_T;
         }
         x = x->next;
@@ -371,7 +351,7 @@ scm_is_registered_callback_p(SCM s_proc)
 static SCM
 scm_get_registered_callback_closure_pointer(SCM s_proc)
 {
-    if (!scm_is_true(scm_procedure_p (s_proc)))
+    if (!scm_is_true(scm_procedure_p(s_proc)))
         scm_wrong_type_arg_msg("get-registered-callback-closure-pointer", 0, s_proc, "procedure");
 
     // Lookup s_func in the callback cache.
@@ -380,8 +360,7 @@ scm_get_registered_callback_closure_pointer(SCM s_proc)
 
     // If you use the same scheme procedure for different callbacks,
     // you're just going to get one closure pointer.
-    while (x != NULL)
-    {
+    while (x != NULL) {
         gcb = x->data;
         if (scm_is_eq(gcb->s_func, s_proc))
             return scm_from_pointer(gcb->callback_ptr, NULL);
@@ -393,8 +372,7 @@ scm_get_registered_callback_closure_pointer(SCM s_proc)
 void
 gir_init_callback(void)
 {
-    scm_c_define_gsubr("is-registered-callback?", 1, 0, 0,
-        scm_is_registered_callback_p);
+    scm_c_define_gsubr("is-registered-callback?", 1, 0, 0, scm_is_registered_callback_p);
     scm_c_define_gsubr("get-registered-callback-closure-pointer", 1, 0, 0,
-        scm_get_registered_callback_closure_pointer);
+                       scm_get_registered_callback_closure_pointer);
 }

--- a/src/gir_callback.h
+++ b/src/gir_callback.h
@@ -4,27 +4,25 @@
 #include <girepository.h>
 #include <ffi.h>
 #include <libguile.h>
-
-extern SCM gir_callback_type;
-
+ extern SCM gir_callback_type;
+ 
 #define DEBUG_CALLBACKS
-
-typedef struct _GirCallback
+typedef struct _GirCallback 
 {
-    GICallbackInfo *callback_info;
-    ffi_closure *closure;
-    ffi_cif cif;
-    SCM s_func;
-    void *callback_ptr;
+    GICallbackInfo *callback_info;
+     ffi_closure *closure;
+     ffi_cif cif;
+     SCM s_func;
+     void *callback_ptr;
+     
 #ifdef DEBUG_CALLBACKS
-    uint64_t callback_info_ptr_as_uint;
-    uint64_t closure_ptr_as_uint;
-    uint64_t callback_ptr_as_uint;
-#endif    
-    
-} GirCallback;
-
-void gir_init_callback (void);
-void *gir_callback_get_ptr(GICallbackInfo *callback_info, SCM s_func);
-
-#endif
+      uint64_t callback_info_ptr_as_uint;
+     uint64_t closure_ptr_as_uint;
+     uint64_t callback_ptr_as_uint;
+     
+#endif                          /*  */
+ } GirCallback;
+ void gir_init_callback(void);
+void *gir_callback_get_ptr(GICallbackInfo *callback_info, SCM s_func);
+ 
+#endif /*  */

--- a/src/gir_constant.c
+++ b/src/gir_constant.c
@@ -33,8 +33,7 @@ gir_constant_define(GIConstantInfo *info)
 
     g_constant_info_get_value(info, &value);
 
-    switch (typetag)
-    {
+    switch (typetag) {
     case GI_TYPE_TAG_BOOLEAN:
         g_debug("defining boolean constant %s as %d", public_name, value.v_boolean);
         ret = scm_from_bool(value.v_boolean);
@@ -80,8 +79,7 @@ gir_constant_define(GIConstantInfo *info)
         ret = scm_from_utf8_string(value.v_string);
         break;
     default:
-        g_critical("Constant %s has unsupported type %d",
-            public_name, typetag);
+        g_critical("Constant %s has unsupported type %d", public_name, typetag);
         ret = SCM_BOOL_F;
     }
     g_constant_info_free_value(info, &value);
@@ -91,7 +89,8 @@ gir_constant_define(GIConstantInfo *info)
     scm_c_export(public_name, NULL);
 }
 
-void gir_init_constant(void)
+void
+gir_init_constant(void)
 {
-    
+
 }

--- a/src/gir_constant.h
+++ b/src/gir_constant.h
@@ -18,6 +18,11 @@
 #include <girepository.h>
 
 void gir_constant_define(GIConstantInfo *info);
-static inline void gir_constant_document(GString **str, const char *namespace_, const char *parent, GIConstantInfo *info) {}
+static inline void
+gir_constant_document(GString ** str, const char *namespace_, const char *parent,
+                      GIConstantInfo *info)
+{
+}
+
 void gir_init_constant(void);
 #endif

--- a/src/gir_flag.c
+++ b/src/gir_flag.c
@@ -26,25 +26,20 @@ gir_flag_gname_to_scm_constant_name(const char *gname)
     GString *str = g_string_new(NULL);
     gboolean was_lower = FALSE;
 
-    for (size_t i = 0; i < len; i++)
-    {
-        if (g_ascii_islower(gname[i]))
-        {
+    for (size_t i = 0; i < len; i++) {
+        if (g_ascii_islower(gname[i])) {
             g_string_append_c(str, g_ascii_toupper(gname[i]));
             was_lower = TRUE;
         }
-        else if (gname[i] == '_' || gname[i] == '-')
-        {
+        else if (gname[i] == '_' || gname[i] == '-') {
             g_string_append_c(str, '_');
             was_lower = FALSE;
         }
-        else if (g_ascii_isdigit(gname[i]))
-        {
+        else if (g_ascii_isdigit(gname[i])) {
             g_string_append_c(str, gname[i]);
             was_lower = FALSE;
         }
-        else if (g_ascii_isupper(gname[i]))
-        {
+        else if (g_ascii_isupper(gname[i])) {
             if (was_lower)
                 g_string_append_c(str, '_');
             g_string_append_c(str, gname[i]);
@@ -53,8 +48,7 @@ gir_flag_gname_to_scm_constant_name(const char *gname)
     }
 
     char *fptr = strstr(str->str, "_FLAGS");
-    if (fptr)
-    {
+    if (fptr) {
         memcpy(fptr, fptr + 6, str->len - (fptr - str->str) - 6);
         memset(str->str + str->len - 6, 0, 6);
         str->len -= 6;
@@ -76,15 +70,14 @@ gir_flag_public_name(const char *parent, GIBaseInfo *info)
 void
 gir_flag_define(GIEnumInfo *info)
 {
-    g_assert (info != NULL);
+    g_assert(info != NULL);
 
     gint n_values = g_enum_info_get_n_values(info);
     gint i = 0;
     GIValueInfo *vi = NULL;
     char *public_name;
 
-    while (i < n_values)
-    {
+    while (i < n_values) {
         vi = g_enum_info_get_value(info, i);
         public_name = gir_flag_public_name(g_base_info_get_name(info), vi);
         gint64 val = g_value_info_get_value(vi);

--- a/src/gir_flag.h
+++ b/src/gir_flag.h
@@ -18,6 +18,10 @@
 #include <girepository.h>
 
 void gir_flag_define(GIEnumInfo *info);
-static inline void gir_flag_document(GString **str, GIEnumInfo *info) {}
-void gir_init_flag (void);
+static inline void
+gir_flag_document(GString ** str, GIEnumInfo *info)
+{
+}
+
+void gir_init_flag(void);
 #endif

--- a/src/gir_function.h
+++ b/src/gir_function.h
@@ -36,9 +36,9 @@ typedef struct _GirFunction
     ffi_type **atypes;
 } GirFunction;
 
-gchar*
-gir_function_make_name(const char *parent, GIFunctionInfo *info);
-SCM gir_function_invoke (char *name, GICallableInfo *info, GObject *object, SCM args, GError **error);
+gchar *gir_function_make_name(const char *parent, GIFunctionInfo *info);
+SCM gir_function_invoke(char *name, GICallableInfo *info, GObject *object, SCM args,
+                        GError ** error);
 void gir_function_define_gsubr(const char *parent, GIFunctionInfo *info);
 void gir_init_function(void);
 #endif

--- a/src/gir_ginterface.c
+++ b/src/gir_ginterface.c
@@ -8,7 +8,7 @@
 GQuark guginterface_type_key;
 GQuark guginterface_info_key;
 
-static void GuGInterface_finalize (SCM x);
+static void GuGInterface_finalize(SCM x);
 
 ////////////////////////////////////////////////////////////////
 // GuGInterface Type: A foreign object type that in an envelope for a
@@ -47,7 +47,7 @@ SCM GuGInterface_Type_Store;
 #define GUGINTERFACE_N_SLOTS 6
 
 static void
-GuGInterface_finalize (SCM x)
+GuGInterface_finalize(SCM x)
 {
 }
 

--- a/src/gir_ginterface.h
+++ b/src/gir_ginterface.h
@@ -5,5 +5,5 @@
 extern GQuark guginterface_type_key;
 extern SCM GuGInterface_Type;
 
-void gir_init_ginterface (void);
+void gir_init_ginterface(void);
 #endif

--- a/src/gir_method.c
+++ b/src/gir_method.c
@@ -33,7 +33,7 @@ GHashTable *gir_method_hash_table = NULL;
 
 static void gir_fini_method(void);
 
-gchar*
+gchar *
 gir_method_public_name(GICallableInfo *info)
 {
     char *public_name, *tmp_str;
@@ -67,9 +67,8 @@ gir_method_table_insert(GType type, GIFunctionInfo *info)
     GHashTable *subhash = g_hash_table_lookup(gir_method_hash_table,
                                               public_name);
     g_debug("Creating method %s for type %s", public_name, g_type_name(type));
-    if (!subhash)
-    {
-        subhash = g_hash_table_new (g_direct_hash, g_direct_equal);
+    if (!subhash) {
+        subhash = g_hash_table_new(g_direct_hash, g_direct_equal);
         g_hash_table_insert(gir_method_hash_table, public_name, subhash);
     }
     else
@@ -84,8 +83,7 @@ gir_method_lookup(SCM obj, const char *method_name)
 {
     // Look up method by name
     GHashTable *subhash = g_hash_table_lookup(gir_method_hash_table, method_name);
-    if (!subhash)
-    {
+    if (!subhash) {
         g_debug("Could not find a method '%s'", method_name);
         return NULL;
     }
@@ -95,23 +93,16 @@ gir_method_lookup(SCM obj, const char *method_name)
     GHashTableIter iter;
     GType original_type = gir_type_get_gtype_from_obj(obj);
 
-    while (original_type >= 80)
-    {
-        g_hash_table_iter_init (&iter, subhash);
-        while (g_hash_table_iter_next (&iter,
-                                       (gpointer *) (&type),
-                                       (gpointer *) &info))
-        {
+    while (original_type >= 80) {
+        g_hash_table_iter_init(&iter, subhash);
+        while (g_hash_table_iter_next(&iter, (gpointer *) (&type), (gpointer *) & info)) {
             //g_debug("checking if %s should call %s:%s", g_type_name(original_type),
             //        g_type_name(type), method_name);
             //if (g_type_is_a (original_type, type))
             //if (g_type_is_a (type, original_type))
-            if (original_type == type)
-            {
+            if (original_type == type) {
                 g_debug("Matched method %s:%s to object of type %s",
-                        g_type_name(type),
-                        method_name,
-                        g_type_name(original_type));
+                        g_type_name(type), method_name, g_type_name(original_type));
 
                 return info;
             }
@@ -119,8 +110,7 @@ gir_method_lookup(SCM obj, const char *method_name)
         original_type = g_type_parent(original_type);
     }
     g_debug("Could not match any method ::%s to object of type %s",
-            method_name,
-            g_type_name(original_type));
+            method_name, g_type_name(original_type));
     return NULL;
 }
 
@@ -129,24 +119,18 @@ gir_method_explicit_lookup(GType type, const char *method_name)
 {
     // Look up method by name
     GHashTable *subhash = g_hash_table_lookup(gir_method_hash_table, method_name);
-    if (!subhash)
-    {
+    if (!subhash) {
         g_debug("Could not find a method '%s'", method_name);
         return NULL;
     }
 
     GICallableInfo *info;
     info = g_hash_table_lookup(subhash, GSIZE_TO_POINTER(type));
-    if (info)
-    {
-        g_debug("Found method %s::%s",
-                g_type_name(type),
-                method_name);
+    if (info) {
+        g_debug("Found method %s::%s", g_type_name(type), method_name);
         return info;
     }
-    g_debug("Could not find method ::%s of type %s",
-            method_name,
-            g_type_name(type));
+    g_debug("Could not find method ::%s of type %s", method_name, g_type_name(type));
     return NULL;
 }
 
@@ -165,13 +149,12 @@ gir_method_lookup_full(SCM s_object, SCM s_method_name)
     name1 = strtok(method_name, token);
     name2 = strtok(NULL, token);
     if (name2 == NULL)
-        info = gir_method_lookup (s_object, name1);
-    else
-    {
+        info = gir_method_lookup(s_object, name1);
+    else {
         GType type = g_type_from_name(name1);
         info = gir_method_explicit_lookup(type, name2);
     }
-    free (method_name);
+    free(method_name);
     return info;
 }
 
@@ -189,13 +172,10 @@ scm_call_method(SCM s_object, SCM s_method_name, SCM s_list_of_args)
     GICallableInfo *info;
     char *method_name = scm_to_utf8_string(s_method_name);
     info = gir_method_lookup_full(s_object, s_method_name);
-    if (info == NULL)
-    {
+    if (info == NULL) {
         free(method_name);
         scm_misc_error("call-method",
-                       "Cannot find a method '~a' for ~s",
-                       scm_list_2(s_method_name,
-                                  s_object));
+                       "Cannot find a method '~a' for ~s", scm_list_2(s_method_name, s_object));
     }
 
     SCM s_args_str = scm_simple_format(SCM_BOOL_F,
@@ -203,19 +183,16 @@ scm_call_method(SCM s_object, SCM s_method_name, SCM s_list_of_args)
                                        scm_list_1(s_list_of_args));
     char *args_str = scm_to_utf8_string(s_args_str);
     g_debug("Invoking %s%s for object of type %s",
-            method_name,
-            args_str,
-            g_type_name(gir_type_get_gtype_from_obj(s_object)));
+            method_name, args_str, g_type_name(gir_type_get_gtype_from_obj(s_object)));
     free(args_str);
 
     GObject *object = scm_foreign_object_ref(s_object, OBJ_SLOT);
 
     GError *err = NULL;
-    SCM output = gir_function_invoke (method_name, info, object, s_list_of_args, &err);
+    SCM output = gir_function_invoke(method_name, info, object, s_list_of_args, &err);
 
     /* If there is a GError, write an error, free, and exit. */
-    if (err)
-    {
+    if (err) {
         g_debug("Failed to invoke method %s", method_name);
 
         char str[256];
@@ -236,8 +213,8 @@ scm_call_method(SCM s_object, SCM s_method_name, SCM s_list_of_args)
 }
 
 void
-gir_method_document(GString **export, const char *namespace_,
-                   const char *parent, GICallableInfo *info)
+gir_method_document(GString ** export, const char *namespace_,
+                    const char *parent, GICallableInfo *info)
 {
 #if 0
     gint n_args;
@@ -247,20 +224,18 @@ gir_method_document(GString **export, const char *namespace_,
     n_args = g_callable_info_get_n_args(info);
     g_assert(parent != NULL);
 
-    public_name = gir_method_public_name (info);
+    public_name = gir_method_public_name(info);
     lookup_name = g_strdup_printf("%s", g_base_info_get_name(info));
 
     g_string_append_printf(*export, "(define (%s self", public_name);
 
     // Write the docstring
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         GIDirection dir = g_arg_info_get_direction(arg);
         if (dir == GI_DIRECTION_IN
             || dir == GI_DIRECTION_INOUT
-            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg)))
-        {
+            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg))) {
             g_string_append_c(*export, ' ');
             tmp_str = gname_to_scm_name(g_base_info_get_name(arg));
             if (dir == GI_DIRECTION_OUT)
@@ -287,14 +262,12 @@ gir_method_document(GString **export, const char *namespace_,
     g_string_append_printf(*export, "  (gi-method-send self \n");
     g_string_append_printf(*export, "     (gi-method-prepare \"%s\"", lookup_name);
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         GIDirection dir = g_arg_info_get_direction(arg);
         if (dir == GI_DIRECTION_IN
             || dir == GI_DIRECTION_INOUT
-            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg)))
-        {
+            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg))) {
             g_string_append_c(*export, ' ');
             tmp_str = gname_to_scm_name(g_base_info_get_name(arg));
             if (dir == GI_DIRECTION_OUT)
@@ -311,12 +284,10 @@ gir_method_document(GString **export, const char *namespace_,
 #endif
 }
 
-void gir_init_method(void)
+void
+gir_init_method(void)
 {
-    gir_method_hash_table = g_hash_table_new_full (g_str_hash,
-                                                   g_str_equal,
-                                                   g_free,
-                                                   NULL);
+    gir_method_hash_table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
     scm_c_define_gsubr("call-method", 2, 0, 1, scm_call_method);
     scm_c_export("call-method", NULL);
     atexit(gir_fini_method);
@@ -329,18 +300,17 @@ gir_fini_method(void)
     GHashTableIter iter;
     gpointer key, value;
 
-    g_hash_table_iter_init (&iter, gir_method_hash_table);
-    while (g_hash_table_iter_next (&iter, &key, &value))
-    {
+    g_hash_table_iter_init(&iter, gir_method_hash_table);
+    while (g_hash_table_iter_next(&iter, &key, &value)) {
         GHashTable *value_hash = value;
 
         GHashTableIter iter2;
         gpointer key2, value2;
         g_hash_table_iter_init(&iter2, value_hash);
-        while (g_hash_table_iter_next (&iter2, &key2, &value2))
-            g_base_info_unref((GIBaseInfo *) value2);
+        while (g_hash_table_iter_next(&iter2, &key2, &value2))
+            g_base_info_unref((GIBaseInfo *)value2);
         g_hash_table_destroy(value_hash);
     }
-    g_hash_table_destroy (gir_method_hash_table);
+    g_hash_table_destroy(gir_method_hash_table);
     g_debug("Freed method table");
 }

--- a/src/gir_method.h
+++ b/src/gir_method.h
@@ -19,10 +19,9 @@
 #include <girepository.h>
 
 void gir_method_table_insert(GType type, GIFunctionInfo *info);
-void gir_method_document(GString **export, const char *namespace_,
-                   const char *parent, GICallableInfo *info);
-gchar*
-gir_method_public_name(GICallableInfo *info);
+void gir_method_document(GString ** export, const char *namespace_,
+                         const char *parent, GICallableInfo *info);
+gchar *gir_method_public_name(GICallableInfo *info);
 void gir_init_method(void);
 
 #endif

--- a/src/gir_type.h
+++ b/src/gir_type.h
@@ -30,10 +30,10 @@
 
 void gir_type_register(GType gtype);
 void gir_type_define(GType gtype);
-GType scm_to_gtype (SCM x);
+GType scm_to_gtype(SCM x);
 GType gir_type_get_gtype_from_obj(SCM x);
 SCM gir_type_get_scheme_type(GType gtype);
-SCM  gir_type_make_object(GType gtype, gpointer obj, GITransfer transfer);
+SCM gir_type_make_object(GType gtype, gpointer obj, GITransfer transfer);
 void gir_init_types(void);
 
 #endif

--- a/src/gir_typelib.c
+++ b/src/gir_typelib.c
@@ -26,14 +26,14 @@
 #include "gir_flag.h"
 #include "gi_util.h"
 
-static void gir_typelib_document_callback_info(GString **export, const char *namespace_, const char *parent, GICallableInfo *info);
-static void gir_typelib_document_function_info(GString **export,
-                                               const char *parent,
-                                               GIFunctionInfo *info,
-                                               gboolean method);
-static void gir_typelib_document_type(GString **export, char *parent, GITypeInfo *info);
+static void gir_typelib_document_callback_info(GString ** export, const char *namespace_,
+                                               const char *parent, GICallableInfo *info);
+static void gir_typelib_document_function_info(GString ** export, const char *parent,
+                                               GIFunctionInfo *info, gboolean method);
+static void gir_typelib_document_type(GString ** export, char *parent, GITypeInfo *info);
 static void scm_i_typelib_load(const char *subr, const char *namespace, const char *version);
-static void scm_i_typelib_load_check_args (const char *subr, SCM s_lib, SCM s_version, char **lib, char **version);
+static void scm_i_typelib_load_check_args(const char *subr, SCM s_lib, SCM s_version, char **lib,
+                                          char **version);
 
 #define MAX_GERROR_MSG 100
 static char gerror_msg[MAX_GERROR_MSG];
@@ -43,8 +43,7 @@ store_gerror_message(const char *msg)
 {
     memset(gerror_msg, 0, MAX_GERROR_MSG);
     strncpy(gerror_msg, msg, MAX_GERROR_MSG - 1);
-    if (strlen(msg) >= MAX_GERROR_MSG - 1)
-    {
+    if (strlen(msg) >= MAX_GERROR_MSG - 1) {
         gerror_msg[MAX_GERROR_MSG - 2] = '.';
         gerror_msg[MAX_GERROR_MSG - 3] = '.';
         gerror_msg[MAX_GERROR_MSG - 4] = '.';
@@ -62,8 +61,7 @@ scm_typelib_get_search_path(void)
 
     if (slist == NULL)
         return SCM_EOL;
-    do
-    {
+    do {
         entry = scm_from_utf8_string(slist->data);
         output = scm_append(scm_list_2(output, scm_list_1(entry)));
     } while ((slist = g_slist_next(slist)));
@@ -85,22 +83,17 @@ scm_typelib_prepend_search_path(SCM s_dir)
 }
 
 static void
-scm_i_typelib_load_check_args (const char *subr,
-                               SCM s_namespace, SCM s_version,
-                               char **lib, char **version)
+scm_i_typelib_load_check_args(const char *subr,
+                              SCM s_namespace, SCM s_version, char **lib, char **version)
 {
     SCM_ASSERT_TYPE(scm_is_string(s_namespace), s_namespace, SCM_ARG1, subr, "string");
     SCM_ASSERT_TYPE(scm_is_string(s_version), s_version, SCM_ARG2, subr, "string");
 
-    *lib = scm_dynwind_or_bust(subr,
-                               scm_to_utf8_string(s_namespace));
-    *version = scm_dynwind_or_bust(subr,
-                                   scm_to_utf8_string(s_version));
+    *lib = scm_dynwind_or_bust(subr, scm_to_utf8_string(s_namespace));
+    *version = scm_dynwind_or_bust(subr, scm_to_utf8_string(s_version));
 
-    SCM_ASSERT(!strchr(*lib, ' '), s_namespace, SCM_ARG1,
-               subr);
-    SCM_ASSERT(!strchr(*version, ' '), s_version, SCM_ARG2,
-               subr);
+    SCM_ASSERT(!strchr(*lib, ' '), s_namespace, SCM_ARG1, subr);
+    SCM_ASSERT(!strchr(*version, ' '), s_version, SCM_ARG2, subr);
 }
 
 static SCM
@@ -110,22 +103,21 @@ scm_typelib_load(SCM s_namespace, SCM s_version)
     gchar *version;
 
     scm_dynwind_begin(0);
-    scm_i_typelib_load_check_args ("typelib-load", s_namespace, s_version, &namespace_, &version);
-    scm_i_typelib_load ("typelib-load", namespace_, version);
+    scm_i_typelib_load_check_args("typelib-load", s_namespace, s_version, &namespace_, &version);
+    scm_i_typelib_load("typelib-load", namespace_, version);
     scm_dynwind_end();
 
     return SCM_UNSPECIFIED;
 }
 
 static void
-scm_i_typelib_load(const char* subr, const char *namespace_, const char *version)
+scm_i_typelib_load(const char *subr, const char *namespace_, const char *version)
 {
     GITypelib *tl;
     GError *error = NULL;
 
     tl = g_irepository_require(NULL, namespace_, version, 0, &error);
-    if (tl == NULL)
-    {
+    if (tl == NULL) {
         store_gerror_message(error->message);
         g_error_free(error);
         scm_misc_error(subr, gerror_msg, SCM_EOL);
@@ -134,19 +126,16 @@ scm_i_typelib_load(const char* subr, const char *namespace_, const char *version
 
     g_debug("Loading irepository %s %s", namespace_, version);
     int n = g_irepository_get_n_infos(NULL, namespace_);
-    for (int i = 0; i < n; i++)
-    {
+    for (int i = 0; i < n; i++) {
         GIBaseInfo *info;
         GIInfoType type;
         info = g_irepository_get_info(NULL, namespace_, i);
-        if (g_base_info_is_deprecated(info))
-        {
+        if (g_base_info_is_deprecated(info)) {
             g_base_info_unref(info);
             continue;
         }
         type = g_base_info_get_type(info);
-        switch (type)
-        {
+        switch (type) {
         case GI_INFO_TYPE_CALLBACK:
             g_debug("Unsupported irepository type 'CALLBACK'");
             break;
@@ -156,32 +145,28 @@ scm_i_typelib_load(const char* subr, const char *namespace_, const char *version
         case GI_INFO_TYPE_STRUCT:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not loading struct type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 break;
             }
             gir_type_define(gtype);
-            if (g_struct_info_get_size(info) > 0)
-            {
+            if (g_struct_info_get_size(info) > 0) {
                 GQuark size_quark = g_quark_from_string("size");
                 g_type_set_qdata(gtype, size_quark,
                                  GSIZE_TO_POINTER(g_struct_info_get_size(info)));
             }
 
             gint n_methods = g_struct_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_struct_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_method_table_insert(gtype, func_info);
                 else
-                    gir_function_define_gsubr(g_base_info_get_name(info),
-                                              func_info);
+                    gir_function_define_gsubr(g_base_info_get_name(info), func_info);
             }
         }
-        break;
+            break;
         case GI_INFO_TYPE_ENUM:
         case GI_INFO_TYPE_FLAGS:
             gir_flag_define(info);
@@ -189,8 +174,7 @@ scm_i_typelib_load(const char* subr, const char *namespace_, const char *version
         case GI_INFO_TYPE_OBJECT:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not loading object type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 break;
@@ -198,39 +182,32 @@ scm_i_typelib_load(const char* subr, const char *namespace_, const char *version
             gir_type_define(gtype);
 
             gint n_methods = g_object_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_object_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_method_table_insert(gtype, func_info);
                 else
-                    gir_function_define_gsubr(g_base_info_get_name(info),
-                                              func_info);
+                    gir_function_define_gsubr(g_base_info_get_name(info), func_info);
             }
 #if 0
             gint n_signals = g_object_info_get_n_signals(info);
             for (gint m = 0; m < n_signals; m++) {
                 GISignalInfo *sig_info = g_object_info_get_signal(info, m);
                 if (!(g_signal_info_get_flags(sig_info) & G_SIGNAL_DEPRECATED)) {
-                    if (!insert_into_signal_table(gtype,
-                                                  sig_info,
-                                                  &is_new_method))
+                    if (!insert_into_signal_table(gtype, sig_info, &is_new_method))
                         g_base_info_unref(sig_info);
                     else
                         export_signal_info(&export,
-                                           g_base_info_get_name(info),
-                                           sig_info,
-                                           is_new_method);
+                                           g_base_info_get_name(info), sig_info, is_new_method);
                 }
             }
 #endif
         }
-        break;
+            break;
         case GI_INFO_TYPE_INTERFACE:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not loading interface type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 break;
@@ -238,49 +215,42 @@ scm_i_typelib_load(const char* subr, const char *namespace_, const char *version
             gir_type_define(gtype);
 
             gint n_methods = g_interface_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_interface_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_method_table_insert(gtype, func_info);
                 else
-                    gir_function_define_gsubr(g_base_info_get_name(info),
-                                              func_info);
+                    gir_function_define_gsubr(g_base_info_get_name(info), func_info);
             }
         }
-        break;
+            break;
         case GI_INFO_TYPE_CONSTANT:
             gir_constant_define(info);
             break;
         case GI_INFO_TYPE_UNION:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not loading union type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 break;
             }
             gir_type_define(gtype);
-            if (g_union_info_get_size(info) > 0)
-            {
+            if (g_union_info_get_size(info) > 0) {
                 GQuark size_quark = g_quark_from_string("size");
-                g_type_set_qdata(gtype, size_quark,
-                                 GSIZE_TO_POINTER(g_union_info_get_size(info)));
+                g_type_set_qdata(gtype, size_quark, GSIZE_TO_POINTER(g_union_info_get_size(info)));
             }
 
             gint n_methods = g_union_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_union_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_method_table_insert(gtype, func_info);
                 else
-                    gir_function_define_gsubr(g_base_info_get_name(info),
-                                              func_info);
+                    gir_function_define_gsubr(g_base_info_get_name(info), func_info);
             }
         }
-        break;
+            break;
         case GI_INFO_TYPE_VALUE:
             g_critical("Unsupported irepository type 'VALUE'");
             break;
@@ -327,8 +297,7 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
     version = scm_to_utf8_string(s_version);
 
     tl = g_irepository_require(NULL, namespace_, version, 0, &error);
-    if (tl == NULL)
-    {
+    if (tl == NULL) {
         free(version);
         free(namespace_);
         store_gerror_message(error->message);
@@ -341,13 +310,11 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
     g_string_append_printf(export, "%s %s\n\n", namespace_, version);
 
     int n = g_irepository_get_n_infos(NULL, namespace_);
-    for (int i = 0; i < n; i++)
-    {
+    for (int i = 0; i < n; i++) {
         GIBaseInfo *info;
         GIInfoType type;
         info = g_irepository_get_info(NULL, namespace_, i);
-        if (g_base_info_is_deprecated(info))
-        {
+        if (g_base_info_is_deprecated(info)) {
             g_string_append_printf(export,
                                    "Not importing '%s' because it is deprecated.\n\n",
                                    g_base_info_get_name(info));
@@ -355,8 +322,7 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
             continue;
         }
         type = g_base_info_get_type(info);
-        switch (type)
-        {
+        switch (type) {
         case GI_INFO_TYPE_CALLBACK:
             gir_typelib_document_callback_info(&export, namespace_, NULL, info);
             break;
@@ -366,8 +332,7 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
         case GI_INFO_TYPE_STRUCT:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not importing struct type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 g_base_info_unref(info);
@@ -376,21 +341,18 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
             g_base_info_ref(info);
             gir_typelib_document_type(&export, NULL, info);
             gint n_methods = g_struct_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_struct_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info)
                     & GI_FUNCTION_IS_METHOD)
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 1);
+                                                       g_base_info_get_name(info), func_info, 1);
                 else
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 0);
+                                                       g_base_info_get_name(info), func_info, 0);
             }
         }
-        break;
+            break;
         case GI_INFO_TYPE_ENUM:
         case GI_INFO_TYPE_FLAGS:
             gir_flag_document(&export, info);
@@ -398,8 +360,7 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
         case GI_INFO_TYPE_OBJECT:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not importing object type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 g_base_info_unref(info);
@@ -407,37 +368,30 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
             }
             gir_typelib_document_type(&export, NULL, info);
             gint n_methods = g_object_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_object_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 1);
+                                                       g_base_info_get_name(info), func_info, 1);
                 else
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 0);
+                                                       g_base_info_get_name(info), func_info, 0);
             }
 #if 0
             gint n_signals = g_object_info_get_n_signals(info);
             for (gint m = 0; m < n_signals; m++) {
                 GISignalInfo *sig_info = g_object_info_get_signal(info, m);
                 if (!(g_signal_info_get_flags(sig_info) & G_SIGNAL_DEPRECATED)) {
-                    if (!insert_into_signal_table(gtype,
-                                                  sig_info,
-                                                  &is_new_method))
+                    if (!insert_into_signal_table(gtype, sig_info, &is_new_method))
                         g_base_info_unref(sig_info);
                     else
                         export_signal_info(&export,
-                                           g_base_info_get_name(info),
-                                           sig_info,
-                                           is_new_method);
+                                           g_base_info_get_name(info), sig_info, is_new_method);
                 }
             }
 #endif
         }
-        break;
+            break;
         case GI_INFO_TYPE_INTERFACE:
             // export_interface_info(&export, g_base_info_get_name(info), info);
             break;
@@ -447,8 +401,7 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
         case GI_INFO_TYPE_UNION:
         {
             GType gtype = g_registered_type_info_get_g_type(info);
-            if (gtype == G_TYPE_NONE)
-            {
+            if (gtype == G_TYPE_NONE) {
                 g_debug("Not importing union type '%s' because is has no GType",
                         g_base_info_get_name(info));
                 g_base_info_unref(info);
@@ -456,20 +409,17 @@ scm_typelib_document(SCM s_namespace, SCM s_version)
             }
             gir_typelib_document_type(&export, NULL, info);
             gint n_methods = g_union_info_get_n_methods(info);
-            for (gint m = 0; m < n_methods; m++)
-            {
+            for (gint m = 0; m < n_methods; m++) {
                 GIFunctionInfo *func_info = g_union_info_get_method(info, m);
                 if (g_function_info_get_flags(func_info) & GI_FUNCTION_IS_METHOD)
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 1);
+                                                       g_base_info_get_name(info), func_info, 1);
                 else
                     gir_typelib_document_function_info(&export,
-                                                       g_base_info_get_name(info),
-                                                       func_info, 0);
+                                                       g_base_info_get_name(info), func_info, 0);
             }
         }
-        break;
+            break;
         case GI_INFO_TYPE_VALUE:
             g_critical("Unsupported irepository type 'VALUE'");
             break;
@@ -515,7 +465,7 @@ static GPtrArray *gi_arg_infos = NULL;
 #endif
 
 static void
-gir_typelib_document_callable_arguments(GString **export, GICallableInfo *info, gboolean style)
+gir_typelib_document_callable_arguments(GString ** export, GICallableInfo *info, gboolean style)
 {
     gint n_args;
     GIArgInfo *arg;
@@ -530,14 +480,12 @@ gir_typelib_document_callable_arguments(GString **export, GICallableInfo *info, 
     else
         g_string_append(*export, "   ARGS: \n");
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         dir = g_arg_info_get_direction(arg);
         type_info = g_arg_info_get_type(arg);
         if (!(dir == GI_DIRECTION_OUT)
-            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg)))
-        {
+            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg))) {
             if (style)
                 g_string_append(*export, ";;   ");
             else
@@ -574,13 +522,11 @@ gir_typelib_document_callable_arguments(GString **export, GICallableInfo *info, 
                                g_type_info_is_pointer(type_info) ? "*" : "");
     g_base_info_unref(type_info);
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         dir = g_arg_info_get_direction(arg);
         type_info = g_arg_info_get_type(arg);
-        if (dir == GI_DIRECTION_OUT && !g_arg_info_is_caller_allocates(arg))
-        {
+        if (dir == GI_DIRECTION_OUT && !g_arg_info_is_caller_allocates(arg)) {
             if (style)
                 g_string_append(*export, ";;   ");
             else
@@ -613,14 +559,12 @@ callback_public_name(const char *namespace_, const char *parent, GICallableInfo 
     char *public_name;
     char *tmp_str;
 
-    if (parent)
-    {
+    if (parent) {
         tmp_str = g_strdup_printf("%s-%s", parent, g_base_info_get_name(info));
         public_name = gname_to_scm_name(tmp_str);
         g_free(tmp_str);
     }
-    else
-    {
+    else {
         tmp_str = g_strdup_printf("%s", g_base_info_get_name(info));
         public_name = gname_to_scm_name(tmp_str);
         g_free(tmp_str);
@@ -629,7 +573,8 @@ callback_public_name(const char *namespace_, const char *parent, GICallableInfo 
 }
 
 static void
-gir_typelib_document_callback_info(GString **export, const char *namespace_, const char *parent, GICallableInfo *info)
+gir_typelib_document_callback_info(GString ** export, const char *namespace_, const char *parent,
+                                   GICallableInfo *info)
 {
     char *lookup_name;
     char *public_name;
@@ -654,10 +599,8 @@ gir_typelib_document_callback_info(GString **export, const char *namespace_, con
 }
 
 static void
-gir_typelib_document_function_info(GString **export,
-                                   const char *parent,
-                                   GIFunctionInfo *info,
-                                   gboolean method)
+gir_typelib_document_function_info(GString ** export,
+                                   const char *parent, GIFunctionInfo *info, gboolean method)
 {
     gint n_args;
     GIArgInfo *arg;
@@ -677,13 +620,11 @@ gir_typelib_document_function_info(GString **export,
     else
         g_string_append_printf(*export, "PROCEDURE %s", public_name);
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         GIDirection dir = g_arg_info_get_direction(arg);
         if (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT
-            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg)))
-        {
+            || (dir == GI_DIRECTION_OUT && g_arg_info_is_caller_allocates(arg))) {
             char *arg_name;
             g_string_append_c(*export, ' ');
             arg_name = gname_to_scm_name(g_base_info_get_name(arg));
@@ -713,17 +654,16 @@ gir_typelib_document_function_info(GString **export,
 }
 
 static void
-gir_typelib_document_type(GString **export, char *parent, GITypeInfo *info)
+gir_typelib_document_type(GString ** export, char *parent, GITypeInfo *info)
 {
     g_string_append_printf(*export, "TYPE <%s> with PREDICATE '%s?'\n\n",
-                           g_base_info_get_name(info),
-                           g_base_info_get_name(info));
+                           g_base_info_get_name(info), g_base_info_get_name(info));
 }
 
 /* FIXME: this is a very sigmal way to export signal info */
 #if 0
 static void
-export_signal_info(GString **export, char *parent, GISignalInfo *info)
+export_signal_info(GString ** export, char *parent, GISignalInfo *info)
 {
     gint n_args;
     GIArgInfo *arg;
@@ -743,18 +683,17 @@ export_signal_info(GString **export, char *parent, GISignalInfo *info)
 
     GITypeInfo *return_type = g_callable_info_get_return_type(info);
     g_assert(return_type);
-    if (g_type_info_get_tag(return_type) == GI_TYPE_TAG_BOOLEAN && !g_type_info_is_pointer(return_type))
+    if (g_type_info_get_tag(return_type) == GI_TYPE_TAG_BOOLEAN &&
+        !g_type_info_is_pointer(return_type))
         g_string_append_c(*export, '?');
     g_base_info_unref(return_type);
 
     g_string_append_printf(*export, " self");
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         GIDirection dir = g_arg_info_get_direction(arg);
-        if (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT)
-        {
+        if (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT) {
             g_string_append_c(*export, ' ');
             name = gname_to_scm_name(g_base_info_get_name(arg));
             g_string_append(*export, name);
@@ -769,12 +708,10 @@ export_signal_info(GString **export, char *parent, GISignalInfo *info)
     g_string_append_printf(*export, "  (gi-signal-send self \n");
     g_string_append_printf(*export, "     (gi-signal-prepare \"%s\"", g_base_info_get_name(info));
 
-    for (int i = 0; i < n_args; i++)
-    {
+    for (int i = 0; i < n_args; i++) {
         arg = g_callable_info_get_arg(info, i);
         GIDirection dir = g_arg_info_get_direction(arg);
-        if (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT)
-        {
+        if (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT) {
             g_string_append_c(*export, ' ');
             name = gname_to_scm_name(g_base_info_get_name(arg));
             g_string_append(*export, name);
@@ -797,8 +734,7 @@ scm_dump_all_arg_types(void)
 
     FILE *fp = fopen("arg_infos.txt", "wt");
 
-    for (guint i = 0; i < len; i++)
-    {
+    for (guint i = 0; i < len; i++) {
         struct _arg_info_func_name *aifn = gi_arg_infos->pdata[i];
         GIArgInfo *ai = aifn->ai;
         GIDirection dir = g_arg_info_get_direction(ai);
@@ -820,9 +756,9 @@ scm_dump_all_arg_types(void)
         else if (dir == GI_DIRECTION_OUT)
             fprintf(fp, "OUT   ");
 
-        if (g_type_info_get_tag(ti) == GI_TYPE_TAG_ARRAY)
-        {
-            fprintf(fp, "LEN %3d SIZE %3d ", g_type_info_get_array_length(ti), g_type_info_get_array_fixed_size(ti));
+        if (g_type_info_get_tag(ti) == GI_TYPE_TAG_ARRAY) {
+            fprintf(fp, "LEN %3d SIZE %3d ", g_type_info_get_array_length(ti),
+                    g_type_info_get_array_fixed_size(ti));
             if (g_type_info_is_zero_terminated(ti))
                 fprintf(fp, "ZERO_TERM ");
             else
@@ -844,8 +780,7 @@ scm_dump_all_arg_types(void)
             else
                 fprintf(fp, "  ");
             GIBaseInfo *pbi = g_type_info_get_interface(pti);
-            if (pbi)
-            {
+            if (pbi) {
                 GIInfoType pit = g_base_info_get_type(pbi);
                 if (pit == GI_INFO_TYPE_INVALID)
                     fprintf(fp, "INVALID   ");
@@ -888,8 +823,7 @@ scm_dump_all_arg_types(void)
         }
 
         GIBaseInfo *bi = g_type_info_get_interface(ti);
-        if (bi)
-        {
+        if (bi) {
             GIInfoType it = g_base_info_get_type(bi);
             if (it == GI_INFO_TYPE_INVALID)
                 fprintf(fp, "INVALID   ");
@@ -961,52 +895,53 @@ scm_dump_all_arg_types(void)
 #endif
 
 static void
-scm_typelib_do_define_module (void *data)
+scm_typelib_do_define_module(void *data)
 {
     const char **real_data = data;
-    scm_i_typelib_load ("%typelib-define-module", real_data[0], real_data[1]);
+    scm_i_typelib_load("%typelib-define-module", real_data[0], real_data[1]);
 }
 
 static SCM
-scm_typelib_define_module (SCM s_lib, SCM s_version)
+scm_typelib_define_module(SCM s_lib, SCM s_version)
 {
     gchar *name, *data[2];
 
-    scm_dynwind_begin (0);
-    scm_i_typelib_load_check_args ("%typelib-define-module", s_lib, s_version, data, data + 1);
+    scm_dynwind_begin(0);
+    scm_i_typelib_load_check_args("%typelib-define-module", s_lib, s_version, data, data + 1);
     name = scm_dynwind_or_bust("%typelib-define-module",
                                g_strdup_printf("%%gi %s-%s", data[0], data[1]));
-    scm_c_define_module (name, scm_typelib_do_define_module, data);
+    scm_c_define_module(name, scm_typelib_do_define_module, data);
 
-    scm_dynwind_end ();
+    scm_dynwind_end();
     return SCM_UNSPECIFIED;
 }
 
 static SCM
-scm_typelib_module_name (SCM s_lib, SCM s_version)
+scm_typelib_module_name(SCM s_lib, SCM s_version)
 {
     gchar *name, *lib, *version;
     SCM ret;
 
-    scm_dynwind_begin (0);
-    scm_i_typelib_load_check_args ("%typelib-module-name", s_lib, s_version, &lib, &version);
+    scm_dynwind_begin(0);
+    scm_i_typelib_load_check_args("%typelib-module-name", s_lib, s_version, &lib, &version);
     name = g_strdup_printf("%s-%s", lib, version);
 
-    ret = scm_list_2(scm_from_utf8_symbol("%gi"),
-                     scm_from_utf8_symbol(name));
+    ret = scm_list_2(scm_from_utf8_symbol("%gi"), scm_from_utf8_symbol(name));
 
-    scm_dynwind_end ();
+    scm_dynwind_end();
     return ret;
 }
 
-void gir_init_typelib_private(void)
+void
+gir_init_typelib_private(void)
 {
     scm_c_define_gsubr("%typelib-module-name", 2, 0, 0, scm_typelib_module_name);
     scm_c_define_gsubr("%typelib-define-module", 2, 0, 0, scm_typelib_define_module);
 }
 
 
-void gir_init_typelib(void)
+void
+gir_init_typelib(void)
 {
 #ifdef FIGURE_OUT_ALL_ARG_TYPES
     gi_arg_infos = g_ptr_array_new();
@@ -1017,8 +952,5 @@ void gir_init_typelib(void)
     scm_c_define_gsubr("typelib-document", 2, 0, 0, scm_typelib_document);
 
     scm_c_export("typelib-get-search-path",
-                 "typelib-prepend-search-path",
-                 "typelib-load",
-                 "typelib-document",
-                 NULL);
+                 "typelib-prepend-search-path", "typelib-load", "typelib-document", NULL);
 }

--- a/src/gir_typelib.h
+++ b/src/gir_typelib.h
@@ -16,6 +16,6 @@
 #ifndef _GIR_TYPELIB_H
 #define _GIR_TYPELIB_H
 
-void  gir_init_typelib(void);
+void gir_init_typelib(void);
 
 #endif


### PR DESCRIPTION
This adds a test for the GResource API (basically cloning the GtkBuilder test), moves typelib module defining code to C instead of using weird eval hacks and indents the code using GNU indent.

I tried using the provided clang-format file (and even adapting it to have less "false positives"), but I gave up when it came to case formatting (which will eventually come with clang 9, but compiling clang would take hours vs. a few minutes for indent, plus indent 2.2.12 exists in Guix). Indent seems to handle cases just fine (at least with the bugfix in 2.2.12) and only really suffers with attributes, around which formatting can be disabled.