### PR TITLE
Callback procedures

### DIFF
--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -1525,7 +1525,7 @@ c_interface_pointer_to_scm(C2S_ARG_DECL)
     else if (referenced_info_type == GI_INFO_TYPE_CALLBACK) {
         TRACE_C2S();
         g_assert_nonnull(arg->v_pointer);
-        gpointer callback_ptr = arg->v_pointer;
+        gpointer callback_ptr = *(gpointer *)arg->v_pointer;
         *object = gig_callback_to_scm(referenced_base_info, callback_ptr);
     }
     else if (referenced_info_type == GI_INFO_TYPE_STRUCT
@@ -1559,7 +1559,9 @@ c_interface_to_scm(C2S_ARG_DECL)
 
     GIBaseInfo *referenced_base_info = g_type_info_get_interface(entry->type_info);
     GIInfoType referenced_info_type = g_base_info_get_type(referenced_base_info);
-    GType referenced_base_gtype = g_registered_type_info_get_g_type(referenced_base_info);
+    GType referenced_base_gtype = G_TYPE_INVALID;
+    if (GI_IS_REGISTERED_TYPE_INFO (referenced_base_info))
+        referenced_base_gtype = g_registered_type_info_get_g_type(referenced_base_info);
 
     switch (referenced_info_type)
     {
@@ -1568,7 +1570,7 @@ c_interface_to_scm(C2S_ARG_DECL)
         *object = scm_from_uint32(arg->v_uint32);
         break;
     case GI_INFO_TYPE_CALLBACK:
-        *object = scm_from_pointer(arg->v_pointer, NULL);
+        *object = gig_callback_to_scm(referenced_base_info, arg->v_pointer);
         break;
     case GI_INFO_TYPE_STRUCT:
         if (referenced_base_gtype == G_TYPE_NONE) {

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -639,7 +639,7 @@ scm_to_c_interface(S2C_ARG_DECL)
     else if (referenced_base_type == GI_INFO_TYPE_CALLBACK) {
         GICallbackInfo *callback_info = referenced_base_info;
         if (scm_is_true(scm_procedure_p(object))) {
-            arg->v_pointer = gig_callback_get_ptr(callback_info, object);
+            arg->v_pointer = gig_callback_to_c(callback_info, object);
             g_assert(arg->v_pointer != NULL);
         }
     }
@@ -1526,7 +1526,7 @@ c_interface_pointer_to_scm(C2S_ARG_DECL)
         TRACE_C2S();
         g_assert_nonnull(arg->v_pointer);
         gpointer callback_ptr = arg->v_pointer;
-        *object = scm_from_pointer(callback_ptr, NULL);
+        *object = gig_callback_to_scm(referenced_base_info, callback_ptr);
     }
     else if (referenced_info_type == GI_INFO_TYPE_STRUCT
              || referenced_info_type == GI_INFO_TYPE_UNION

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -231,7 +231,7 @@ gig_callback_new(GICallbackInfo *callback_info, SCM s_func)
 }
 
 gpointer
-gig_callback_get_ptr(GICallbackInfo *cb_info, SCM s_func)
+gig_callback_to_c(GICallbackInfo *cb_info, SCM s_func)
 {
     g_assert(cb_info != NULL);
     g_assert(scm_is_true(scm_procedure_p(s_func)));
@@ -258,6 +258,12 @@ gig_callback_get_ptr(GICallbackInfo *cb_info, SCM s_func)
     gcb = gig_callback_new(cb_info, s_func);
     callback_list = g_slist_prepend(callback_list, gcb);
     return gcb->callback_ptr;
+}
+
+SCM
+gig_callback_to_scm(GICallbackInfo *info, gpointer callback)
+{
+    return scm_from_pointer(callback, NULL);
 }
 
 static ffi_type *

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -2,14 +2,20 @@
 #include <ffi.h>
 #include "gig_argument.h"
 #include "gig_callback.h"
+#include "gig_function.h"
 
 typedef struct _GigCallback GigCallback;
 struct _GigCallback
 {
+    GICallbackInfo *callback_info;
     GigArgMap *amap;
     ffi_closure *closure;
     ffi_cif cif;
-    SCM s_func;
+    union
+    {
+        SCM s_func;
+        gpointer c_func;
+    };
     gchar *name;
     gpointer callback_ptr;
     ffi_type **atypes;
@@ -112,6 +118,41 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     }
 }
 
+void
+c_callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_data)
+{
+    GigCallback *gcb = user_data;
+    SCM s_args = SCM_UNDEFINED;
+
+    g_assert(cif != NULL);
+    g_assert(ret != NULL);
+    g_assert(ffi_args != NULL);
+    g_assert(user_data != NULL);
+
+    guint n_args = cif->nargs;
+    g_debug("Invoking callback %s with %d args", gcb->name, n_args);
+
+    // we have either 0 args or 1 args, which is the already packed list
+    g_assert(n_args <= 1);
+    if (n_args)
+        s_args = SCM_PACK(*(scm_t_bits *) (ffi_args[0]));
+
+    if (SCM_UNBNDP(s_args))
+        s_args = SCM_EOL;
+
+    GError *error = NULL;
+    SCM output = gig_callable_invoke(gcb->callback_info, gcb->c_func, gcb->amap, gcb->name, NULL,
+                                     s_args, &error);
+
+    if (error != NULL) {
+        SCM err = scm_from_utf8_string(error->message);
+        g_error_free(error);
+        scm_misc_error(gcb->name, "~A", scm_list_1(err));
+    }
+
+    *(ffi_arg *)ret = SCM_UNPACK(output);
+}
+
 static SCM
 callback_call_proc(gpointer user_data)
 {
@@ -175,7 +216,8 @@ gig_callback_new(GICallbackInfo *callback_info, SCM s_func)
     }
 
     gcb->s_func = s_func;
-    gcb->amap = gig_arg_map_new(callback_info);
+    gcb->callback_info = g_base_info_ref(callback_info);
+    gcb->amap = gig_arg_map_new(gcb->callback_info);
 
     // STEP 1
     // Allocate the block of memory that FFI uses to hold a closure object,
@@ -229,6 +271,41 @@ gig_callback_new(GICallbackInfo *callback_info, SCM s_func)
     return gcb;
 }
 
+GigCallback *
+gig_callback_new_for_callback(GICallbackInfo *info, gpointer c_func)
+{
+    gint n_args = g_callable_info_get_n_args(info);
+
+    // we only take one arg now, the scm arg list
+    n_args = n_args == 0 ? 0 : 1;
+
+    GigCallback *gcb = g_new0(GigCallback, 1);
+    ffi_type *ffi_ret_type;
+
+    gcb->name = g_strdup("(anonymous)");
+
+    gcb->c_func = c_func;
+    gcb->callback_info = g_base_info_ref(info);
+    gcb->amap = gig_arg_map_new(gcb->callback_info);
+
+    if (n_args > 0) {
+        gcb->atypes = g_new0(ffi_type *, 1);
+        gcb->atypes[0] = &ffi_type_pointer;
+    }
+
+    ffi_status prep_ok, closure_ok;
+    prep_ok = ffi_prep_cif(&(gcb->cif), FFI_DEFAULT_ABI, n_args, &ffi_type_pointer, gcb->atypes);
+    g_return_val_if_fail(prep_ok == FFI_OK, NULL);
+
+    gcb->closure = ffi_closure_alloc(sizeof(ffi_closure), &(gcb->callback_ptr));
+    closure_ok = ffi_prep_closure_loc(gcb->closure, &(gcb->cif), c_callback_binding, gcb,
+                                      gcb->callback_ptr);
+    g_return_val_if_fail(closure_ok == FFI_OK, NULL);
+
+    return gcb;
+}
+
+
 gpointer
 gig_callback_to_c(GICallbackInfo *cb_info, SCM s_func)
 {
@@ -257,7 +334,10 @@ gig_callback_to_c(GICallbackInfo *cb_info, SCM s_func)
 SCM
 gig_callback_to_scm(GICallbackInfo *info, gpointer callback)
 {
-    return scm_from_pointer(callback, NULL);
+    // we probably shouldn't cache this, because C callbacks can be
+    // invalidated
+    GigCallback *gcb = gig_callback_new_for_callback(info, callback);
+    return scm_c_make_gsubr("(anonymous)", 0, 0, 1, gcb->closure);
 }
 
 static ffi_type *
@@ -419,6 +499,7 @@ callback_free(GigCallback *gcb)
     gcb->closure = NULL;
 
     gig_arg_map_free(gcb->amap);
+    g_base_info_unref(gcb->callback_info);
     g_free(gcb->atypes);
     gcb->atypes = NULL;
 

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -7,6 +7,7 @@ typedef struct _GigCallback GigCallback;
 struct _GigCallback
 {
     GICallbackInfo *callback_info;
+    GigArgMap *amap;
     ffi_closure *closure;
     ffi_cif cif;
     SCM s_func;
@@ -43,9 +44,8 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     guint n_args = cif->nargs;
 
     g_assert_cmpint(n_args, ==, g_callable_info_get_n_args(gcb->callback_info));
-
-    // FIXME: cache this
-    GigArgMap *amap = gig_arg_map_new(gcb->callback_info);
+    g_assert(gcb->amap != NULL);
+    GigArgMap *amap = gcb->amap;
 
     for (guint i = 0; i < n_args; i++) {
         SCM s_entry = SCM_BOOL_F;
@@ -109,7 +109,6 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
         // I'll try brutally coercing the data, and see what happens.
         *(ffi_arg *) ret = giarg.v_uint64;
     }
-    gig_arg_map_free(amap);
 }
 
 static SCM
@@ -175,8 +174,8 @@ gig_callback_new(GICallbackInfo *callback_info, SCM s_func)
     }
 
     gcb->s_func = s_func;
-    gcb->callback_info = callback_info;
-    g_base_info_ref(callback_info);
+    gcb->callback_info = g_base_info_ref(callback_info);
+    gcb->amap = gig_arg_map_new(gcb->callback_info);
 
     // STEP 1
     // Allocate the block of memory that FFI uses to hold a closure object,
@@ -424,6 +423,7 @@ callback_free(GigCallback *gcb)
     ffi_closure_free(gcb->closure);
     gcb->closure = NULL;
 
+    gig_arg_map_free(gcb->amap);
     g_base_info_unref(gcb->callback_info);
     g_free(gcb->atypes);
     gcb->atypes = NULL;

--- a/src/gig_callback.h
+++ b/src/gig_callback.h
@@ -9,7 +9,8 @@
 G_BEGIN_DECLS
 // *INDENT-ON*
 
-gpointer gig_callback_get_ptr(GICallbackInfo *callback_info, SCM s_func);
+SCM gig_callback_to_scm(GICallbackInfo *info, gpointer proc);
+gpointer gig_callback_to_c(GICallbackInfo *callback_info, SCM s_func);
 void gig_init_callback(void);
 
 G_END_DECLS

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -46,16 +46,16 @@ static void make_formals(GICallableInfo *, GigArgMap *, gint n_inputs, SCM self_
                          SCM *formals, SCM *specializers);
 static void function_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_data);
 
-static SCM convert_output_args(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *name,
+static SCM convert_output_args(GigArgMap *amap, const gchar *name,
                                GArray *out_args);
-static void object_list_to_c_args(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *subr,
+static void object_list_to_c_args(GigArgMap *amap, const gchar *subr,
                                   SCM s_args, GArray *in_args, GPtrArray *cinvoke_free_array,
                                   GArray *out_args);
 static void
 store_argument(gint invoke_in, gint invoke_out, gboolean inout, GIArgument *arg,
                GArray *cinvoke_input_arg_array, GPtrArray *cinvoke_free_array,
                GArray *cinvoke_output_arg_array);
-static SCM rebox_inout_args(GIFunctionInfo *func_info, GigArgMap *amap,
+static SCM rebox_inout_args(GigArgMap *amap,
                             const gchar *func_name, GArray *in_args, GArray *out_args, SCM s_args);
 static void function_free(GigFunction *fn);
 static void gig_fini_function(void);
@@ -378,7 +378,7 @@ gig_function_invoke(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *nam
     cinvoke_free_array = g_ptr_array_new_with_free_func(g_free);
 
     // Convert the scheme arguments into C.
-    object_list_to_c_args(func_info, amap, name, args, cinvoke_input_arg_array,
+    object_list_to_c_args(amap, name, args, cinvoke_input_arg_array,
                           cinvoke_free_array, cinvoke_output_arg_array);
     // For methods calls, the object gets inserted as the 1st argument.
     if (self) {
@@ -434,8 +434,8 @@ gig_function_invoke(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *nam
         else
             output = scm_list_1(s_return);
 
-        SCM output2 = convert_output_args(func_info, amap, name, cinvoke_output_arg_array);
-        SCM output3 = rebox_inout_args(func_info, amap, name, cinvoke_input_arg_array,
+        SCM output2 = convert_output_args(amap, name, cinvoke_output_arg_array);
+        SCM output3 = rebox_inout_args(amap, name, cinvoke_input_arg_array,
                                        cinvoke_output_arg_array, args);
         output = scm_append(scm_list_3(output, output2, output3));
     }
@@ -582,13 +582,11 @@ store_argument(gint invoke_in, gint invoke_out, gboolean inout, GIArgument *arg,
 }
 
 static void
-object_list_to_c_args(GIFunctionInfo *func_info,
-                      GigArgMap *amap,
+object_list_to_c_args(GigArgMap *amap,
                       const gchar *subr, SCM s_args,
                       GArray *cinvoke_input_arg_array,
                       GPtrArray *cinvoke_free_array, GArray *cinvoke_output_arg_array)
 {
-    g_assert_nonnull(func_info);
     g_assert_nonnull(amap);
     g_assert_nonnull(subr);
     g_assert_nonnull(cinvoke_input_arg_array);
@@ -620,7 +618,7 @@ object_list_to_c_args(GIFunctionInfo *func_info,
 }
 
 static SCM
-convert_output_args(GIFunctionInfo *func_info, GigArgMap *amap,
+convert_output_args(GigArgMap *amap,
                     const gchar *func_name, GArray *out_args)
 {
     SCM output = SCM_EOL;
@@ -663,7 +661,7 @@ convert_output_args(GIFunctionInfo *func_info, GigArgMap *amap,
 // For INOUT args, if they came from SCM boxes, push the resulting
 // outputs back into those boxes.
 static SCM
-rebox_inout_args(GIFunctionInfo *func_info, GigArgMap *amap,
+rebox_inout_args(GigArgMap *amap,
                  const gchar *func_name, GArray *in_args, GArray *out_args, SCM s_args)
 {
     if (scm_is_null(s_args))

--- a/src/gig_function.h
+++ b/src/gig_function.h
@@ -30,6 +30,8 @@ typedef SCM (*GigGsubr)(void);
 SCM gig_function_define(GType type, GICallableInfo *info, const gchar *namespace, SCM defs);
 SCM gig_function_invoke(GIFunctionInfo *info, GigArgMap *amap, const gchar *name, GObject *object,
                         SCM args, GError **error);
+SCM gig_callable_invoke(GICallableInfo *callable_info, gpointer callable, GigArgMap *amap,
+                        const gchar *name, GObject *self, SCM args, GError **error);
 void gig_init_function(void);
 
 G_END_DECLS

--- a/test/everything/callback-thunk.scm
+++ b/test/everything/callback-thunk.scm
@@ -1,0 +1,8 @@
+(use-modules (gi)
+             (test automake-test-lib))
+
+(typelib-require ("Marshall" "1.0"))
+
+(automake-test
+ (let ((cb (new-callback-return-value-only)))
+   (= (cb) 42)))

--- a/test/marshall.c
+++ b/test/marshall.c
@@ -3558,6 +3558,17 @@ glong marshall_callback_return_value_only (MarshallCallbackReturnValueOnly callb
   return callback ();
 }
 
+glong
+return_value_only()
+{
+    return 42;
+}
+
+void marshall_new_callback_return_value_only(MarshallCallbackReturnValueOnly *callback)
+{
+    *callback = return_value_only;
+}
+
 /**
  * marshall_callback_one_out_parameter:
  * @callback: (scope call):

--- a/test/marshall.h
+++ b/test/marshall.h
@@ -1160,6 +1160,13 @@ _GI_TEST_EXTERN
 glong marshall_callback_return_value_only (MarshallCallbackReturnValueOnly callback);
 
 /**
+ * marshall_new_callback_return_value_only:
+ * @callback: (out) (scope call):
+ */
+_GI_TEST_EXTERN
+void marshall_new_callback_return_value_only(MarshallCallbackReturnValueOnly *callback);
+
+/**
  * MarshallCallbackOneOutParameter:
  * @a: (out):
  */


### PR DESCRIPTION
With this C callback pointers (such as `GCallback *`) can appear as `out` arguments to C functions and will be converted to Scheme procedures. This is a good first step towards integrating GObject-based FP patterns.