### PR TITLE
I guess this handles array size parameters

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -165,3 +165,6 @@ check-syntax:
 	$(CC) -std=c11 $(GUILE_CFLAGS) $(GLIB_CFLAGS) $(GOBJECT_CFLAGS) \
 	 $(GOBJECT_INTROSPECTION_CFLAGS) $(FFI_CFLAGS) \
 	 -DG_LOG_DOMAIN=\"GuileGI\" $(CFLAGS) -fsyntax-only $(CHK_SOURCES)
+
+indent:
+	VERSION_CONTROL=none indent $(libguile_gi_la_SOURCES)

--- a/src/gi_giargument.c
+++ b/src/gi_giargument.c
@@ -242,16 +242,14 @@ static size_t
 array_length(struct array_info *ai, GIArgument *arg)
 {
     size_t array_length = array_length_1(ai, arg);
-    if (ai->array_length != -1 &&
-        ai->array_length != array_length)
-        g_warning ("mismatching array lengths: expected %zd, but got %zd",
-                   ai->array_length, array_length);
-    if (ai->array_fixed_size != -1 &&
-        ai->array_fixed_size != array_length)
-        g_warning ("mismatching array lengths: expected %zd, but got %zd",
-                   ai->array_fixed_size, array_length);
+    if (ai->array_length != -1 && ai->array_length != array_length)
+        g_warning("mismatching array lengths: expected %zd, but got %zd",
+                  ai->array_length, array_length);
+    if (ai->array_fixed_size != -1 && ai->array_fixed_size != array_length)
+        g_warning("mismatching array lengths: expected %zd, but got %zd",
+                  ai->array_fixed_size, array_length);
     if (array_length == 0)
-        g_debug ("array has length 0, are you sure about that?");
+        g_debug("array has length 0, are you sure about that?");
     return array_length;
 }
 
@@ -1413,25 +1411,25 @@ object_to_c_native_string_array_arg(char *subr, int argpos,
         SCM iter = object;
 
         for (size_t i = 0; i < len; i++) {
-            SCM entry = scm_car (iter);
+            SCM entry = scm_car(iter);
             if (ai->item_type_tag == GI_TYPE_TAG_FILENAME)
                 strv[i] = scm_to_locale_string(entry);
             else
                 strv[i] = scm_to_utf8_string(entry);
-            iter = scm_cdr (iter);
+            iter = scm_cdr(iter);
         }
         strv[len] = NULL;
         arg->v_pointer = strv;
         if (ai->item_transfer == GI_TRANSFER_NOTHING)
             ai->must_free = GIR_FREE_STRV;
     }
-    else if (scm_is_vector (object)) {
+    else if (scm_is_vector(object)) {
         scm_t_array_handle handle;
         gsize len;
         gssize inc;
         const SCM *elt;
 
-        elt = scm_vector_elements (object, &handle, &len, &inc);
+        elt = scm_vector_elements(object, &handle, &len, &inc);
         gchar **strv = g_new0(gchar *, len + 1);
 
         for (size_t i = 0; i < len; i++, elt += inc) {
@@ -1446,7 +1444,7 @@ object_to_c_native_string_array_arg(char *subr, int argpos,
         if (ai->item_transfer == GI_TRANSFER_NOTHING)
             ai->must_free = GIR_FREE_STRV;
 
-        scm_array_handle_release (&handle);
+        scm_array_handle_release(&handle);
     }
     else
         scm_wrong_type_arg_msg(subr, argpos, object, "list or vector of strings");

--- a/src/gi_gvalue.c
+++ b/src/gi_gvalue.c
@@ -553,7 +553,7 @@ gi_gvalue_to_scm_structured_type(const GValue *value, GType fundamental, gboolea
             return gi_gvalue_as_scm(n_value, copy_boxed);
         }
         else if (G_VALUE_HOLDS(value, G_TYPE_GSTRING)) {
-            GString *string = (GString *) g_value_get_boxed(value);
+            GString *string = (GString *)g_value_get_boxed(value);
             return scm_from_utf8_stringn(string->str, string->len);
         }
         else {

--- a/src/gir_constant.h
+++ b/src/gir_constant.h
@@ -19,7 +19,7 @@
 
 void gir_constant_define(GIConstantInfo *info);
 static inline void
-gir_constant_document(GString ** str, const char *namespace_, const char *parent,
+gir_constant_document(GString **str, const char *namespace_, const char *parent,
                       GIConstantInfo *info)
 {
 }

--- a/src/gir_flag.h
+++ b/src/gir_flag.h
@@ -19,7 +19,7 @@
 
 void gir_flag_define(GIEnumInfo *info);
 static inline void
-gir_flag_document(GString ** str, GIEnumInfo *info)
+gir_flag_document(GString **str, GIEnumInfo *info)
 {
 }
 

--- a/src/gir_method.h
+++ b/src/gir_method.h
@@ -23,6 +23,6 @@ void gir_method_document(GString **export, const char *namespace_, const char *p
                          GICallableInfo *info);
 void gir_init_method(void);
 
-G_GNUC_MALLOC gchar * gir_method_public_name(GICallableInfo *info);
+G_GNUC_MALLOC gchar *gir_method_public_name(GICallableInfo *info);
 
 #endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -137,6 +137,8 @@ BYTE_ARRAY_TESTS = \
  byte_array/bytes_new_null_contents.scm
 
 GAPPLICATION_TESTS = \
+ gapplication/command-line.scm \
+ gapplication/command-line-options.scm \
  gapplication/create1.scm \
  gapplication/create2.scm \
  gapplication/set_resource_path.scm
@@ -189,6 +191,7 @@ TESTS = \
  misc/use-typelibs.scm
 
 XFAIL_TESTS = \
+ gapplication/command-line.scm \
  grilo/init_commandline.scm \
  misc/atomic_int_set.scm \
  string/strjoinv.scm

--- a/test/gapplication/command-line-options.scm
+++ b/test/gapplication/command-line-options.scm
@@ -1,0 +1,26 @@
+(use-modules (gi)
+             (test automake-test-lib)
+             (srfi srfi-43))
+
+(automake-test
+ (begin
+   (use-typelibs ("GLib" "2.0") ("Gio" "2.0"))
+   (let ((app (make-gobject (get-gtype <GApplication>)
+                            `(("application-id" . "gi.guile.Example")
+                              ("flags" . ,APPLICATION_HANDLES_COMMAND_LINE))))
+         (success #f))
+     (send app (add-main-option "hello" (char->integer #\h) 0
+                                OPTION_ARG_STRING_ARRAY "" #f))
+
+     (connect app (command-line
+                   (lambda (app command-line data)
+                     (let* ((dict (send command-line (get-options-dict)))
+                            (hello (send dict (lookup-value "hello" #f)))
+                            (args (send hello (get-strv))))
+                       (vector-for-each (lambda (i arg) (format #t "Hello, ~a~%" arg))
+                                        args)
+                       (set! success (vector= string=? args #("world" "darkness, my old friend"))))
+                     (send app (quit))
+                     0)))
+     (send app (run 5 #("command-line" "-h" "world" "-h" "darkness, my old friend")))
+     success)))

--- a/test/gapplication/command-line.scm
+++ b/test/gapplication/command-line.scm
@@ -1,0 +1,22 @@
+(use-modules (gi)
+             (test automake-test-lib)
+             (srfi srfi-43))
+
+(automake-test
+ (begin
+   (typelib-load "Gio" "2.0")
+   (let ((app (make-gobject (get-gtype <GApplication>)
+                            `(("application-id" . "gi.guile.Example")
+                              ("flags" . ,APPLICATION_HANDLES_COMMAND_LINE))))
+         (success #f))
+     (connect app (command-line
+                   (lambda (app command-line data)
+                     (let ((args (send  command-line (get-arguments))))
+                       (vector-for-each (lambda (world)
+                                          (format #t "Hello, ~a~%" world))
+                                        args)
+                       (send app (quit))
+                       (set! success (vector= string=? args #("world" "darkness, my old friend")))
+                       0))))
+     (send app (run 3 #("hello" "world" "darkness, my old friend")))
+     success)))

--- a/test/gapplication/set_resource_path.scm
+++ b/test/gapplication/set_resource_path.scm
@@ -9,10 +9,10 @@
          (result #f))
      (connect app (activate
                    (lambda (app user-data)
-                     (gobject-set-property! app "resource_base_path"
+                     (gobject-set-property! app "resource-base-path"
                                             "/gi/guile/resource/base_path")
                      (set! result
-                           (equal? (gobject-get-property app "resource_base_path")
+                           (equal? (gobject-get-property app "resource-base-path")
                                    "/gi/guile/resource/base_path"))
                      (send app (quit)))))
      (send app (run (length (command-line)) (command-line)))

--- a/test/string/str_tokenize_and_fold.scm
+++ b/test/string/str_tokenize_and_fold.scm
@@ -2,7 +2,7 @@
              (rnrs bytevectors)
              (test automake-test-lib)
              (ice-9 receive)
-             (srfi srfi-1))
+             (srfi srfi-43))
 
 ;; FIXME: the ascii-alternates output parameter
 ;; is from a gchar*** output parameter.  This is
@@ -19,4 +19,4 @@
    (write tokens) (newline)
      (write ascii-alternates) (newline)
      ;; take case-folding into account
-     (every string-ci=? (list "Les" "pâtes") tokens)))
+     (vector= string-ci=? #("Les" "pâtes") tokens)))


### PR DESCRIPTION
It turns out my array_length function really wasn't the robustest in the world. Commit 9d7d011 should fix this. It's not awfully an awfully clean commit, given that the tests depend on the array to vector conversion in the previous one, but that should be easy to fix if you wish to cherry-pick just this single commit. 