### PR TITLE
Export properties as generics

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ libguile_gi_la_SOURCES = \
  gig_callback.h \
  gig_function.c \
  gig_function.h \
+ gig_function_private.h \
  gig_constant.c \
  gig_constant.h \
  gig_flag.c \

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -490,7 +490,8 @@ function_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     g_debug("Binding C function %s as %s with %d args", g_base_info_get_name(gfn->function_info),
             gfn->name, n_args);
 
-    g_assert(n_args < 20);
+    // we have either 0 args or 1 args, which is the already packed list
+    g_assert(n_args <= 1);
 
     if (n_args)
         s_args = SCM_PACK(*(scm_t_bits *) (ffi_args[0]));

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -74,7 +74,7 @@ current_module_definition(SCM name)
     return SCM_BOOL_F;
 }
 
-static SCM
+SCM
 default_definition(SCM name)
 {
     LOOKUP_DEFINITION(scm_c_resolve_module("gi"));

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -19,6 +19,7 @@
 #include "gig_util.h"
 #include "gig_arg_map.h"
 #include "gig_function.h"
+#include "gig_function_private.h"
 #include "gig_type.h"
 #include "gig_signal.h"
 
@@ -34,20 +35,6 @@ typedef struct _GigFunction
 } GigFunction;
 
 GHashTable *function_cache;
-
-static SCM generic_table;
-
-static SCM ensure_generic_proc;
-static SCM make_proc;
-static SCM add_method_proc;
-
-static SCM top_type;
-static SCM method_type;
-
-static SCM kwd_specializers;
-static SCM kwd_formals;
-static SCM kwd_procedure;
-
 
 static GigGsubr *check_gsubr_cache(GICallableInfo *function_info, SCM self_type,
                                    gint *required_input_count, gint *optional_input_count,
@@ -270,7 +257,7 @@ make_formals(GICallableInfo *callable,
     i_specializer = *specializers = scm_make_list(scm_from_int(n_inputs), top_type);
 
     if (g_callable_info_is_method(callable)) {
-        scm_set_car_x(i_formal, scm_from_utf8_symbol("self"));
+        scm_set_car_x(i_formal, sym_self);
         scm_set_car_x(i_specializer, self_type);
 
         i_formal = scm_cdr(i_formal);
@@ -676,6 +663,8 @@ gig_init_function(void)
     kwd_specializers = scm_from_utf8_keyword("specializers");
     kwd_formals = scm_from_utf8_keyword("formals");
     kwd_procedure = scm_from_utf8_keyword("procedure");
+
+    sym_self = scm_from_utf8_symbol("self");
 
     atexit(gig_fini_function);
 }

--- a/src/gig_function_private.h
+++ b/src/gig_function_private.h
@@ -1,0 +1,19 @@
+#ifndef GIG_FUNCTION_PRIVATE_H
+#define GIG_FUNCTION_PRIVATE_H
+
+SCM generic_table;
+
+SCM ensure_generic_proc;
+SCM make_proc;
+SCM add_method_proc;
+
+SCM top_type;
+SCM method_type;
+
+SCM kwd_specializers;
+SCM kwd_formals;
+SCM kwd_procedure;
+
+SCM sym_self;
+
+#endif

--- a/src/gig_function_private.h
+++ b/src/gig_function_private.h
@@ -16,4 +16,6 @@ SCM kwd_procedure;
 
 SCM sym_self;
 
+SCM default_definition(SCM name);
+
 #endif

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -600,7 +600,11 @@ do_define_property(const gchar *public_name, SCM prop, SCM self_type, SCM value_
     sym_public_name = scm_from_utf8_symbol(public_name);
 
     SCM old_generic = scm_hashq_ref(generic_table, sym_public_name, SCM_BOOL_F);
-    generic = scm_call_2(ensure_accessor_proc, old_generic, sym_public_name);
+    if (!scm_is_generic(old_generic))
+        generic = scm_call_2(ensure_accessor_proc, default_definition(sym_public_name),
+                             sym_public_name);
+    else
+        generic = scm_call_2(ensure_accessor_proc, old_generic, sym_public_name);
     was_accessor = scm_is_eq(old_generic, generic);
 
     // getter

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -575,6 +575,7 @@ gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace)
     prop = g_object_class_find_property(class, name);
     g_assert(prop != NULL);
 
+    gig_type_define(G_PARAM_SPEC_TYPE(prop));
     s_prop = gig_type_transfer_object(G_PARAM_SPEC_TYPE(prop), prop, GI_TRANSFER_NOTHING);
     // This should not conflict with anything else defined in a class
     scm_c_define(long_name, s_prop);

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -549,6 +549,9 @@ gig_i_scm_emit(SCM self, SCM signal, SCM s_detail, SCM args)
 }
 
 static SCM sym_value;
+static SCM ensure_accessor_proc;
+
+static void do_define_property(const gchar *, SCM, SCM, SCM);
 
 void
 gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace)
@@ -561,10 +564,9 @@ gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace)
     const gchar *name = g_base_info_get_name(info);
     gchar *long_name;
 
-    scm_dynwind_begin(0);
+    SCM self_type = gig_type_get_scheme_type(type);
 
-    formals = scm_list_2(sym_self, sym_value);
-    specializers = scm_list_2(gig_type_get_scheme_type(type), top_type);
+    scm_dynwind_begin(0);
 
     class = g_type_class_ref(type);
     scm_dynwind_unwind_handler(g_type_class_unref, class, SCM_F_WIND_EXPLICITLY);
@@ -578,11 +580,57 @@ gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace)
     gig_type_define(G_PARAM_SPEC_TYPE(prop));
     s_prop = gig_type_transfer_object(G_PARAM_SPEC_TYPE(prop), prop, GI_TRANSFER_NOTHING);
     // This should not conflict with anything else defined in a class
-    scm_c_define(long_name, s_prop);
-    scm_c_export(long_name, NULL);
+
+    do_define_property(long_name, s_prop, self_type, top_type);
     g_debug("dynamically bound %s to property %s of %s", long_name, name, g_type_name(type));
+    do_define_property(name, s_prop, self_type, top_type);
+    g_debug("dynamically bound %s to property %s of %s", name, name, g_type_name(type));
 
     scm_dynwind_end();
+}
+
+static void
+do_define_property(const gchar *public_name, SCM prop, SCM self_type, SCM value_type)
+{
+    g_return_if_fail(public_name != NULL);
+
+    SCM sym_public_name, formals, specializers, generic, proc, setter;
+    gboolean was_accessor = FALSE;
+
+    sym_public_name = scm_from_utf8_symbol(public_name);
+
+    SCM old_generic = scm_hashq_ref(generic_table, sym_public_name, SCM_BOOL_F);
+    generic = scm_call_2(ensure_accessor_proc, old_generic, sym_public_name);
+    was_accessor = scm_is_eq(old_generic, generic);
+
+    // getter
+    proc = scm_procedure(prop);
+    formals = scm_list_1(sym_self);
+    specializers = scm_list_1(self_type);
+
+    scm_call_2(add_method_proc, generic,
+               scm_call_7(make_proc, method_type,
+                          kwd_specializers, specializers,
+                          kwd_formals, formals,
+                          kwd_procedure, proc));
+
+    // setter
+    setter = scm_setter(prop);
+    formals = scm_list_2(sym_self, sym_value);
+    specializers = scm_list_2(self_type, value_type);
+
+    scm_call_2(add_method_proc, scm_setter(generic),
+               scm_call_7(make_proc, method_type,
+                          kwd_specializers, specializers,
+                          kwd_formals, formals,
+                          kwd_procedure, setter));
+
+    if (was_accessor)
+        scm_c_reexport(public_name, NULL);
+    else {
+        scm_c_define(public_name, generic);
+        scm_c_export(public_name, NULL);
+    }
 }
 
 void
@@ -591,6 +639,8 @@ gig_init_object()
     gig_user_object_properties = g_quark_from_static_string("GigObject::properties");
 
     sym_value = scm_from_utf8_symbol("value");
+
+    ensure_accessor_proc = scm_c_public_ref("oop goops", "ensure-accessor");
 
     scm_c_define_gsubr("%make-gobject", 1, 1, 0, gig_i_scm_make_gobject);
     scm_c_define_gsubr("%object-get-pspec", 2, 0, 0, gig_i_scm_get_pspec);

--- a/src/gig_object.h
+++ b/src/gig_object.h
@@ -7,5 +7,6 @@
 #include <girepository.h>
 
 void gig_init_object();
+void gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace);
 
 #endif

--- a/src/gig_typelib.c
+++ b/src/gig_typelib.c
@@ -192,6 +192,12 @@ scm_i_typelib_load(const gchar *subr, const gchar *namespace_, const gchar *vers
                 if (!(g_signal_info_get_flags(sig_info) & G_SIGNAL_DEPRECATED))
                     gig_function_define(gtype, sig_info, namespace);
             }
+
+            gint n_properties = g_object_info_get_n_properties(info);
+            for (gint m = 0; m < n_properties; m++) {
+                GIPropertyInfo *prop_info = g_object_info_get_property(info, m);
+                gig_property_define(gtype, prop_info, namespace);
+            }
             break;
         }
         case GI_INFO_TYPE_INTERFACE:

--- a/src/gig_util.c
+++ b/src/gig_util.c
@@ -62,9 +62,9 @@ gig_gname_to_scm_name(const gchar *gname)
             g_string_append_c(str, '-');
             was_lower = FALSE;
         }
-        else if (gname[i] == '?') {
-            // does this even occur?
-            g_string_append_c(str, '?');
+        else if (gname[i] == '?' ||
+                 gname[i] == ':') {
+            g_string_append_c(str, gname[i]);
             was_lower = FALSE;
         }
         else if (g_ascii_isdigit(gname[i])) {

--- a/src/gig_util.c
+++ b/src/gig_util.c
@@ -141,18 +141,25 @@ scm_c_reexport(const gchar *name, ...)
     if (SCM_UNBNDP(module_reexport_proc))
         module_reexport_proc = scm_c_public_ref("guile", "module-re-export!");
 
-
     va_list args;
     va_start(args, name);
 
     SCM current_module = scm_current_module();
-    SCM syms = scm_list_1(scm_from_utf8_symbol(name));
+    SCM syms = SCM_EOL;
 
-    while ((name = va_arg(args, gchar *)) != NULL)
-          syms = scm_cons(scm_from_utf8_symbol(name), syms);
+    SCM public = scm_module_public_interface(current_module);
+    SCM obarray = SCM_MODULE_OBARRAY(public);
+
+    do {
+        SCM sym = scm_from_utf8_symbol(name);
+
+        if (!scm_hashq_get_handle(obarray, sym))
+            syms = scm_cons(scm_from_utf8_symbol(name), syms);
+
+        name = va_arg(args, gchar *);
+    } while (name != NULL);
 
     scm_call_2(module_reexport_proc, current_module, syms);
-
     va_end(args);
 
     return SCM_UNSPECIFIED;

--- a/test/gapplication/make.scm
+++ b/test/gapplication/make.scm
@@ -7,9 +7,9 @@
  (begin
    (let ((app (make <GApplication>
                 #:application-id "gi.guile.Example")))
-     (connect app (make <signal> #:name "activate")
+     (connect app activate
               (lambda (app)
-                (display (gobject-get-property app "application-id"))
+                (display (application:application-id app))
                 (display " says \"Hello, world!\"")
                 (newline)
                 (quit app)))

--- a/test/gapplication/make.scm
+++ b/test/gapplication/make.scm
@@ -9,7 +9,7 @@
                 #:application-id "gi.guile.Example")))
      (connect app activate
               (lambda (app)
-                (display (application:application-id app))
+                (display (application-id app))
                 (display " says \"Hello, world!\"")
                 (newline)
                 (quit app)))

--- a/test/gapplication/set_resource_path.scm
+++ b/test/gapplication/set_resource_path.scm
@@ -10,10 +10,10 @@
          (result #f))
      (connect app activate
               (lambda (app)
-                (set! (application:resource-base-path app)
+                (set! (resource-base-path app)
                       "/gi/guile/resource/base_path")
                 (set! result
-                      (equal? (application:resource-base-path app)
+                      (equal? (resource-base-path app)
                               "/gi/guile/resource/base_path"))
                 (quit app)))
      (run app (command-line))

--- a/test/gapplication/set_resource_path.scm
+++ b/test/gapplication/set_resource_path.scm
@@ -8,12 +8,12 @@
    (let ((app (make <GApplication>
                 #:application-id "gi.guile.Example"))
          (result #f))
-     (connect app (make <signal> #:name "activate")
+     (connect app activate
               (lambda (app)
-                (gobject-set-property! app "resource-base-path"
-                                       "/gi/guile/resource/base_path")
+                (set! (application:resource-base-path app)
+                      "/gi/guile/resource/base_path")
                 (set! result
-                      (equal? (gobject-get-property app "resource-base-path")
+                      (equal? (application:resource-base-path app)
                               "/gi/guile/resource/base_path"))
                 (quit app)))
      (run app (command-line))


### PR DESCRIPTION
This is a continuation of #13.

We already have ParamSpec objects, but they are applicable structs with setters, not (generic) methods. For this change we need to:
- use generics with setters
- introspect properties and resolve param specs using object classes (see `gig_i_scm_get_pspec`)
- add existing getters and setters to the generics with some sane formals

Once this is done, we can drop `gobject-get-property` and `gobject-set-property`.