### PR TITLE
GigMeta Type

### DIFF
--- a/src/.indent.pro
+++ b/src/.indent.pro
@@ -106,5 +106,6 @@
 -T GigRepositoryNested
 -T GigSignalSpec
 -T GigSignalSlot
+-T GigTypeMeta
 -T GigTypeRefFunction
 -T GigTypeUnrefFunction

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,8 @@ libguile_gi_la_SOURCES = \
  gi_callable_info.h \
  gig_argument.c \
  gig_argument.h \
+ gig_data_type.c \
+ gig_data_type.h \
  gig_object.c \
  gig_object.h \
  gig_value.c \

--- a/src/gig.c
+++ b/src/gig.c
@@ -26,6 +26,7 @@
 #include "gig_argument.h"
 #include "gig_callback.h"
 #include "gig_constant.h"
+#include "gig_data_type.h"
 #include "gig_flag.h"
 #include "gig_function.h"
 #include "gig_object.h"
@@ -156,6 +157,7 @@ gig_init(void)
     mtrace();
 #endif
     g_debug("Begin libguile-gir initialization");
+    gig_init_data_type();
     gig_init_constant();
     gig_init_flag();
     gig_init_argument();

--- a/src/gig.c
+++ b/src/gig.c
@@ -23,6 +23,7 @@
 #include <libguile.h>
 #include <stdio.h>
 #include <time.h>
+#include <threads.h>
 #include "gig_argument.h"
 #include "gig_callback.h"
 #include "gig_constant.h"
@@ -42,6 +43,8 @@ void __gcov_dump(void);
 #ifdef MTRACE
 #include <mcheck.h>
 #endif
+
+thread_local int logger_initialized = 0;
 
 static const GLogField *
 field_ref(const gchar *needle, const GLogField *fields, gsize n_fields)
@@ -71,7 +74,10 @@ gig_log_writer(GLogLevelFlags flags, const GLogField *fields, gsize n_fields, gp
     const GLogField *message, domain;
 
     const gchar *prefix, *color;
-    scm_init_guile();
+    if (!logger_initialized) {
+        scm_init_guile();
+        logger_initialized = 1;
+    }
     switch (flags & G_LOG_LEVEL_MASK) {
     case G_LOG_LEVEL_ERROR:
         color = "\033[1;31m%s\033[0m";

--- a/src/gig.c
+++ b/src/gig.c
@@ -17,22 +17,22 @@
 #include "config.h"
 #endif
 
-#include <time.h>
+#include <girepository.h>
 #include <glib-object.h>
 #include <glib.h>
-#include <girepository.h>
 #include <libguile.h>
 #include <stdio.h>
-#include "gig_object.h"
-#include "gig_value.h"
-#include "gig_signal.h"
+#include <time.h>
 #include "gig_argument.h"
-#include "gig_type.h"
 #include "gig_callback.h"
-#include "gig_function.h"
 #include "gig_constant.h"
 #include "gig_flag.h"
+#include "gig_function.h"
+#include "gig_object.h"
+#include "gig_signal.h"
+#include "gig_type.h"
 #include "gig_util.h"
+#include "gig_value.h"
 
 #ifdef ENABLE_GCOV
 void __gcov_reset(void);
@@ -71,6 +71,7 @@ gig_log_writer(GLogLevelFlags flags, const GLogField *fields, gsize n_fields, gp
     const GLogField *message, domain;
 
     const gchar *prefix, *color;
+    scm_init_guile();
     switch (flags & G_LOG_LEVEL_MASK) {
     case G_LOG_LEVEL_ERROR:
         color = "\033[1;31m%s\033[0m";

--- a/src/gig.c
+++ b/src/gig.c
@@ -23,7 +23,6 @@
 #include <libguile.h>
 #include <stdio.h>
 #include <time.h>
-#include <threads.h>
 #include "gig_argument.h"
 #include "gig_callback.h"
 #include "gig_constant.h"
@@ -44,7 +43,7 @@ void __gcov_dump(void);
 #include <mcheck.h>
 #endif
 
-thread_local int logger_initialized = 0;
+_Thread_local int logger_initialized = 0;
 
 static const GLogField *
 field_ref(const gchar *needle, const GLogField *fields, gsize n_fields)

--- a/src/gig_arg_map.c
+++ b/src/gig_arg_map.c
@@ -184,7 +184,7 @@ fill_array_info(GigArgMapEntry *entry)
 
 
 static void
-gig_arg_map_entry_apply_arg_info(GigArgMapEntry *e, GIArgInfo *ai)
+gig_amap_entry_apply_arg_info(GigArgMapEntry *e, GIArgInfo *ai)
 {
     g_assert_nonnull(e);
     g_assert_nonnull(ai);
@@ -201,7 +201,7 @@ gig_arg_map_entry_apply_arg_info(GigArgMapEntry *e, GIArgInfo *ai)
 
 // This function gathers information about return values that are arrays.
 static void
-gig_arg_map_entry_apply_callable_info(GigArgMapEntry *e, GICallableInfo *ci)
+gig_amap_entry_apply_callable_info(GigArgMapEntry *e, GICallableInfo *ci)
 {
     g_assert_nonnull(e);
     g_assert_nonnull(ci);
@@ -218,7 +218,7 @@ gig_arg_map_entry_apply_callable_info(GigArgMapEntry *e, GICallableInfo *ci)
 
 // Gather information on how to map Scheme arguments to C arguments.
 GigArgMap *
-gig_arg_map_new(GICallableInfo *function_info)
+gig_amap_new(GICallableInfo *function_info)
 {
     gsize arg_info_count = g_callable_info_get_n_args(function_info);
     GigArgMap *amap = g_new0(GigArgMap, 1);
@@ -235,7 +235,7 @@ gig_arg_map_new(GICallableInfo *function_info)
         g_assert_cmpint(arg_info_index, <, entry_array->len);
         GIArgInfo *arg_info = g_callable_info_get_arg(function_info, arg_info_index);
         GigArgMapEntry *entry = g_ptr_array_index(entry_array, arg_info_index);
-        gig_arg_map_entry_apply_arg_info(entry, arg_info);
+        gig_amap_entry_apply_arg_info(entry, arg_info);
         g_base_info_unref(arg_info);
 
         entry->arg_info_index = arg_info_index;
@@ -306,7 +306,7 @@ gig_arg_map_new(GICallableInfo *function_info)
     }
 
     amap->return_val = arg_map_entry_new();
-    gig_arg_map_entry_apply_callable_info(amap->return_val, function_info);
+    gig_amap_entry_apply_callable_info(amap->return_val, function_info);
     if (amap->return_val->type_tag == GI_TYPE_TAG_ARRAY) {
         fill_array_info(amap->return_val);
         if (amap->return_val->array_length_index >= 0) {
@@ -358,7 +358,7 @@ gig_arg_map_new(GICallableInfo *function_info)
 }
 
 void
-gig_arg_map_free(GigArgMap *amap)
+gig_amap_free(GigArgMap *amap)
 {
     for (gint i = 0; i < amap->len; i++) {
         g_base_info_unref(amap->pdata[i]->type_info);
@@ -376,7 +376,7 @@ gig_arg_map_free(GigArgMap *amap)
 }
 
 void
-gig_arg_map_dump(const GigArgMap *amap)
+gig_amap_dump(const GigArgMap *amap)
 {
     g_debug("Arg map for '%s'", amap->name);
     g_debug(" SCM inputs required: %d, optional: %d, outputs: %d", amap->gsubr_required_input_count,
@@ -424,7 +424,7 @@ gig_arg_map_dump(const GigArgMap *amap)
 }
 
 void
-gig_arg_map_get_gsubr_args_count(const GigArgMap *amap, gint *required, gint *optional)
+gig_amap_get_gsubr_args_count(const GigArgMap *amap, gint *required, gint *optional)
 {
     g_assert_nonnull(amap);
     g_assert_nonnull(required);
@@ -434,7 +434,7 @@ gig_arg_map_get_gsubr_args_count(const GigArgMap *amap, gint *required, gint *op
 }
 
 GigArgMapEntry *
-gig_arg_map_get_entry(GigArgMap *amap, gint input)
+gig_amap_get_entry(GigArgMap *amap, gint input)
 {
     g_assert_nonnull(amap);
     gint i = 0;
@@ -448,7 +448,7 @@ gig_arg_map_get_entry(GigArgMap *amap, gint input)
 }
 
 GigArgMapEntry *
-gig_arg_map_get_output_entry(GigArgMap *amap, gint output)
+gig_amap_get_output_entry(GigArgMap *amap, gint output)
 {
     g_assert_nonnull(amap);
 
@@ -466,7 +466,7 @@ gig_arg_map_get_output_entry(GigArgMap *amap, gint output)
 // being its size, this returns TRUE and stores the index of the other
 // argument.
 gboolean
-gig_arg_map_has_output_array_size_index(GigArgMap *amap, gint cinvoke_output_index,
+gig_amap_has_output_array_size_index(GigArgMap *amap, gint cinvoke_output_index,
                                         gint *cinvoke_output_array_size_index)
 {
     g_assert_nonnull(amap);
@@ -488,7 +488,7 @@ gig_arg_map_has_output_array_size_index(GigArgMap *amap, gint cinvoke_output_ind
 // Get the number of required and optional gsubr arguments for this
 // gsubr call.
 void
-gig_arg_map_get_cinvoke_args_count(const GigArgMap *amap, gint *cinvoke_input_count,
+gig_amap_get_cinvoke_args_count(const GigArgMap *amap, gint *cinvoke_input_count,
                                    gint *cinvoke_output_count)
 {
     g_assert_nonnull(amap);
@@ -503,7 +503,7 @@ gig_arg_map_get_cinvoke_args_count(const GigArgMap *amap, gint *cinvoke_input_co
 // index positions for this argument in the C function call.  Return
 // TRUE if this gsubr argument is used in the C function call.
 gboolean
-gig_arg_map_get_cinvoke_indices(const GigArgMap *amap, gint gsubr_input_index,
+gig_amap_get_cinvoke_indices(const GigArgMap *amap, gint gsubr_input_index,
                                 gint *cinvoke_input_index, gint *cinvoke_output_index)
 {
     g_assert_nonnull(amap);
@@ -530,7 +530,7 @@ gig_arg_map_get_cinvoke_indices(const GigArgMap *amap, gint gsubr_input_index,
 // function call.  Return TRUE if this gsubr argument's array size is
 // used in the C function call.
 gboolean
-gig_arg_map_get_cinvoke_array_length_indices(const GigArgMap *amap, gint gsubr_input_index,
+gig_amap_get_cinvoke_array_length_indices(const GigArgMap *amap, gint gsubr_input_index,
                                              gint *cinvoke_input_index, gint *cinvoke_output_index)
 {
     g_assert_nonnull(amap);
@@ -560,7 +560,7 @@ gig_arg_map_get_cinvoke_array_length_indices(const GigArgMap *amap, gint gsubr_i
 }
 
 gboolean
-gig_arg_map_has_gsubr_output_index(const GigArgMap *amap, gint cinvoke_output_index,
+gig_amap_has_gsubr_output_index(const GigArgMap *amap, gint cinvoke_output_index,
                                    gint *gsubr_output_index)
 {
     g_assert_nonnull(amap);

--- a/src/gig_arg_map.c
+++ b/src/gig_arg_map.c
@@ -49,7 +49,6 @@ arg_map_entry_init(GigArgMapEntry *entry)
 {
     memset(entry, 0, sizeof(GigArgMapEntry));
     entry->name = g_strdup("(uninitialized)");
-    entry->meta.name = g_strdup("(uninitialized)");
 }
 
 // Gather information on how to map Scheme arguments to C arguments.
@@ -95,7 +94,6 @@ arg_map_apply_function_info(GigArgMap *amap, GIFunctionInfo *func_info)
 {
     gint i, n;
     GIArgInfo *arg_info;
-    GigArgMapEntry *entry;
 
     n = amap->len;
 

--- a/src/gig_arg_map.c
+++ b/src/gig_arg_map.c
@@ -17,6 +17,7 @@
 #include "gig_arg_map.h"
 
 const gchar dir_strings[GIG_ARG_DIRECTION_COUNT][9] = {
+    [GIG_ARG_DIRECTION_VOID] = "VOID",
     [GIG_ARG_DIRECTION_INPUT] = "INPUT",
     [GIG_ARG_DIRECTION_INOUT] = "INOUT",
     [GIG_ARG_DIRECTION_PREALLOCATED_OUTPUT] = "PREALLOC",

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -18,6 +18,7 @@
 
 #include <glib.h>
 #include <girepository.h>
+#include "gig_data_type.h"
 
 // *INDENT-OFF*
 G_BEGIN_DECLS
@@ -60,42 +61,7 @@ typedef struct _GigArgMapEntry GigArgMapEntry;
 struct _GigArgMapEntry
 {
     gchar *name;
-
-    ////////////////////////////////////////////////////////////////
-    // This block is similar to GIArgInfo, except it is generic for
-    // both arguments and return types
-    GITypeInfo *type_info;
-    GITypeTag type_tag;
-    gboolean is_ptr;
-    // The direction of the C argument, which may differ from the SCM
-    GIDirection c_direction;
-    // Nothing, container, or everything
-    GITransfer transfer;
-    // For C 'in' values, whether NULL is a valid value.  For 'out'
-    // values, whether NULL may be returned.
-    gboolean may_be_null;
-    // For C 'out' values, whether this argument is allocated by the
-    // caller.
-    gboolean is_caller_allocates;
-
-    ////////////////////////////////////////////////////////////////
-    // This block is additional data that is valid only for arrays
-
-    // The array itself
-    GIArrayType array_type;
-    gsize array_fixed_size;
-    gint array_length_index;
-    gboolean array_is_zero_terminated;
-
-    // The elements of the array
-    GITransfer item_transfer;
-    GITypeTag item_type_tag;
-    gboolean item_is_ptr;
-    gsize item_size;
-
-    // The objects held by elements of the array
-    GIInfoType referenced_base_type;
-    GType referenced_object_type;
+    GigTypeMeta meta;
 
     ////////////////////////////////////////////////////////////////
     // This block is derived information about how to map

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -113,6 +113,9 @@ struct _GigArgMap
     gint c_input_len;
     gint c_output_len;
 
+    // If this arg map has invalid entries
+    gboolean is_invalid;
+
     // An array of arg_map_entry
     GigArgMapEntry *pdata;
     gint len;

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -143,10 +143,10 @@ struct _GigArgMap
     gint c_output_len;
 
     // An array of arg_map_entry
-    GigArgMapEntry **pdata;
+    GigArgMapEntry *pdata;
     gint len;
 
-    GigArgMapEntry *return_val;
+    GigArgMapEntry return_val;
 };
 
 GigArgMap *gig_amap_new(GICallableInfo *function_info);

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 //  - arguments as they appear in g_function_info_invoke calls
 typedef enum
 {
+    GIG_ARG_DIRECTION_VOID,
     GIG_ARG_DIRECTION_INPUT,
     GIG_ARG_DIRECTION_INOUT,
     GIG_ARG_DIRECTION_PREALLOCATED_OUTPUT,

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GIG_ARG_MAP_H
-#define GIG_ARG_MAP_H
+#ifndef GIG_AMAP_H
+#define GIG_AMAP_H
 
 #include <glib.h>
 #include <girepository.h>
@@ -145,24 +145,24 @@ struct _GigArgMap
     GigArgMapEntry *return_val;
 };
 
-GigArgMap *gig_arg_map_new(GICallableInfo *function_info);
-void gig_arg_map_free(GigArgMap *am);
-void gig_arg_map_dump(const GigArgMap *am);
+GigArgMap *gig_amap_new(GICallableInfo *function_info);
+void gig_amap_free(GigArgMap *am);
+void gig_amap_dump(const GigArgMap *am);
 
-void gig_arg_map_get_gsubr_args_count(const GigArgMap *am, gint *gsubr_required_input_count,
+void gig_amap_get_gsubr_args_count(const GigArgMap *am, gint *gsubr_required_input_count,
                                       gint *gsubr_optional_input_count);
-GigArgMapEntry *gig_arg_map_get_entry(GigArgMap *am, gint gsubr_input_index);
-GigArgMapEntry *gig_arg_map_get_output_entry(GigArgMap *am, gint cinvoke_output_index);
-gboolean gig_arg_map_has_output_array_size_index(GigArgMap *am, gint cinvoke_output_index,
+GigArgMapEntry *gig_amap_get_entry(GigArgMap *am, gint gsubr_input_index);
+GigArgMapEntry *gig_amap_get_output_entry(GigArgMap *am, gint cinvoke_output_index);
+gboolean gig_amap_has_output_array_size_index(GigArgMap *am, gint cinvoke_output_index,
                                                  gint *cinvoke_output_array_size_index);
-void gig_arg_map_get_cinvoke_args_count(const GigArgMap *am, gint *cinvoke_input_count,
+void gig_amap_get_cinvoke_args_count(const GigArgMap *am, gint *cinvoke_input_count,
                                         gint *cinvoke_output_count);
-gboolean gig_arg_map_get_cinvoke_indices(const GigArgMap *am, gint gsubr_input_index,
+gboolean gig_amap_get_cinvoke_indices(const GigArgMap *am, gint gsubr_input_index,
                                          gint *cinvoke_input_index, gint *cinvoke_output_index);
-gboolean gig_arg_map_get_cinvoke_array_length_indices(const GigArgMap *am, gint gsubr_input_index,
+gboolean gig_amap_get_cinvoke_array_length_indices(const GigArgMap *am, gint gsubr_input_index,
                                                       gint *cinvoke_input_index,
                                                       gint *cinvoke_output_index);
-gboolean gig_arg_map_has_gsubr_output_index(const GigArgMap *am, gint cinvoke_output_index,
+gboolean gig_amap_has_gsubr_output_index(const GigArgMap *am, gint cinvoke_output_index,
                                             gint *gsubr_output_index);
 G_END_DECLS
 #endif

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -126,6 +126,7 @@ struct _GigArgMapEntry
 typedef struct _GigArgMap GigArgMap;
 struct _GigArgMap
 {
+    gchar *name;
     // SCM arguments.
     gint gsubr_required_input_count;
     gint gsubr_optional_input_count;

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -109,6 +109,11 @@ struct _GigArgMapEntry
     GigArgPresence presence;
     // This arg's index in g_callable_info_get_arg()
 
+    guint8 is_c_input:1;
+    guint8 is_c_output:1;
+    guint8 is_s_input:1;
+    guint8 is_s_output:1;
+    guint8 padding:4;
 
     gint i;
     // This arg's position in input args of g_function_info_invoke
@@ -159,10 +164,10 @@ GigArgMapEntry *gig_amap_get_output_entry_by_c(GigArgMap *am, gint cpos);
 gboolean gig_amap_output_child_c(GigArgMap *am, gint c_output_pos,
                                  gint *cinvoke_output_array_size_index);
 void gig_amap_c_count(const GigArgMap *am, gint *c_input_pos, gint *c_output_pos);
-gboolean gig_amap_input_s_2_inout_c(const GigArgMap *amap, gint s_input, gint *c_input,
-                                    gint *c_output);
-gboolean gig_amap_input_s_2_child_inout_c(const GigArgMap *amap, gint s_input, gint *c_input,
-                                          gint *c_output);
+gboolean gig_amap_input_s_2_input_c(const GigArgMap *amap, gint s_input, gint *c_input);
+gboolean gig_amap_input_s_2_output_c(const GigArgMap *amap, gint s_input, gint *c_output);
+gboolean gig_amap_input_s_2_child_input_c(const GigArgMap *amap, gint s_input, gint *c_input);
+gboolean gig_amap_input_s_2_child_output_c(const GigArgMap *amap, gint s_input, gint *c_output);
 gboolean gig_amap_get_cinvoke_array_length_indices(const GigArgMap *am, gint s_input_pos,
                                                    gint *c_input_pos, gint *c_output_pos);
 gboolean gig_amap_input_i2c(const GigArgMap *amap, gint i, gint *c);

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -108,17 +108,20 @@ struct _GigArgMapEntry
     // If this arg is optional in the Scheme GSubr.
     GigArgPresence presence;
     // This arg's index in g_callable_info_get_arg()
-    gint arg_info_index;
+
+
+    gint i;
     // This arg's position in input args of g_function_info_invoke
-    gint cinvoke_input_index;
+    gint c_input_pos;
     // This arg's position in the output args of g_function_info_invoke
-    gint cinvoke_output_index;
+    gint c_output_pos;
     // This arg's position in the Scheme GSubr
-    gint gsubr_input_index;
+    gint s_input_pos;
     // This arg's position in the return values list
-    gint gsubr_output_index;
+    gint s_output_pos;
     // When non-NULL, this is the entry of the array length argument
     // for this array argument.
+
     GigArgMapEntry *child;
     GigArgMapEntry *parent;
 };
@@ -127,16 +130,17 @@ typedef struct _GigArgMap GigArgMap;
 struct _GigArgMap
 {
     gchar *name;
-    // SCM arguments.
-    gint gsubr_required_input_count;
-    gint gsubr_optional_input_count;
 
-    // SCM return values
-    gint gsubr_output_count;
+    // S arguments.
+    gint s_input_req;
+    gint s_input_opt;
+
+    // S return values
+    gint s_output_len;
 
     // For g_function_invoke call
-    gint cinvoke_input_count;
-    gint cinvoke_output_count;
+    gint c_input_len;
+    gint c_output_len;
 
     // An array of arg_map_entry
     GigArgMapEntry **pdata;
@@ -150,19 +154,16 @@ void gig_amap_free(GigArgMap *am);
 void gig_amap_dump(const GigArgMap *am);
 
 void gig_amap_get_gsubr_args_count(const GigArgMap *am, gint *gsubr_required_input_count,
-                                      gint *gsubr_optional_input_count);
-GigArgMapEntry *gig_amap_get_entry(GigArgMap *am, gint gsubr_input_index);
-GigArgMapEntry *gig_amap_get_output_entry(GigArgMap *am, gint cinvoke_output_index);
-gboolean gig_amap_has_output_array_size_index(GigArgMap *am, gint cinvoke_output_index,
-                                                 gint *cinvoke_output_array_size_index);
-void gig_amap_get_cinvoke_args_count(const GigArgMap *am, gint *cinvoke_input_count,
-                                        gint *cinvoke_output_count);
-gboolean gig_amap_get_cinvoke_indices(const GigArgMap *am, gint gsubr_input_index,
-                                         gint *cinvoke_input_index, gint *cinvoke_output_index);
-gboolean gig_amap_get_cinvoke_array_length_indices(const GigArgMap *am, gint gsubr_input_index,
-                                                      gint *cinvoke_input_index,
-                                                      gint *cinvoke_output_index);
-gboolean gig_amap_has_gsubr_output_index(const GigArgMap *am, gint cinvoke_output_index,
-                                            gint *gsubr_output_index);
+                                   gint *gsubr_optional_input_count);
+GigArgMapEntry *gig_amap_get_entry(GigArgMap *am, gint g_input_pos);
+GigArgMapEntry *gig_amap_get_output_entry(GigArgMap *am, gint c_output_pos);
+gboolean gig_amap_has_output_array_size_index(GigArgMap *am, gint c_output_pos,
+                                              gint *cinvoke_output_array_size_index);
+void gig_amap_get_cinvoke_args_count(const GigArgMap *am, gint *c_input_pos, gint *c_output_pos);
+gboolean gig_amap_get_cinvoke_indices(const GigArgMap *am, gint s_input_pos,
+                                      gint *c_input_pos, gint *c_output_pos);
+gboolean gig_amap_get_cinvoke_array_length_indices(const GigArgMap *am, gint s_input_pos,
+                                                   gint *c_input_pos, gint *c_output_pos);
+gboolean gig_amap_has_s_output_pos(const GigArgMap *am, gint c_output_pos, gint *s_output_pos);
 G_END_DECLS
 #endif

--- a/src/gig_arg_map.h
+++ b/src/gig_arg_map.h
@@ -153,17 +153,34 @@ GigArgMap *gig_amap_new(GICallableInfo *function_info);
 void gig_amap_free(GigArgMap *am);
 void gig_amap_dump(const GigArgMap *am);
 
-void gig_amap_get_gsubr_args_count(const GigArgMap *am, gint *gsubr_required_input_count,
-                                   gint *gsubr_optional_input_count);
-GigArgMapEntry *gig_amap_get_entry(GigArgMap *am, gint g_input_pos);
-GigArgMapEntry *gig_amap_get_output_entry(GigArgMap *am, gint c_output_pos);
-gboolean gig_amap_has_output_array_size_index(GigArgMap *am, gint c_output_pos,
-                                              gint *cinvoke_output_array_size_index);
-void gig_amap_get_cinvoke_args_count(const GigArgMap *am, gint *c_input_pos, gint *c_output_pos);
-gboolean gig_amap_get_cinvoke_indices(const GigArgMap *am, gint s_input_pos,
-                                      gint *c_input_pos, gint *c_output_pos);
+void gig_amap_s_input_count(const GigArgMap *amap, gint *required, gint *optional);
+GigArgMapEntry *gig_amap_get_input_entry_by_s(GigArgMap *am, gint spos);
+GigArgMapEntry *gig_amap_get_output_entry_by_c(GigArgMap *am, gint cpos);
+gboolean gig_amap_output_child_c(GigArgMap *am, gint c_output_pos,
+                                 gint *cinvoke_output_array_size_index);
+void gig_amap_c_count(const GigArgMap *am, gint *c_input_pos, gint *c_output_pos);
+gboolean gig_amap_input_s_2_inout_c(const GigArgMap *amap, gint s_input, gint *c_input,
+                                    gint *c_output);
+gboolean gig_amap_input_s_2_child_inout_c(const GigArgMap *amap, gint s_input, gint *c_input,
+                                          gint *c_output);
 gboolean gig_amap_get_cinvoke_array_length_indices(const GigArgMap *am, gint s_input_pos,
                                                    gint *c_input_pos, gint *c_output_pos);
-gboolean gig_amap_has_s_output_pos(const GigArgMap *am, gint c_output_pos, gint *s_output_pos);
+gboolean gig_amap_input_i2c(const GigArgMap *amap, gint i, gint *c);
+gboolean gig_amap_input_i2s(const GigArgMap *amap, gint i, gint *s);
+gboolean gig_amap_input_c2i(const GigArgMap *amap, gint c, gint *i);
+gboolean gig_amap_input_s2i(const GigArgMap *amap, gint s, gint *i);
+gboolean gig_amap_input_c2s(const GigArgMap *amap, gint c, gint *s);
+gboolean gig_amap_input_s2c(const GigArgMap *amap, gint s, gint *c);
+
+gboolean gig_amap_output_i2c(const GigArgMap *amap, gint i, gint *c);
+gboolean gig_amap_output_i2s(const GigArgMap *amap, gint i, gint *s);
+gboolean gig_amap_output_c2i(const GigArgMap *amap, gint c, gint *i);
+gboolean gig_amap_output_s2i(const GigArgMap *amap, gint s, gint *i);
+gboolean gig_amap_output_c2s(const GigArgMap *amap, gint c, gint *s);
+gboolean gig_amap_output_s2c(const GigArgMap *amap, gint s, gint *c);
+
+gboolean gig_amap_child_i(const GigArgMap *amap, gint i, gint *ichild);
+gboolean gig_amap_return_child_i(const GigArgMap *amap, gint *ichild);
+
 G_END_DECLS
 #endif

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -29,14 +29,14 @@
 #endif
 
 #if GIG_DEBUG_TRANSFERS
-#define TRACE_C2S() g_debug("[C2S] On line %d while handing %s of %s.", __LINE__, entry->name, subr)
-#define TRACE_S2C() g_debug("[S2C] On line %d while handing %s of %s.", __LINE__, entry->name, subr)
+#define TRACE_C2S() g_debug("[C2S] On line %d while handing %s of %s.", __LINE__, gig_type_meta_describe(meta), subr)
+#define TRACE_S2C() g_debug("[S2C] On line %d while handing %s of %s.", __LINE__, gig_type_meta_describe(meta), subr)
 #else
 #define TRACE_C2S()
 #define TRACE_S2C()
 #endif
 
-static gpointer later_free(GPtrArray *must_free, GigArgMapEntry *entry, gpointer ptr);
+static gpointer later_free(GPtrArray *must_free, GigTypeMeta * meta, gpointer ptr);
 static void scm_to_c_immediate(S2C_ARG_DECL);
 static void scm_to_c_immediate_pointer(S2C_ARG_DECL);
 static void scm_to_c_interface(S2C_ARG_DECL);
@@ -69,33 +69,33 @@ static void describe_non_pointer_type(GString *desc, GITypeInfo *type_info);
 
 // Use this to register allocated data to be freed after use.
 static gpointer
-later_free(GPtrArray *must_free, GigArgMapEntry *entry, gpointer ptr)
+later_free(GPtrArray *must_free, GigTypeMeta * meta, gpointer ptr)
 {
-    if (must_free != NULL && entry->meta.transfer == GI_TRANSFER_NOTHING)
+    if (must_free != NULL && meta->transfer == GI_TRANSFER_NOTHING)
         g_ptr_array_insert(must_free, 0, ptr);
     return ptr;
 }
 
-#define LATER_FREE(_ptr) later_free(must_free, entry, _ptr)
+#define LATER_FREE(_ptr) later_free(must_free, meta, _ptr)
 
 static gsize
-array_length(GigArgMapEntry *entry, GIArgument *arg)
+array_length(GigTypeMeta * meta, GIArgument *arg)
 {
-    if (entry->meta.array_is_zero_terminated) {
+    if (meta->array_is_zero_terminated) {
         gpointer array = arg->v_pointer;
         if (array == NULL)
             return 0;
 
         gsize length = 0;
 
-        if (gi_type_tag_is_string(entry->meta.item_type_tag)) {
+        if (gi_type_tag_is_string(meta->item_type_tag)) {
             gchar **ptr = array;
             while (ptr[length] != NULL)
                 length++;
             return length;
         }
 
-        switch (entry->meta.item_size) {
+        switch (meta->item_size) {
         case 0:
             g_assert_not_reached();
         case 1:
@@ -129,20 +129,20 @@ array_length(GigArgMapEntry *entry, GIArgument *arg)
             do {
                 length++;
                 non_null = FALSE;
-                for (gsize i = 0; i <= entry->meta.item_size; i++)
+                for (gsize i = 0; i <= meta->item_size; i++)
                     if (ptr + i != 0) {
                         non_null = TRUE;
                         break;
                     }
-                ptr += entry->meta.item_size;
+                ptr += meta->item_size;
             } while (non_null);
 
             return length;
         }
         }
     }
-    else if (entry->meta.array_fixed_size != GIG_ARRAY_SIZE_UNKNOWN)
-        return entry->meta.array_fixed_size;
+    else if (meta->array_fixed_size != GIG_ARRAY_SIZE_UNKNOWN)
+        return meta->array_fixed_size;
 
     return GIG_ARRAY_SIZE_UNKNOWN;
 }
@@ -160,13 +160,13 @@ gig_argument_scm_to_c(S2C_ARG_DECL)
         *size = 0;
 
     // SCM #f means either NULL or FALSE.  Here we handle NULL.
-    if (entry->meta.may_be_null && scm_is_false(object)) {
+    if (meta->may_be_null && scm_is_false(object)) {
         arg->v_pointer = NULL;
         return;
     }
 
-    if (!entry->meta.is_ptr) {
-        switch (entry->meta.type_tag) {
+    if (!meta->is_ptr) {
+        switch (meta->type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -209,7 +209,7 @@ gig_argument_scm_to_c(S2C_ARG_DECL)
         }
     }
     else {
-        switch (entry->meta.type_tag) {
+        switch (meta->type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -530,7 +530,7 @@ gig_argument_describe_arg(GIArgInfo *arg_info)
 static void
 scm_to_c_immediate(S2C_ARG_DECL)
 {
-    switch (entry->meta.type_tag) {
+    switch (meta->type_tag) {
     case GI_TYPE_TAG_INT8:
         if (SCM_CHARP(object)) {
             if (SCM_CHAR(object) > 255)
@@ -627,9 +627,9 @@ scm_to_c_immediate(S2C_ARG_DECL)
 static void
 scm_to_c_interface(S2C_ARG_DECL)
 {
-    g_assert(entry->meta.type_tag == GI_TYPE_TAG_INTERFACE);
+    g_assert(meta->type_tag == GI_TYPE_TAG_INTERFACE);
 
-    GIBaseInfo *referenced_base_info = g_type_info_get_interface(entry->meta.type_info);
+    GIBaseInfo *referenced_base_info = g_type_info_get_interface(meta->type_info);
     GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
 
     if (referenced_base_type == GI_INFO_TYPE_ENUM)
@@ -669,7 +669,7 @@ scm_to_c_immediate_pointer(S2C_ARG_DECL)
     }
     else {
         // FIXME: add bytevector minimum length checks.
-        if (entry->meta.transfer == GI_TRANSFER_EVERYTHING)
+        if (meta->transfer == GI_TRANSFER_EVERYTHING)
             arg->v_pointer =
                 g_memdup(SCM_BYTEVECTOR_CONTENTS(object), SCM_BYTEVECTOR_LENGTH(object));
         else
@@ -688,7 +688,7 @@ scm_to_c_string(S2C_ARG_DECL)
         // place to store an output.  Since Glib strings and Guile
         // strings have no encoding in common, we can use
         // bytevectors...
-        if (entry->meta.transfer == GI_TRANSFER_NOTHING) {
+        if (meta->transfer == GI_TRANSFER_NOTHING) {
             // But when we're using bytevectors as a possibly writable
             // location, they do need to be null terminated.
             gboolean terminated = FALSE;
@@ -706,7 +706,7 @@ scm_to_c_string(S2C_ARG_DECL)
                                       SCM_BYTEVECTOR_LENGTH(object));
     }
     else if (scm_is_string(object)) {
-        if (entry->meta.type_tag == GI_TYPE_TAG_FILENAME)
+        if (meta->type_tag == GI_TYPE_TAG_FILENAME)
             arg->v_string = scm_to_locale_string(object);
         else
             arg->v_string = scm_to_utf8_string(object);
@@ -729,8 +729,8 @@ static void
 scm_to_c_interface_pointer(S2C_ARG_DECL)
 {
     // Usually STRUCT, UNION, INTERFACE, OBJECT.  Handle NULL_OK
-    g_assert_cmpint(entry->meta.type_tag, ==, GI_TYPE_TAG_INTERFACE);
-    GIBaseInfo *referenced_base_info = g_type_info_get_interface(entry->meta.type_info);
+    g_assert_cmpint(meta->type_tag, ==, GI_TYPE_TAG_INTERFACE);
+    GIBaseInfo *referenced_base_info = g_type_info_get_interface(meta->type_info);
     GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
 
     GType obj_type = gig_type_get_gtype_from_obj(object);
@@ -766,7 +766,7 @@ scm_to_c_interface_pointer(S2C_ARG_DECL)
 static void
 scm_to_c_array(S2C_ARG_DECL)
 {
-    switch (entry->meta.array_type) {
+    switch (meta->array_type) {
     case GI_ARRAY_TYPE_C:
         scm_to_c_native_array(S2C_ARGS);
         break;
@@ -788,16 +788,16 @@ scm_to_c_array(S2C_ARG_DECL)
 static void
 scm_to_c_native_array(S2C_ARG_DECL)
 {
-    if (entry->meta.item_type_tag == GI_TYPE_TAG_BOOLEAN)
+    if (meta->item_type_tag == GI_TYPE_TAG_BOOLEAN)
         scm_to_c_native_boolean_array(S2C_ARGS);
-    else if (entry->meta.item_type_tag == GI_TYPE_TAG_UNICHAR)
+    else if (meta->item_type_tag == GI_TYPE_TAG_UNICHAR)
         scm_to_c_native_unichar_array(S2C_ARGS);
-    else if (gi_type_tag_is_integer(entry->meta.item_type_tag)
-             || gi_type_tag_is_real_number(entry->meta.item_type_tag))
+    else if (gi_type_tag_is_integer(meta->item_type_tag)
+             || gi_type_tag_is_real_number(meta->item_type_tag))
         scm_to_c_native_immediate_array(S2C_ARGS);
-    else if (gi_type_tag_is_string(entry->meta.item_type_tag))
+    else if (gi_type_tag_is_string(meta->item_type_tag))
         scm_to_c_native_string_array(S2C_ARGS);
-    else if (entry->meta.item_type_tag == GI_TYPE_TAG_INTERFACE) {
+    else if (meta->item_type_tag == GI_TYPE_TAG_INTERFACE) {
         scm_to_c_native_interface_array(S2C_ARGS);
     }
     else {
@@ -812,7 +812,7 @@ scm_to_c_native_boolean_array(S2C_ARG_DECL)
     if (!scm_is_vector(object))
         scm_wrong_type_arg_msg(subr, argpos, object, "vector of booleans");
     *size = scm_c_vector_length(object);
-    if (entry->meta.array_is_zero_terminated) {
+    if (meta->array_is_zero_terminated) {
         arg->v_pointer = malloc(sizeof(gboolean) * (*size + 1));
         ((gboolean *)arg->v_pointer)[*size] = 0;
         LATER_FREE(arg->v_pointer);
@@ -833,7 +833,7 @@ scm_to_c_native_unichar_array(S2C_ARG_DECL)
     if (!scm_is_string(object))
         scm_wrong_type_arg_msg(subr, argpos, object, "string");
     *size = scm_c_string_length(object);
-    if (entry->meta.array_is_zero_terminated) {
+    if (meta->array_is_zero_terminated) {
         arg->v_pointer = malloc(sizeof(gunichar) * (*size + 1));
         ((gunichar *)arg->v_pointer)[*size] = 0;
         LATER_FREE(arg->v_pointer);
@@ -854,32 +854,32 @@ scm_to_c_native_immediate_array(S2C_ARG_DECL)
     // integer arrays are ever used. Sometimes deep copy.  Sometimes
     // zero terminated.
 
-    g_assert_cmpint(entry->meta.item_size, !=, 0);
+    g_assert_cmpint(meta->item_size, !=, 0);
 
     if (scm_is_bytevector(object)) {
-        *size = SCM_BYTEVECTOR_LENGTH(object) / entry->meta.item_size;
-        if (entry->meta.item_transfer == GI_TRANSFER_NOTHING) {
-            if (!entry->meta.array_is_zero_terminated) {
+        *size = SCM_BYTEVECTOR_LENGTH(object) / meta->item_size;
+        if (meta->item_transfer == GI_TRANSFER_NOTHING) {
+            if (!meta->array_is_zero_terminated) {
                 // The fast path
                 arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(object);
             }
             else {
                 gsize len = SCM_BYTEVECTOR_LENGTH(object);
                 // Adding null terminator element.
-                arg->v_pointer = g_malloc0(len + entry->meta.item_size);
+                arg->v_pointer = g_malloc0(len + meta->item_size);
                 LATER_FREE(arg->v_pointer);
                 memcpy(arg->v_pointer, SCM_BYTEVECTOR_CONTENTS(object), len);
             }
         }
-        else if (entry->meta.item_transfer == GI_TRANSFER_EVERYTHING) {
-            if (!entry->meta.array_is_zero_terminated) {
+        else if (meta->item_transfer == GI_TRANSFER_EVERYTHING) {
+            if (!meta->array_is_zero_terminated) {
                 arg->v_pointer = g_memdup(SCM_BYTEVECTOR_CONTENTS(object),
                                           SCM_BYTEVECTOR_LENGTH(object));
             }
             else {
                 gsize len = SCM_BYTEVECTOR_LENGTH(object);
                 // Note, null terminated here.
-                arg->v_pointer = g_malloc0(len + entry->meta.item_size);
+                arg->v_pointer = g_malloc0(len + meta->item_size);
                 memcpy(arg->v_pointer, SCM_BYTEVECTOR_CONTENTS(object), len);
             }
         }
@@ -896,7 +896,7 @@ scm_to_c_byte_array(S2C_ARG_DECL)
         gpointer contents = SCM_BYTEVECTOR_CONTENTS(object);
         gsize len = SCM_BYTEVECTOR_LENGTH(object);
         *size = len;
-        if (entry->meta.transfer == GI_TRANSFER_EVERYTHING)
+        if (meta->transfer == GI_TRANSFER_EVERYTHING)
             arg->v_pointer = g_byte_array_new_take(contents, len);
         else
             arg->v_pointer = g_byte_array_new_take(g_memdup(contents, len), len);
@@ -909,9 +909,9 @@ static void
 scm_to_c_garray(S2C_ARG_DECL)
 {
     GIArgument _arg;
-    GigArgMapEntry ae = *entry;
-    ae.meta.array_type = GI_ARRAY_TYPE_C;
-    gig_argument_scm_to_c(subr, argpos, &ae, object, NULL, &_arg, size);
+    GigTypeMeta _meta = *meta;
+    _meta.array_type = GI_ARRAY_TYPE_C;
+    gig_argument_scm_to_c(subr, argpos, &_meta, object, NULL, &_arg, size);
     arg->v_pointer = g_new0(GArray, 1);
     ((GArray *)(arg->v_pointer))->len = *size;
     ((GArray *)(arg->v_pointer))->data = _arg.v_pointer;
@@ -936,14 +936,14 @@ scm_to_c_native_direct_struct_array(S2C_ARG_DECL)
     // For example, gtk_tree_view_enable_model_drag_dest
     gsize len = scm_to_size_t(scm_length(object));
     gpointer ptr;
-    if (entry->meta.array_is_zero_terminated)
-        ptr = g_malloc0_n(entry->meta.item_size, len + 1);
+    if (meta->array_is_zero_terminated)
+        ptr = g_malloc0_n(meta->item_size, len + 1);
     else
-        ptr = g_malloc0_n(entry->meta.item_size, len);
+        ptr = g_malloc0_n(meta->item_size, len);
     LATER_FREE(ptr);
     gpointer entry_ptr = gig_type_peek_object(object);
     for (gsize i = 0; i < len; i++)
-        memcpy((char *)ptr + i * entry->meta.item_size, entry_ptr, entry->meta.item_size);
+        memcpy((char *)ptr + i * meta->item_size, entry_ptr, meta->item_size);
 }
 
 static void
@@ -951,14 +951,14 @@ scm_to_c_native_indirect_object_array(S2C_ARG_DECL)
 {
     // Arrays of pointers to OBJECTS.  The only example I could find
     // is g_socket_send_message.
-    if ((entry->meta.item_type_tag == GI_TYPE_TAG_INTERFACE)
-        && (entry->meta.referenced_base_type == G_TYPE_OBJECT)
-        && entry->meta.item_is_ptr) {
+    if ((meta->item_type_tag == GI_TYPE_TAG_INTERFACE)
+        && (meta->referenced_base_type == G_TYPE_OBJECT)
+        && meta->item_is_ptr) {
         // On the Scheme side, an array of pointers to objects will be
         // a list of GObjects.
         gsize len = scm_to_size_t(scm_length(object));
         gpointer *ptr;
-        if (entry->meta.array_is_zero_terminated)
+        if (meta->array_is_zero_terminated)
             ptr = g_malloc0_n(sizeof(gpointer), len + 1);
         else
             ptr = g_malloc0_n(sizeof(gpointer), len);
@@ -977,25 +977,25 @@ static void
 scm_to_c_native_interface_array(S2C_ARG_DECL)
 {
 #define FUNC_NAME "%object->c-native-interface-array-arg"
-    if ((entry->meta.referenced_base_type == GI_INFO_TYPE_ENUM)
-        || (entry->meta.referenced_base_type == GI_INFO_TYPE_FLAGS)) {
+    if ((meta->referenced_base_type == GI_INFO_TYPE_ENUM)
+        || (meta->referenced_base_type == GI_INFO_TYPE_FLAGS)) {
         // We haven't bothered to make a special flag or enum
         // class on the Scheme side of things.  On the scheme
         // side, enums and flags are just variables holding
         // integers.
         scm_to_c_native_immediate_array(S2C_ARGS);
     }
-    else if ((entry->meta.referenced_base_type == GI_INFO_TYPE_STRUCT)
-             || (entry->meta.referenced_base_type == GI_INFO_TYPE_UNION)
-             || (entry->meta.referenced_base_type == GI_INFO_TYPE_OBJECT)) {
+    else if ((meta->referenced_base_type == GI_INFO_TYPE_STRUCT)
+             || (meta->referenced_base_type == GI_INFO_TYPE_UNION)
+             || (meta->referenced_base_type == GI_INFO_TYPE_OBJECT)) {
         // If we are a Struct or Object, we need to look up
         // our actual GType.
-        g_assert(entry->meta.referenced_object_type != G_TYPE_NONE);
+        g_assert(meta->referenced_object_type != G_TYPE_NONE);
         if (!scm_is_vector(object))
             scm_wrong_type_arg_msg(subr, argpos, object, "vector of objects");
         *size = scm_c_vector_length(object);
-        if (entry->meta.item_is_ptr) {
-            if (entry->meta.array_is_zero_terminated) {
+        if (meta->item_is_ptr) {
+            if (meta->array_is_zero_terminated) {
                 arg->v_pointer = malloc(sizeof(gpointer) * (*size + 1));
                 ((gpointer *)arg->v_pointer)[*size] = 0;
             }
@@ -1004,10 +1004,10 @@ scm_to_c_native_interface_array(S2C_ARG_DECL)
             }
             for (gsize i = 0; i < *size; i++) {
                 gpointer p = gig_type_peek_object(scm_c_vector_ref(object, i));
-                if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
-                    if (entry->meta.referenced_base_type == GI_INFO_TYPE_STRUCT
-                        || entry->meta.referenced_base_type == GI_INFO_TYPE_UNION) {
-                        ((gpointer *)(arg->v_pointer))[i] = g_memdup(p, entry->meta.item_size);
+                if (meta->transfer == GI_TRANSFER_EVERYTHING) {
+                    if (meta->referenced_base_type == GI_INFO_TYPE_STRUCT
+                        || meta->referenced_base_type == GI_INFO_TYPE_UNION) {
+                        ((gpointer *)(arg->v_pointer))[i] = g_memdup(p, meta->item_size);
                         // ((gpointer *)(arg->v_pointer))[i] = p;
                     }
                     else {
@@ -1020,18 +1020,17 @@ scm_to_c_native_interface_array(S2C_ARG_DECL)
             }
         }
         else {
-            if (entry->meta.array_is_zero_terminated)
-                arg->v_pointer = g_malloc0(entry->meta.item_size * (*size + 1));
+            if (meta->array_is_zero_terminated)
+                arg->v_pointer = g_malloc0(meta->item_size * (*size + 1));
             else
                 arg->v_pointer = malloc(sizeof(gpointer) * *size);
             for (gsize i = 0; i < *size; i++) {
                 gpointer p = gig_type_peek_object(scm_c_vector_ref(object, i));
-                if (entry->meta.transfer == GI_TRANSFER_EVERYTHING)
-                    memcpy((char *)(arg->v_pointer) + i * entry->meta.item_size,
-                           g_memdup(p, entry->meta.item_size), entry->meta.item_size);
+                if (meta->transfer == GI_TRANSFER_EVERYTHING)
+                    memcpy((char *)(arg->v_pointer) + i * meta->item_size,
+                           g_memdup(p, meta->item_size), meta->item_size);
                 else
-                    memcpy((char *)(arg->v_pointer) + i * entry->meta.item_size, p,
-                           entry->meta.item_size);
+                    memcpy((char *)(arg->v_pointer) + i * meta->item_size, p, meta->item_size);
 
             }
         }
@@ -1063,7 +1062,7 @@ scm_to_c_native_string_array(S2C_ARG_DECL)
         LATER_FREE(strv);
 
         for (gsize i = 0; i < len; i++, elt += inc) {
-            if (entry->meta.item_type_tag == GI_TYPE_TAG_FILENAME)
+            if (meta->item_type_tag == GI_TYPE_TAG_FILENAME)
                 strv[i] = scm_to_locale_string(*elt);
             else
                 strv[i] = scm_to_utf8_string(*elt);
@@ -1082,7 +1081,7 @@ scm_to_c_native_string_array(S2C_ARG_DECL)
         SCM iter = object;
         for (gsize i = 0; i < len; i++) {
             SCM elt = scm_car(iter);
-            if (entry->meta.item_type_tag == GI_TYPE_TAG_FILENAME)
+            if (meta->item_type_tag == GI_TYPE_TAG_FILENAME)
                 strv[i] = scm_to_locale_string(elt);
             else
                 strv[i] = scm_to_utf8_string(elt);
@@ -1240,9 +1239,9 @@ gig_argument_c_to_scm(C2S_ARG_DECL)
 {
     TRACE_C2S();
 
-    if (!entry->meta.is_ptr) {
+    if (!meta->is_ptr) {
         TRACE_C2S();
-        switch (entry->meta.type_tag) {
+        switch (meta->type_tag) {
         case GI_TYPE_TAG_VOID:
             *object = SCM_UNSPECIFIED;
             break;
@@ -1281,12 +1280,12 @@ gig_argument_c_to_scm(C2S_ARG_DECL)
             break;
         }
     }
-    else if (entry->meta.may_be_null && (arg == NULL || arg->v_pointer == NULL)) {
+    else if (meta->may_be_null && (arg == NULL || arg->v_pointer == NULL)) {
         *object = SCM_BOOL_F;
     }
     else {
         TRACE_C2S();
-        switch (entry->meta.type_tag) {
+        switch (meta->type_tag) {
         case GI_TYPE_TAG_BOOLEAN:
         case GI_TYPE_TAG_DOUBLE:
         case GI_TYPE_TAG_FLOAT:
@@ -1318,7 +1317,7 @@ gig_argument_c_to_scm(C2S_ARG_DECL)
         case GI_TYPE_TAG_GHASH:
             TRACE_C2S();
             // FIXME: unhandled
-            g_critical("Unhandled hash argument type tag %d", entry->meta.type_tag);
+            g_critical("Unhandled hash argument type tag %d", meta->type_tag);
             g_assert_not_reached();
             break;
 
@@ -1454,7 +1453,7 @@ gig_argument_describe_return(GITypeInfo *type_info,
 static void
 c_immediate_to_scm(C2S_ARG_DECL)
 {
-    switch (entry->meta.type_tag) {
+    switch (meta->type_tag) {
     case GI_TYPE_TAG_BOOLEAN:
         *object = scm_from_bool(arg->v_boolean);
         break;
@@ -1505,11 +1504,11 @@ static void
 c_interface_pointer_to_scm(C2S_ARG_DECL)
 {
     TRACE_C2S();
-    g_assert_cmpint(entry->meta.type_tag, ==, GI_TYPE_TAG_INTERFACE);
-    g_assert_cmpint(entry->meta.is_ptr, ==, TRUE);
+    g_assert_cmpint(meta->type_tag, ==, GI_TYPE_TAG_INTERFACE);
+    g_assert_cmpint(meta->is_ptr, ==, TRUE);
     g_assert_nonnull(arg);
 
-    GIBaseInfo *referenced_base_info = g_type_info_get_interface(entry->meta.type_info);
+    GIBaseInfo *referenced_base_info = g_type_info_get_interface(meta->type_info);
     GIInfoType referenced_info_type = g_base_info_get_type(referenced_base_info);
     if (referenced_info_type == GI_INFO_TYPE_ENUM) {
         TRACE_C2S();
@@ -1538,7 +1537,7 @@ c_interface_pointer_to_scm(C2S_ARG_DECL)
         if (arg->v_pointer == NULL)
             *object = SCM_BOOL_F;
         else if (referenced_base_gtype != G_TYPE_NONE)
-            *object = gig_type_transfer_object(referenced_base_gtype, arg->v_pointer, entry->meta.transfer);
+            *object = gig_type_transfer_object(referenced_base_gtype, arg->v_pointer, meta->transfer);
         else if (referenced_info_type == GI_INFO_TYPE_STRUCT ||
                  referenced_info_type == GI_INFO_TYPE_UNION) {
             gpointer struct_ptr = arg->v_pointer;
@@ -1556,9 +1555,9 @@ static void
 c_interface_to_scm(C2S_ARG_DECL)
 {
     TRACE_C2S();
-    g_assert(entry->meta.type_tag == GI_TYPE_TAG_INTERFACE);
+    g_assert(meta->type_tag == GI_TYPE_TAG_INTERFACE);
 
-    GIBaseInfo *referenced_base_info = g_type_info_get_interface(entry->meta.type_info);
+    GIBaseInfo *referenced_base_info = g_type_info_get_interface(meta->type_info);
     GIInfoType referenced_info_type = g_base_info_get_type(referenced_base_info);
     GType referenced_base_gtype = g_registered_type_info_get_g_type(referenced_base_info);
 
@@ -1603,14 +1602,14 @@ c_string_to_scm(C2S_ARG_DECL)
     // We can't transfer strings directly, since GObject and Guile use
     // different internal encodings.  So for GI_TRANSFER_EVERYTHGING,
     // we just free.
-    switch (entry->meta.type_tag) {
+    switch (meta->type_tag) {
 
     case GI_TYPE_TAG_UTF8:
     case GI_TYPE_TAG_FILENAME:
         if (!arg->v_string)
             *object = scm_c_make_string(0, SCM_MAKE_CHAR(0));
         else {
-            if (entry->meta.type_tag == GI_TYPE_TAG_UTF8) {
+            if (meta->type_tag == GI_TYPE_TAG_UTF8) {
                 if (size != GIG_ARRAY_SIZE_UNKNOWN)
                     *object = scm_from_utf8_stringn(arg->v_string, size);
                 else
@@ -1622,7 +1621,7 @@ c_string_to_scm(C2S_ARG_DECL)
                 else
                     *object = scm_from_locale_string(arg->v_string);
             }
-            if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
+            if (meta->transfer == GI_TRANSFER_EVERYTHING) {
                 g_free(arg->v_string);
                 arg->v_string = NULL;
             }
@@ -1636,10 +1635,10 @@ c_string_to_scm(C2S_ARG_DECL)
 static void
 c_array_to_scm(C2S_ARG_DECL)
 {
-    if (entry->meta.array_length_index >= 0)
-        entry->meta.array_fixed_size = size;
+    if (meta->array_length_index >= 0)
+        meta->array_fixed_size = size;
 
-    switch (entry->meta.array_type) {
+    switch (meta->array_type) {
     case GI_ARRAY_TYPE_BYTE_ARRAY:
         c_byte_array_to_scm(C2S_ARGS);
         break;
@@ -1664,7 +1663,7 @@ c_array_to_scm(C2S_ARG_DECL)
 static void
 c_native_array_to_scm(C2S_ARG_DECL)
 {
-    gsize length = array_length(entry, arg);
+    gsize length = array_length(meta, arg);
 
     if (length == GIG_ARRAY_SIZE_UNKNOWN) {
         c_void_pointer_to_scm(C2S_ARGS);
@@ -1675,17 +1674,17 @@ c_native_array_to_scm(C2S_ARG_DECL)
 #define TRANSFER(_type,_short_type)                                     \
     do {                                                                \
         gsize sz;                                                       \
-        if (!g_size_checked_mul(&sz, length, entry->meta.item_size) || sz == G_MAXSIZE) \
+        if (!g_size_checked_mul(&sz, length, meta->item_size) || sz == G_MAXSIZE) \
             scm_misc_error(subr, "Array size overflow", SCM_EOL);               \
         if (sz == 0) \
             *object = scm_make_ ## _short_type ## vector (scm_from_int(0), scm_from_int(0)); \
-        else if (entry->meta.transfer == GI_TRANSFER_EVERYTHING)             \
+        else if (meta->transfer == GI_TRANSFER_EVERYTHING)             \
             *object = scm_take_ ## _short_type ## vector((_type *)(arg->v_pointer), length); \
         else                                                            \
             *object = scm_take_ ## _short_type ## vector((_type *)g_memdup(arg->v_pointer, sz), length); \
     } while(0)
 
-    switch (entry->meta.item_type_tag) {
+    switch (meta->item_type_tag) {
     case GI_TYPE_TAG_INT8:
         TRANSFER(gint8, s8);
         break;
@@ -1717,7 +1716,7 @@ c_native_array_to_scm(C2S_ARG_DECL)
         TRANSFER(gdouble, f64);
         break;
     case GI_TYPE_TAG_GTYPE:
-        switch (entry->meta.item_size) {
+        switch (meta->item_size) {
         case 1:
             TRANSFER(guint8, u8);
             break;
@@ -1745,7 +1744,7 @@ c_native_array_to_scm(C2S_ARG_DECL)
         for (gsize k = 0; k < len; k++, elt += inc)
             *elt = ((gboolean *)(arg->v_pointer))[k] ? SCM_BOOL_T : SCM_BOOL_F;
         scm_array_handle_release(&handle);
-        if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
+        if (meta->transfer == GI_TRANSFER_EVERYTHING) {
             free(arg->v_pointer);
             arg->v_pointer = 0;
         }
@@ -1756,18 +1755,18 @@ c_native_array_to_scm(C2S_ARG_DECL)
         for (gsize k = 0; k < length; k++)
             scm_c_string_set_x(*object, k, SCM_MAKE_CHAR(((gunichar *)(arg->v_pointer))[k]));
         break;
-        if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
+        if (meta->transfer == GI_TRANSFER_EVERYTHING) {
             free(arg->v_pointer);
             arg->v_pointer = 0;
         }
     case GI_TYPE_TAG_INTERFACE:
-        switch (entry->meta.referenced_base_type) {
+        switch (meta->referenced_base_type) {
         case GI_INFO_TYPE_ENUM:
-            g_assert(!entry->meta.item_is_ptr);
+            g_assert(!meta->item_is_ptr);
             TRANSFER(gint32, s32);
 
         case GI_INFO_TYPE_FLAGS:
-            g_assert(!entry->meta.item_is_ptr);
+            g_assert(!meta->item_is_ptr);
             TRANSFER(guint32, u32);
 
         case GI_INFO_TYPE_STRUCT:
@@ -1784,24 +1783,23 @@ c_native_array_to_scm(C2S_ARG_DECL)
 
             GIArgument _arg;
             gpointer iter = arg->v_pointer;
-            GigArgMapEntry ae = {
-                .name = "(array internal)",
-                .meta.type_info = g_type_info_get_param_type(entry->meta.type_info, 0),
-                .meta.type_tag = entry->meta.item_type_tag,
-                .meta.is_ptr = TRUE,
-                .meta.transfer = entry->meta.item_transfer
+            GigTypeMeta _meta = {
+                .type_info = g_type_info_get_param_type(meta->type_info, 0),
+                .type_tag = meta->item_type_tag,
+                .is_ptr = TRUE,
+                .transfer = meta->item_transfer
             };
 
-            for (gsize k = 0; k < len; k++, elt += inc, iter += entry->meta.item_size) {
-                if (entry->meta.item_is_ptr)
+            for (gsize k = 0; k < len; k++, elt += inc, iter += meta->item_size) {
+                if (meta->item_is_ptr)
                     _arg.v_pointer = *(gpointer *)iter;
                 else
                     _arg.v_pointer = iter;
-                gig_argument_c_to_scm(subr, argpos, &ae, &_arg, elt, -1);
+                gig_argument_c_to_scm(subr, argpos, &_meta, &_arg, elt, -1);
             }
 
             scm_array_handle_release(&handle);
-            if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
+            if (meta->transfer == GI_TRANSFER_EVERYTHING) {
                 free(arg->v_pointer);
                 arg->v_pointer = 0;
             }
@@ -1828,18 +1826,17 @@ c_native_array_to_scm(C2S_ARG_DECL)
         for (gsize i = 0; i < length; i++, elt += inc) {
             gchar *str = ((gchar **)(arg->v_pointer))[i];
             if (str) {
-                if (entry->meta.item_type_tag == GI_TYPE_TAG_UTF8)
+                if (meta->item_type_tag == GI_TYPE_TAG_UTF8)
                     *elt = scm_from_utf8_string(str);
                 else
                     *elt = scm_from_locale_string(str);
             }
-            if (entry->meta.transfer == GI_TRANSFER_EVERYTHING) {
+            if (meta->transfer == GI_TRANSFER_EVERYTHING) {
                 free(((gchar **)(arg->v_pointer))[i]);
                 ((gchar **)(arg->v_pointer))[i] = NULL;
             }
         }
-        if (entry->meta.transfer == GI_TRANSFER_EVERYTHING ||
-            entry->meta.transfer == GI_TRANSFER_CONTAINER) {
+        if (meta->transfer == GI_TRANSFER_EVERYTHING || meta->transfer == GI_TRANSFER_CONTAINER) {
             free(arg->v_pointer);
             arg->v_pointer = NULL;
         }
@@ -1861,7 +1858,7 @@ c_byte_array_to_scm(C2S_ARG_DECL)
     GByteArray *byte_array = arg->v_pointer;
     *object = scm_c_make_bytevector(byte_array->len);
     memcpy(SCM_BYTEVECTOR_CONTENTS(*object), byte_array->data, byte_array->len);
-    if (entry->meta.item_transfer == GI_TRANSFER_EVERYTHING)
+    if (meta->item_transfer == GI_TRANSFER_EVERYTHING)
         g_byte_array_free(byte_array, TRUE);
     else
         g_byte_array_free(byte_array, FALSE);
@@ -1870,27 +1867,27 @@ c_byte_array_to_scm(C2S_ARG_DECL)
 static void
 c_garray_to_scm(C2S_ARG_DECL)
 {
-    GigArgMapEntry ae = *entry;
+    GigTypeMeta _meta = *meta;
     GIArgument _arg;
     GArray *array = arg->v_pointer;
     _arg.v_pointer = array->data;
-    ae.meta.array_type = GI_ARRAY_TYPE_C;
-    ae.meta.array_fixed_size = array->len;
+    _meta.array_type = GI_ARRAY_TYPE_C;
+    _meta.array_fixed_size = array->len;
     size = array->len;
-    c_array_to_scm(subr, argpos, &ae, &_arg, object, size);
+    c_array_to_scm(subr, argpos, &_meta, &_arg, object, size);
 }
 
 static void
 c_gptrarray_to_scm(C2S_ARG_DECL)
 {
-    GigArgMapEntry ae = *entry;
+    GigTypeMeta _meta = *meta;
     GIArgument _arg;
     GPtrArray *array = arg->v_pointer;
     _arg.v_pointer = array->pdata;
-    ae.meta.array_type = GI_ARRAY_TYPE_C;
-    ae.meta.array_fixed_size = array->len;
+    _meta.array_type = GI_ARRAY_TYPE_C;
+    _meta.array_fixed_size = array->len;
     size = array->len;
-    c_array_to_scm(subr, argpos, &ae, &_arg, object, size);
+    c_array_to_scm(subr, argpos, &_meta, &_arg, object, size);
 }
 
 
@@ -1899,8 +1896,8 @@ c_list_to_scm(C2S_ARG_DECL)
 {
     // Dissect layers as in `fill_array_info`, except that less information
     // is needed.
-    GITypeInfo *list_type_info = entry->meta.type_info;
-    GITransfer list_transfer = entry->meta.transfer;
+    GITypeInfo *list_type_info = meta->type_info;
+    GITransfer list_transfer = meta->transfer;
     GITypeTag list_type_tag = g_type_info_get_tag(list_type_info);
     GITypeInfo *item_type_info = g_type_info_get_param_type(list_type_info, 0);
     GITypeTag item_type_tag = g_type_info_get_tag(item_type_info);
@@ -1997,17 +1994,16 @@ c_list_to_scm(C2S_ARG_DECL)
         }
         else {
             GIArgument _arg;
-            GigArgMapEntry ae = {
-                .name = "(list internal)",
-                .meta.type_info = item_type_info,
-                .meta.type_tag = item_type_tag,
-                .meta.is_ptr = item_is_ptr,
-                .meta.transfer = item_transfer
+            GigTypeMeta _meta = {
+                _meta.type_info = item_type_info,
+                _meta.type_tag = item_type_tag,
+                _meta.is_ptr = item_is_ptr,
+                _meta.transfer = item_transfer
             };
             SCM elt;
             _arg.v_pointer = *(void **)data;
 
-            gig_argument_c_to_scm(subr, argpos, &ae, &_arg, &elt, -1);
+            gig_argument_c_to_scm(subr, argpos, &_meta, &_arg, &elt, -1);
             scm_set_car_x(out_iter, elt);
         }
 

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -48,35 +48,43 @@
     } while(FALSE)
 
 static gpointer later_free(GPtrArray *must_free, GigTypeMeta *meta, gpointer ptr);
-static void scm_to_c_immediate(S2C_ARG_DECL);
-// static void scm_to_c_immediate_pointer(S2C_ARG_DECL);
+static void scm_to_c_char(S2C_ARG_DECL);
+static void scm_to_c_boolean(S2C_ARG_DECL);
+static void scm_to_c_integer(S2C_ARG_DECL);
+static void scm_to_c_enum(S2C_ARG_DECL);
+static void scm_to_c_real(S2C_ARG_DECL);
+static void scm_to_c_boxed(S2C_ARG_DECL);
+static void scm_to_c_object(S2C_ARG_DECL);
+static void scm_to_c_variant(S2C_ARG_DECL);
 static void scm_to_c_interface(S2C_ARG_DECL);
 static void scm_to_c_string(S2C_ARG_DECL);
-static void scm_to_c_void_pointer(S2C_ARG_DECL);
-static void scm_to_c_interface_pointer(S2C_ARG_DECL);
-static void scm_to_c_array(S2C_ARG_DECL);
+static void scm_to_c_pointer(S2C_ARG_DECL);
 static void scm_to_c_native_array(S2C_ARG_DECL);
 static void scm_to_c_native_unichar_array(S2C_ARG_DECL);
 static void scm_to_c_native_boolean_array(S2C_ARG_DECL);
 static void scm_to_c_native_immediate_array(S2C_ARG_DECL);
 static void scm_to_c_native_string_array(S2C_ARG_DECL);
 static void scm_to_c_native_interface_array(S2C_ARG_DECL);
-static void scm_to_c_ptr_array(S2C_ARG_DECL);
 static void scm_to_c_garray(S2C_ARG_DECL);
 static void scm_to_c_byte_array(S2C_ARG_DECL);
-static void c_immediate_to_scm(C2S_ARG_DECL);
+static void c_char_to_scm(C2S_ARG_DECL);
+static void c_boolean_to_scm(C2S_ARG_DECL);
+static void c_integer_to_scm(C2S_ARG_DECL);
+static void c_enum_to_scm(C2S_ARG_DECL);
+static void c_real_to_scm(C2S_ARG_DECL);
+static void c_boxed_to_scm(C2S_ARG_DECL);
+static void c_object_to_scm(C2S_ARG_DECL);
+static void c_variant_to_scm(C2S_ARG_DECL);
+static void c_param_to_scm(C2S_ARG_DECL);
 static void c_interface_to_scm(C2S_ARG_DECL);
-static void c_interface_pointer_to_scm(C2S_ARG_DECL);
 static void c_string_to_scm(C2S_ARG_DECL);
-static void c_void_pointer_to_scm(C2S_ARG_DECL);
+static void c_pointer_to_scm(C2S_ARG_DECL);
 static void c_array_to_scm(C2S_ARG_DECL);
 static void c_byte_array_to_scm(C2S_ARG_DECL);
 static void c_native_array_to_scm(C2S_ARG_DECL);
 static void c_garray_to_scm(C2S_ARG_DECL);
 static void c_gptrarray_to_scm(C2S_ARG_DECL);
 static void c_list_to_scm(C2S_ARG_DECL);
-
-static void describe_non_pointer_type(GString *desc, GITypeInfo *type_info);
 
 // Use this to register allocated data to be freed after use.
 static gpointer
@@ -167,344 +175,74 @@ array_length(GigTypeMeta *meta, GIArgument *arg)
 void
 gig_argument_scm_to_c(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     if (size)
         *size = 0;
 
-    // SCM #f means either NULL or FALSE.  Here we handle NULL.
-    if (meta->is_nullable && scm_is_false(object)) {
-        arg->v_pointer = NULL;
-        return;
-    }
     GType fundamental_type = G_TYPE_FUNDAMENTAL(meta->gtype);
-    if (!meta->is_ptr) {
-        switch (fundamental_type) {
-        case G_TYPE_BOOLEAN:
-        case G_TYPE_DOUBLE:
-        case G_TYPE_FLOAT:
-        case G_TYPE_INT:
-        case G_TYPE_INT64:
-        case G_TYPE_UINT:
-        case G_TYPE_UINT64:
-        case G_TYPE_CHAR:
-        case G_TYPE_UCHAR:
-            scm_to_c_immediate(S2C_ARGS);
-            break;
-        case G_TYPE_FLAGS:
-        case G_TYPE_ENUM:
-            scm_to_c_interface(S2C_ARGS);
-            break;
-        case G_TYPE_NONE:
-            SURPRISING;
-            arg->v_pointer = NULL;
-            break;
-        case G_TYPE_POINTER:
-            if (meta->gtype == G_TYPE_CALLBACK)
-                scm_to_c_interface(S2C_ARGS);
-            else if (meta->gtype == G_TYPE_GTYPE)
-                scm_to_c_immediate(S2C_ARGS);
-            else
-                UNHANDLED;
-            break;
-        default:
-            UNHANDLED;
-            break;
-        }
-    }
-    else {
-        switch (fundamental_type) {
-#if 0
-        case G_TYPE_BOOLEAN:
-        case G_TYPE_DOUBLE:
-        case G_TYPE_FLOAT:
-        case G_TYPE_INT:
-        case G_TYPE_INT64:
-        case G_TYPE_UINT:
-        case G_TYPE_UINT64:
-        case G_TYPE_CHAR:
-        case G_TYPE_UCHAR:
-            scm_to_c_immediate_pointer(S2C_ARGS);
-            break;
-#endif
-        case G_TYPE_STRING:
-            scm_to_c_string(S2C_ARGS);
-            break;
-        case G_TYPE_POINTER:
-            if (meta->gtype == G_TYPE_POINTER)
-                scm_to_c_void_pointer(S2C_ARGS);
-            else
-                UNHANDLED;
-            break;
-        case G_TYPE_BOXED:
-        case G_TYPE_OBJECT:
-            if (meta->gtype == G_TYPE_LENGTH_CARRAY
-                || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
-                || meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY
-                || meta->gtype == G_TYPE_ARRAY)
-                scm_to_c_array(S2C_ARGS);
-            else
-                scm_to_c_interface(S2C_ARGS);
-            break;
-        default:
-            UNHANDLED;
-            break;
-        }
-    }
-}
-
-#if 0
-static void
-describe_non_pointer_type(GString *desc, GITypeInfo *type_info)
-{
-    GITypeTag type_tag = g_type_info_get_tag(type_info);
-    switch (type_tag) {
-    case GI_TYPE_TAG_BOOLEAN:
-        g_string_append(desc, "boolean");
+    switch (fundamental_type) {
+    case G_TYPE_INVALID:
+        UNHANDLED;
         break;
-    case GI_TYPE_TAG_DOUBLE:
-    case GI_TYPE_TAG_FLOAT:
-        g_string_append_printf(desc, "real number of size %s",
-                               g_type_tag_to_string(g_type_info_get_tag(type_info)));
+    case G_TYPE_NONE:
+        SURPRISING;
+        arg->v_pointer = NULL;
         break;
-    case GI_TYPE_TAG_INT16:
-    case GI_TYPE_TAG_INT32:
-    case GI_TYPE_TAG_INT64:
-    case GI_TYPE_TAG_INT8:
-    case GI_TYPE_TAG_UINT16:
-    case GI_TYPE_TAG_UINT32:
-    case GI_TYPE_TAG_UINT64:
-    case GI_TYPE_TAG_UINT8:
-        g_string_append_printf(desc, "exact integer of size %s",
-                               g_type_tag_to_string(g_type_info_get_tag(type_info)));
+    case G_TYPE_INTERFACE:
+        scm_to_c_interface(S2C_ARGS);
         break;
-    case GI_TYPE_TAG_UNICHAR:
-        g_string_append_printf(desc, "character");
+    case G_TYPE_CHAR:
+    case G_TYPE_UCHAR:
+        scm_to_c_char(S2C_ARGS);
         break;
-    case GI_TYPE_TAG_GTYPE:
-        g_string_append_printf(desc, "<GType>");
+    case G_TYPE_BOOLEAN:
+        scm_to_c_boolean(S2C_ARGS);
         break;
-
-    case GI_TYPE_TAG_VOID:
-    case GI_TYPE_TAG_ARRAY:
-    case GI_TYPE_TAG_UTF8:
-    case GI_TYPE_TAG_FILENAME:
-    case GI_TYPE_TAG_GHASH:
-    case GI_TYPE_TAG_GLIST:
-    case GI_TYPE_TAG_GSLIST:
-    case GI_TYPE_TAG_ERROR:
-        //g_assert_not_reached();
-        g_string_append_printf(desc, "Unhandled argument type tag %d in %s:%d", type_tag, __FILE__,
-                               __LINE__);
+    case G_TYPE_INT:
+    case G_TYPE_UINT:
+    case G_TYPE_LONG:
+    case G_TYPE_ULONG:
+    case G_TYPE_INT64:
+    case G_TYPE_UINT64:
+        scm_to_c_integer(S2C_ARGS);
         break;
-
-    case GI_TYPE_TAG_INTERFACE:
-    {
-        GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
-        GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-        if (referenced_base_type == GI_INFO_TYPE_ENUM)
-            g_string_printf(desc, "exact integer of enum type %s",
-                            g_base_info_get_name(referenced_base_info));
-        else if (referenced_base_type == GI_INFO_TYPE_FLAGS)
-            g_string_printf(desc, "exact integer of flags type %s",
-                            g_base_info_get_name(referenced_base_info));
-        else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-            g_string_printf(desc, "procedure of type %s",
-                            g_base_info_get_name(referenced_base_info));
-        else if (referenced_base_type == GI_INFO_TYPE_INTERFACE
-                 || referenced_base_type == GI_INFO_TYPE_OBJECT
-                 || referenced_base_type == GI_INFO_TYPE_STRUCT
-                 || referenced_base_type == GI_INFO_TYPE_UNION) {
-            GType type = g_registered_type_info_get_g_type(referenced_base_info);
-            gchar *class_name = gig_type_class_name_from_gtype(type);
-            g_string_append(desc, class_name);
-            g_free(class_name);
-        }
-        else
-            g_string_append_printf(desc, "Unhandled argument type tag %d in %s:%d", type_tag,
-                                   __FILE__, __LINE__);
-        g_base_info_unref(referenced_base_info);
+    case G_TYPE_ENUM:
+    case G_TYPE_FLAGS:
+        scm_to_c_enum(S2C_ARGS);
         break;
-    }
+    case G_TYPE_FLOAT:
+    case G_TYPE_DOUBLE:
+        scm_to_c_real(S2C_ARGS);
+        break;
+    case G_TYPE_STRING:
+        scm_to_c_string(S2C_ARGS);
+        break;
+    case G_TYPE_POINTER:
+        scm_to_c_pointer(S2C_ARGS);
+        break;
+    case G_TYPE_BOXED:
+        scm_to_c_boxed(S2C_ARGS);
+        break;
+    case G_TYPE_PARAM:
+        //scm_to_c_param(S2C_ARGS);
+        UNHANDLED;
+        break;
+    case G_TYPE_OBJECT:
+        scm_to_c_object(S2C_ARGS);
+        break;
+    case G_TYPE_VARIANT:
+        scm_to_c_variant(S2C_ARGS);
+        break;
     default:
-        g_assert_not_reached();
+        UNHANDLED;
         break;
     }
 }
 
-gchar *
-gig_argument_describe_arg(GIArgInfo *arg_info)
-{
-    GString *desc = g_string_new(NULL);
-    GITypeInfo *type_info = g_arg_info_get_type(arg_info);
-    GITypeTag type_tag = g_type_info_get_tag(type_info);
-    gboolean is_ptr = g_type_info_is_pointer(type_info);
-
-    if (g_arg_info_may_be_null(arg_info))
-        g_string_append(desc, "#f for NULL or ");
-
-    if (!is_ptr) {
-        describe_non_pointer_type(desc, type_info);
-    }
-    else {
-        switch (type_tag) {
-        case GI_TYPE_TAG_BOOLEAN:
-        case GI_TYPE_TAG_UNICHAR:
-            g_string_append_printf(desc, "Unhandled argument type tag %d in %s:%d", type_tag,
-                                   __FILE__, __LINE__);
-
-            break;
-        case GI_TYPE_TAG_DOUBLE:
-        case GI_TYPE_TAG_FLOAT:
-        case GI_TYPE_TAG_INT16:
-        case GI_TYPE_TAG_INT32:
-        case GI_TYPE_TAG_INT64:
-        case GI_TYPE_TAG_INT8:
-        case GI_TYPE_TAG_UINT16:
-        case GI_TYPE_TAG_UINT32:
-        case GI_TYPE_TAG_UINT64:
-        case GI_TYPE_TAG_UINT8:
-            g_string_append_printf(desc, "bytevector containing elements %s",
-                                   g_type_tag_to_string(type_tag));
-            break;
-
-        case GI_TYPE_TAG_UTF8:
-            g_string_append(desc, "string");
-            break;
-        case GI_TYPE_TAG_FILENAME:
-            g_string_append(desc, "locale string");
-            break;
-
-        case GI_TYPE_TAG_VOID:
-            g_string_append(desc, "pointer");
-            break;
-
-        case GI_TYPE_TAG_GHASH:
-            g_string_append(desc, "<GHash>");
-            break;
-        case GI_TYPE_TAG_GLIST:
-            g_string_append(desc, "<GList>");
-            break;
-        case GI_TYPE_TAG_GSLIST:
-            g_string_append(desc, "<GSList>");
-            break;
-
-        case GI_TYPE_TAG_INTERFACE:
-        {
-            GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
-            GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-            if (referenced_base_type == GI_INFO_TYPE_ENUM ||
-                referenced_base_type == GI_INFO_TYPE_FLAGS)
-                g_string_printf(desc, "bytevector containing %s",
-                                g_base_info_get_name(referenced_base_info));
-            else if (referenced_base_type == GI_INFO_TYPE_CALLBACK)
-                g_string_printf(desc, "list of procedures of type %s",
-                                g_base_info_get_name(referenced_base_info));
-            else if (referenced_base_type == GI_INFO_TYPE_STRUCT
-                     || referenced_base_type == GI_INFO_TYPE_UNION
-                     || referenced_base_type == GI_INFO_TYPE_OBJECT
-                     || referenced_base_type == GI_INFO_TYPE_INTERFACE) {
-                GType type = g_registered_type_info_get_g_type(referenced_base_info);
-                gchar *class_name = gig_type_class_name_from_gtype(type);
-                g_string_append(desc, class_name);
-                g_free(class_name);
-            }
-            else
-                g_string_append_printf(desc, "Unhandled argument type tag %d in %s:%d", type_tag,
-                                       __FILE__, __LINE__);
-            g_base_info_unref(referenced_base_info);
-            break;
-        }
-
-        case GI_TYPE_TAG_GTYPE:
-            g_string_append(desc, "GType");
-            break;
-
-        case GI_TYPE_TAG_ERROR:
-            g_string_append(desc, "<GError>");
-            break;
-
-        case GI_TYPE_TAG_ARRAY:
-        {
-            GIArrayType array_type = g_type_info_get_array_type(type_info);
-            if (array_type == GI_ARRAY_TYPE_BYTE_ARRAY)
-                g_string_append_printf(desc, "A bytevector containing unspecified binary data");
-            else if (array_type == GI_ARRAY_TYPE_C) {
-                GITypeInfo *item_type_info = g_type_info_get_param_type(type_info, 0);
-                GITypeTag item_type_tag = g_type_info_get_tag(item_type_info);
-                if (item_type_tag == GI_TYPE_TAG_INTERFACE) {
-                    GIBaseInfo *referenced_base_info = g_type_info_get_interface(item_type_info);
-                    GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-                    referenced_base_info = g_type_info_get_interface(item_type_info);
-                    referenced_base_type = g_base_info_get_type(referenced_base_info);
-                    if (referenced_base_type == GI_INFO_TYPE_ENUM)
-                        g_string_append_printf(desc,
-                                               "A list of enum values of type %s as integers",
-                                               g_base_info_get_name(referenced_base_info));
-                    else if (referenced_base_type == GI_INFO_TYPE_FLAGS)
-                        g_string_append_printf(desc,
-                                               "A list of flag values of type %s as integers",
-                                               g_base_info_get_name(referenced_base_info));
-                    else if (referenced_base_type == GI_INFO_TYPE_STRUCT
-                             || referenced_base_type == GI_INFO_TYPE_UNION
-                             || referenced_base_type == GI_INFO_TYPE_OBJECT) {
-                        GType type = g_registered_type_info_get_g_type(referenced_base_info);
-                        gchar *class_name = gig_type_class_name_from_gtype(type);
-                        g_string_append_printf(desc, "A list of %s", class_name);
-                        g_free(class_name);
-                    }
-                }
-                else if (item_type_tag == GI_TYPE_TAG_BOOLEAN)
-                    g_string_append_printf(desc, "A list of booleans");
-                else if (item_type_tag == GI_TYPE_TAG_INT8)
-                    g_string_append_printf(desc, "A bytevector containing int8");
-                else if (item_type_tag == GI_TYPE_TAG_UINT8)
-                    g_string_append_printf(desc, "A bytevector containing uint8");
-                else if (item_type_tag == GI_TYPE_TAG_INT16)
-                    g_string_append_printf(desc, "A bytevector containing int16");
-                else if (item_type_tag == GI_TYPE_TAG_UINT16)
-                    g_string_append_printf(desc, "A bytevector containing uint16");
-                else if (item_type_tag == GI_TYPE_TAG_INT32)
-                    g_string_append_printf(desc, "A bytevector containing int32");
-                else if (item_type_tag == GI_TYPE_TAG_UINT32)
-                    g_string_append_printf(desc, "A bytevector containing uint32");
-                else if (item_type_tag == GI_TYPE_TAG_INT64)
-                    g_string_append_printf(desc, "A bytevector containing int64");
-                else if (item_type_tag == GI_TYPE_TAG_UINT64)
-                    g_string_append_printf(desc, "A bytevector containing uint64");
-                else if (item_type_tag == GI_TYPE_TAG_FLOAT)
-                    g_string_append_printf(desc,
-                                           "A bytevector containing %d-byte floating-point numbers",
-                                           (int)sizeof(float));
-                else if (item_type_tag == GI_TYPE_TAG_DOUBLE)
-                    g_string_append_printf(desc,
-                                           "A bytevector containing %d-byte floating-point numbers",
-                                           (int)sizeof(double));
-                else if (gi_type_tag_is_string(item_type_tag))
-                    g_string_append_printf(desc, "A list of strings");
-                else if (item_type_tag == GI_TYPE_TAG_GTYPE)
-                    g_string_append_printf(desc, "A list of <GType>");
-                else {
-                    g_string_append_printf(desc,
-                                           "A bytevector containing some unknown type tag %d",
-                                           item_type_tag);
-                    g_critical("Unhandled array entry type in %s:%d", __FILE__, __LINE__);
-                }
-            }
-            break;
-        }
-
-        default:
-            g_assert_not_reached();
-        }
-    }
-    g_base_info_unref(type_info);
-
-    return g_string_free(desc, FALSE);
-}
-#endif
-
 static void
-scm_to_c_immediate(S2C_ARG_DECL)
+scm_to_c_char(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     GType t = meta->gtype;
     if (t == G_TYPE_CHAR) {
         if (SCM_CHARP(object)) {
@@ -530,7 +268,21 @@ scm_to_c_immediate(S2C_ARG_DECL)
         else
             arg->v_uint8 = scm_to_uint8(object);
     }
-    else if (t == G_TYPE_INT16) {
+}
+
+static void
+scm_to_c_boolean(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    arg->v_boolean = scm_is_true(object);
+}
+
+static void
+scm_to_c_integer(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    GType t = meta->gtype;
+    if (t == G_TYPE_INT16) {
         if (!scm_is_signed_integer(object, INT16_MIN, INT16_MAX))
             scm_wrong_type_arg_msg(subr, argpos, object, "int16");
         arg->v_int16 = scm_to_int16(object);
@@ -560,10 +312,26 @@ scm_to_c_immediate(S2C_ARG_DECL)
             scm_wrong_type_arg_msg(subr, argpos, object, "uint64");
         arg->v_uint64 = scm_to_uint64(object);
     }
-    else if (t == G_TYPE_BOOLEAN) {
-        arg->v_boolean = scm_is_true(object);
+    else if (t == G_TYPE_UNICHAR) {
+        if (SCM_CHARP(object))
+            arg->v_uint32 = SCM_CHAR(object);
+        else if (scm_is_unsigned_integer(object, 0, SCM_CODEPOINT_MAX))
+            arg->v_uint32 = scm_to_uint32(object);
+        else {
+            scm_wrong_type_arg_msg(subr, argpos, object, "char");
+        }
     }
-    else if (t == G_TYPE_FLOAT) {
+    else
+        UNHANDLED;
+}
+
+static void
+scm_to_c_real(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    GType t = meta->gtype;
+
+    if (t == G_TYPE_FLOAT) {
         if (!scm_is_real(object))
             scm_wrong_type_arg_msg(subr, argpos, object, "float32");
         gdouble dtmp = scm_to_double(object);
@@ -576,74 +344,108 @@ scm_to_c_immediate(S2C_ARG_DECL)
             scm_wrong_type_arg_msg(subr, argpos, object, "float64");
         arg->v_double = scm_to_double(object);
     }
-    else if (t == G_TYPE_GTYPE) {
-        if (!scm_is_unsigned_integer(object, 0, UINT64_MAX))
-            scm_wrong_type_arg_msg(subr, argpos, object, "GType integer");
-        arg->v_size = scm_to_size_t(object);
-    }
-    else if (t == G_TYPE_UNICHAR) {
-        if (SCM_CHARP(object))
-            arg->v_uint32 = SCM_CHAR(object);
-        else if (scm_is_unsigned_integer(object, 0, SCM_CODEPOINT_MAX))
-            arg->v_uint32 = scm_to_uint32(object);
-        else
-            scm_wrong_type_arg_msg(subr, argpos, object, "char");
-    }
     else
-        // Should never get here.
-        g_assert_not_reached();
+        UNHANDLED;
 }
 
-// Handle SCM conversion to non-pointer objects that aren't simple C
-// types.
 static void
-scm_to_c_interface(S2C_ARG_DECL)
+scm_to_c_enum(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     GType fundamental_type = G_TYPE_FUNDAMENTAL(meta->gtype);
     if (fundamental_type == G_TYPE_ENUM)
         arg->v_int = scm_to_int(object);
     else if (fundamental_type == G_TYPE_FLAGS)
         arg->v_uint = scm_to_uint(object);
+    else
+        UNHANDLED;
+}
+
+static void
+scm_to_c_pointer(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    if (scm_is_false(object) && meta->is_nullable)
+        arg->v_pointer = NULL;
     else if (meta->gtype == G_TYPE_CALLBACK) {
         if (scm_is_true(scm_procedure_p(object))) {
             arg->v_pointer = gig_callback_get_ptr(meta->callable_info, object);
             g_assert(arg->v_pointer != NULL);
         }
+        else
+            scm_wrong_type_arg_msg(subr, argpos, object, "a procedure");
     }
-    else if (fundamental_type == G_TYPE_BOXED || fundamental_type == G_TYPE_OBJECT) {
+    else if (meta->gtype == G_TYPE_GTYPE) {
+        if (!scm_is_unsigned_integer(object, 0, UINT64_MAX))
+            scm_wrong_type_arg_msg(subr, argpos, object, "GType integer");
+        arg->v_size = scm_to_size_t(object);
+    }
+    else if (SCM_POINTER_P(object))
+        arg->v_pointer = scm_to_pointer(object);
+    else if (scm_is_bytevector(object))
+        arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(object);
+    else
+        UNHANDLED;
+}
+
+static void
+scm_to_c_boxed(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    GType t = meta->gtype;
+    if (meta->is_nullable && scm_is_false(object)) {
+        arg->v_pointer = NULL;
+    }
+    else if (t == G_TYPE_LENGTH_CARRAY
+             || t == G_TYPE_ZERO_TERMINATED_CARRAY || t == G_TYPE_FIXED_SIZE_CARRAY)
+        scm_to_c_native_array(S2C_ARGS);
+    else if (t == G_TYPE_ARRAY)
+        scm_to_c_garray(S2C_ARGS);
+    else if (t == G_TYPE_BYTE_ARRAY)
+        scm_to_c_byte_array(S2C_ARGS);
+    else
         arg->v_pointer = gig_type_peek_object(object);
+}
+
+static void
+scm_to_c_object(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    if (meta->is_nullable && scm_is_false(object)) {
+        arg->v_pointer = NULL;
+    }
+    else
+        arg->v_pointer = gig_type_peek_object(object);
+}
+
+static void
+scm_to_c_variant(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    arg->v_pointer = gig_type_peek_object(object);
+}
+
+static void
+scm_to_c_interface(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    if (meta->is_nullable && scm_is_false(object)) {
+        arg->v_pointer = NULL;
+        return;
     }
     else
         UNHANDLED;
 }
 
-#if 0
-static void
-scm_to_c_immediate_pointer(S2C_ARG_DECL)
-{
-    // Here we handle the uncommon case of converting an SCM to a
-    // pointer to a simple C type like 'int *', but not objects or
-    // arrays, which are handled elsewhere.
-
-    // We'll require an input of bytevectors, since they can apply to
-    // most cases, and this case is underspecified anyway.
-    if (!scm_is_bytevector(object)) {
-        scm_wrong_type_arg_msg(subr, argpos, object, "a bytevector");
-    }
-    else {
-        // FIXME: add bytevector minimum length checks.
-        if (meta->transfer == GI_TRANSFER_EVERYTHING)
-            arg->v_pointer =
-                g_memdup(SCM_BYTEVECTOR_CONTENTS(object), SCM_BYTEVECTOR_LENGTH(object));
-        else
-            arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(object);
-    }
-}
-#endif
-
 static void
 scm_to_c_string(S2C_ARG_DECL)
 {
+    TRACE_S2C();
+    if (meta->is_nullable && scm_is_false(object)) {
+        arg->v_pointer = NULL;
+        return;
+    }
+
     // Here we convert an input string into an argument.  The input
     // string is either UTF8 or locale encoded.
     if (scm_is_bytevector(object)) {
@@ -680,74 +482,11 @@ scm_to_c_string(S2C_ARG_DECL)
         scm_wrong_type_arg_msg(subr, argpos, object, "string or bytevector");
 }
 
-static void
-scm_to_c_void_pointer(S2C_ARG_DECL)
-{
-    if (SCM_POINTER_P(object))
-        arg->v_pointer = scm_to_pointer(object);
-    else if (scm_is_bytevector(object))
-        arg->v_pointer = SCM_BYTEVECTOR_CONTENTS(object);
-    else
-        UNHANDLED;
-
-    //scm_wrong_type_arg_msg(subr, argpos, object, "pointer");
-}
-
-#if 0
-static void
-scm_to_c_interface_pointer(S2C_ARG_DECL)
-{
-    // Usually STRUCT, UNION, INTERFACE, OBJECT.  Handle NULL_OK
-    g_assert_cmpint(meta->type_tag, ==, GI_TYPE_TAG_INTERFACE);
-    GIBaseInfo *referenced_base_info = g_type_info_get_interface(meta->type_info);
-    GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-
-    GType obj_type = gig_type_get_gtype_from_obj(object);
-    if (obj_type == G_TYPE_NONE || obj_type == G_TYPE_INVALID)
-        scm_wrong_type_arg_msg(subr, argpos, object,
-                               "a GObject struct, union, interface, or object");
-
-    GType arg_type = g_registered_type_info_get_g_type(referenced_base_info);
-    if (!g_type_is_a(obj_type, arg_type)) {
-        gchar msg[80];
-        snprintf(msg, 80, "a GObject that is a type of %s", g_type_name(arg_type));
-        scm_wrong_type_arg_msg(subr, argpos, object, msg);
-    }
-    else if ((referenced_base_type == GI_INFO_TYPE_STRUCT)
-             || (referenced_base_type == GI_INFO_TYPE_UNION)
-             || (referenced_base_type == GI_INFO_TYPE_OBJECT)) {
-        arg->v_pointer = gig_type_peek_object(object);
-    }
-    else if (referenced_base_type == GI_INFO_TYPE_CALLBACK) {
-        scm_misc_error(subr,
-                       "Marshalling to C callback pointer args is unimplemented: ~S",
-                       scm_list_1(object));
-    }
-    else if (referenced_base_type == GI_INFO_TYPE_INTERFACE) {
-        scm_misc_error(subr,
-                       "Marshalling to C interface pointer args is unimplemented: ~S",
-                       scm_list_1(object));
-    }
-    g_base_info_unref(referenced_base_info);
-}
-#endif
-
-static void
-scm_to_c_array(S2C_ARG_DECL)
-{
-    GType t = meta->gtype;
-    if (t == G_TYPE_LENGTH_CARRAY
-        || t == G_TYPE_ZERO_TERMINATED_CARRAY || t == G_TYPE_FIXED_SIZE_CARRAY)
-        scm_to_c_native_array(S2C_ARGS);
-    else if (t == G_TYPE_ARRAY)
-        scm_to_c_garray(S2C_ARGS);
-    else
-        UNHANDLED;
-}
 
 static void
 scm_to_c_native_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     GType item_type = meta->params[0].gtype;
     GType fundamental_item_type = G_TYPE_FUNDAMENTAL(item_type);
 
@@ -778,6 +517,7 @@ scm_to_c_native_array(S2C_ARG_DECL)
 static void
 scm_to_c_native_boolean_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     // For booleans, we expect a vector of booleans
     if (!scm_is_vector(object))
         scm_wrong_type_arg_msg(subr, argpos, object, "vector of booleans");
@@ -798,6 +538,7 @@ scm_to_c_native_boolean_array(S2C_ARG_DECL)
 static void
 scm_to_c_native_unichar_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     // When asked to convert an SCM to an array of unichars,
     // we expect that SCM to be a string.
     if (!scm_is_string(object))
@@ -819,6 +560,7 @@ scm_to_c_native_unichar_array(S2C_ARG_DECL)
 static void
 scm_to_c_native_immediate_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
 #define FUNC_NAME "%object->c-native-immediate-array-arg"
     // IMMEDIATE TYPES.  It seems only double, and 8 and 32-bit
     // integer arrays are ever used. Sometimes deep copy.  Sometimes
@@ -864,15 +606,15 @@ scm_to_c_native_immediate_array(S2C_ARG_DECL)
 #undef FUNC_NAME
 }
 
-#if 0
 static void
 scm_to_c_byte_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     if (scm_is_bytevector(object)) {
         gpointer contents = SCM_BYTEVECTOR_CONTENTS(object);
         gsize len = SCM_BYTEVECTOR_LENGTH(object);
         *size = len;
-        if (meta->transfer == GI_TRANSFER_EVERYTHING)
+        if (meta->is_transfer_ownership == GI_TRANSFER_EVERYTHING)
             arg->v_pointer = g_byte_array_new_take(contents, len);
         else
             arg->v_pointer = g_byte_array_new_take(g_memdup(contents, len), len);
@@ -880,11 +622,11 @@ scm_to_c_byte_array(S2C_ARG_DECL)
     else
         scm_wrong_type_arg_msg(subr, argpos, object, "bytevector");
 }
-#endif
 
 static void
 scm_to_c_garray(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     GIArgument _arg;
     GigTypeMeta _meta = *meta;
     _meta.gtype = G_TYPE_LENGTH_CARRAY;
@@ -894,74 +636,12 @@ scm_to_c_garray(S2C_ARG_DECL)
     ((GArray *)(arg->v_pointer))->data = _arg.v_pointer;
 }
 
-#if 0
-static void
-scm_to_c_ptr_array(S2C_ARG_DECL)
-{
-#define FUNC_NAME "%object->c-ptr-array-arg"
-    scm_misc_error(FUNC_NAME,
-                   "Marshalling to C ptr array pointer args is unimplemented: ~S",
-                   scm_list_1(object));
-#undef FUNC_NAME
-}
-
-static void
-scm_to_c_native_direct_struct_array(S2C_ARG_DECL)
-{
-    // This is the uncommon case of the argument containing
-    // an array of structs themselves, rather than an array
-    // of pointers to structs.  These may be null terminated.
-    // For example, gtk_tree_view_enable_model_drag_dest
-    gsize len = scm_to_size_t(scm_length(object));
-    gpointer ptr;
-    if (meta->array_is_zero_terminated)
-        ptr = g_malloc0_n(meta->item_size, len + 1);
-    else
-        ptr = g_malloc0_n(meta->item_size, len);
-    LATER_FREE(ptr);
-    gpointer entry_ptr = gig_type_peek_object(object);
-    for (gsize i = 0; i < len; i++)
-        memcpy((char *)ptr + i * meta->item_size, entry_ptr, meta->item_size);
-}
-#endif
-
-#if 0
-static void
-scm_to_c_native_indirect_object_array(S2C_ARG_DECL)
-{
-    gsize len = scm_to_size_t(scm_length(object));
-    gpointer *ptr;
-    if (meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY)
-        ptr = g_malloc0_n(sizeof(gpointer), len + 1);
-    else
-        ptr = g_malloc0_n(sizeof(gpointer), len);
-    LATER_FREE(ptr);
-    for (gsize i = 0; i < len; i++) {
-        SCM elt = scm_list_ref(object, scm_from_size_t(i));
-        // Entry should be a GObject.  I guess we're not
-        // increasing refcnt?  At least that is the case for
-        // g_socket_send_message.
-        ptr[i] = gig_type_peek_object(elt);
-    }
-}
-#endif
-
 static void
 scm_to_c_native_interface_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
 #define FUNC_NAME "%object->c-native-interface-array-arg"
-#if 0
-    if ((meta->referenced_base_type == GI_INFO_TYPE_ENUM)
-        || (meta->referenced_base_type == GI_INFO_TYPE_FLAGS)) {
-        // We haven't bothered to make a special flag or enum
-        // class on the Scheme side of things.  On the scheme
-        // side, enums and flags are just variables holding
-        // integers.
-        scm_to_c_native_immediate_array(S2C_ARGS);
-    }
-    else
-#endif
-        GType item_type = meta->params[0].gtype;
+    GType item_type = meta->params[0].gtype;
     GType fundamental_item_type = G_TYPE_FUNDAMENTAL(item_type);
     if (fundamental_item_type == G_TYPE_OBJECT
         || fundamental_item_type == G_TYPE_INTERFACE || fundamental_item_type == G_TYPE_VARIANT) {
@@ -1017,9 +697,12 @@ scm_to_c_native_interface_array(S2C_ARG_DECL)
 #undef FUNC_NAME
 }
 
+
+
 static void
 scm_to_c_native_string_array(S2C_ARG_DECL)
 {
+    TRACE_S2C();
     // This is a C array of string pointers, e.g. char **
 
     // We're adding a NULL termination to the list of strings
@@ -1081,179 +764,83 @@ gig_argument_c_to_scm(C2S_ARG_DECL)
     TRACE_C2S();
 
     GType fundamental_type = G_TYPE_FUNDAMENTAL(meta->gtype);
-    if (!meta->is_ptr) {
-        TRACE_C2S();
-        switch (fundamental_type) {
-        case G_TYPE_NONE:
-            *object = SCM_UNSPECIFIED;
-            break;
-        case G_TYPE_CHAR:
-        case G_TYPE_UCHAR:
-        case G_TYPE_BOOLEAN:
-        case G_TYPE_INT:
-        case G_TYPE_UINT:
-        case G_TYPE_INT64:
-        case G_TYPE_UINT64:
-        case G_TYPE_FLOAT:
-        case G_TYPE_DOUBLE:
-            c_immediate_to_scm(C2S_ARGS);
-            break;
-        case G_TYPE_ENUM:
-        case G_TYPE_FLAGS:
-            c_interface_to_scm(C2S_ARGS);
-            break;
-        case G_TYPE_POINTER:
-            if (meta->gtype == G_TYPE_GTYPE)
-                *object = scm_from_uintptr_t(arg->v_pointer);
-            else
-                UNHANDLED;
-            break;
-        default:
-            UNHANDLED;
-            break;
-        }
-    }
-    else if (meta->is_nullable && (arg == NULL || arg->v_pointer == NULL)) {
-        *object = SCM_BOOL_F;
-    }
-    else {
-        TRACE_C2S();
-        switch (fundamental_type) {
-        case G_TYPE_STRING:
-            c_string_to_scm(C2S_ARGS);
-            break;
-        case G_TYPE_BOXED:
-        case G_TYPE_INTERFACE:
-            if (meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY
-                || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
-                || meta->gtype == G_TYPE_LENGTH_CARRAY)
-                c_native_array_to_scm(C2S_ARGS);
-            else
-                c_interface_pointer_to_scm(C2S_ARGS);
-            break;
-        case G_TYPE_POINTER:
-            if (meta->gtype == G_TYPE_POINTER)
-                c_void_pointer_to_scm(C2S_ARGS);
-            else
-                UNHANDLED;
-            break;
-        case G_TYPE_VARIANT:
-        case G_TYPE_OBJECT:
-        case G_TYPE_PARAM:
-            c_interface_pointer_to_scm(C2S_ARGS);
-            break;
-        default:
-            UNHANDLED;
-            break;
-
-        }
+    TRACE_C2S();
+    switch (fundamental_type) {
+    case G_TYPE_NONE:
+        *object = SCM_UNSPECIFIED;
+        break;
+    case G_TYPE_INTERFACE:
+        c_interface_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_CHAR:
+    case G_TYPE_UCHAR:
+        c_char_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_BOOLEAN:
+        c_boolean_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_INT:
+    case G_TYPE_UINT:
+    case G_TYPE_LONG:
+    case G_TYPE_ULONG:
+    case G_TYPE_INT64:
+    case G_TYPE_UINT64:
+        c_integer_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_ENUM:
+    case G_TYPE_FLAGS:
+        c_enum_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_FLOAT:
+    case G_TYPE_DOUBLE:
+        c_real_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_STRING:
+        c_string_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_POINTER:
+        c_pointer_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_BOXED:
+        c_boxed_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_PARAM:
+        c_param_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_OBJECT:
+        c_object_to_scm(C2S_ARGS);
+        break;
+    case G_TYPE_VARIANT:
+        c_variant_to_scm(C2S_ARGS);
+        break;
+    default:
+        UNHANDLED;
+        break;
     }
 }
-
-#if 0
-gchar *
-gig_argument_describe_return(GITypeInfo *type_info,
-                             GITransfer transfer, gboolean null_ok, gboolean skip)
-{
-    GString *desc = g_string_new(NULL);
-    if (skip) {
-        g_string_append(desc, "unspecified");
-        goto ret_end;
-    }
-    if (null_ok)
-        g_string_append(desc, "#f for NULL or ");
-
-    GITypeTag type_tag = g_type_info_get_tag(type_info);
-    gboolean is_ptr = g_type_info_is_pointer(type_info);
-
-    if (!is_ptr) {
-        switch (type_tag) {
-        case GI_TYPE_TAG_VOID:
-            g_string_append(desc, "unspecified");
-            break;
-        default:
-            describe_non_pointer_type(desc, type_info);
-            break;
-        }
-    }
-    else {
-        switch (type_tag) {
-        case GI_TYPE_TAG_BOOLEAN:
-        case GI_TYPE_TAG_DOUBLE:
-        case GI_TYPE_TAG_FLOAT:
-        case GI_TYPE_TAG_INT16:
-        case GI_TYPE_TAG_INT32:
-        case GI_TYPE_TAG_INT64:
-        case GI_TYPE_TAG_INT8:
-        case GI_TYPE_TAG_UINT16:
-        case GI_TYPE_TAG_UINT32:
-        case GI_TYPE_TAG_UINT64:
-        case GI_TYPE_TAG_UINT8:
-        case GI_TYPE_TAG_UNICHAR:
-        case GI_TYPE_TAG_VOID:
-            g_string_append(desc, "a pointer");
-            break;
-
-        case GI_TYPE_TAG_UTF8:
-        case GI_TYPE_TAG_FILENAME:
-            g_string_append(desc, "a string");
-            break;
-
-        case GI_TYPE_TAG_GHASH:
-            g_string_append(desc, "a hash");
-            break;
-        case GI_TYPE_TAG_GLIST:
-        case GI_TYPE_TAG_GSLIST:
-            g_string_append(desc, "a list");
-            break;
-
-        case GI_TYPE_TAG_INTERFACE:
-        {
-            GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
-            GIInfoType referenced_base_type = g_base_info_get_type(referenced_base_info);
-            GType referenced_base_gtype = g_registered_type_info_get_g_type(referenced_base_info);
-            g_base_info_unref(referenced_base_info);
-
-            if (referenced_base_type == GI_INFO_TYPE_STRUCT ||
-                referenced_base_type == GI_INFO_TYPE_UNION ||
-                referenced_base_type == GI_INFO_TYPE_OBJECT ||
-                referenced_base_type == GI_INFO_TYPE_INTERFACE) {
-                gchar *class_name = gig_type_class_name_from_gtype(referenced_base_gtype);
-                g_string_append(desc, class_name);
-                g_free(class_name);
-            }
-            else
-                g_string_append(desc, g_type_name(referenced_base_gtype));
-            break;
-        }
-        case GI_TYPE_TAG_GTYPE:
-            g_string_append(desc, "a GType");
-            break;
-        case GI_TYPE_TAG_ERROR:
-            g_string_append(desc, "a GError");
-            break;
-        case GI_TYPE_TAG_ARRAY:
-            g_string_append(desc, "an array");
-            break;
-        default:
-            g_assert_not_reached();
-        }
-    }
-  ret_end:
-    return g_string_free(desc, FALSE);
-}
-#endif
 
 static void
-c_immediate_to_scm(C2S_ARG_DECL)
+c_char_to_scm(C2S_ARG_DECL)
 {
-    if (meta->gtype == G_TYPE_BOOLEAN)
-        *object = scm_from_bool(arg->v_boolean);
-    else if (meta->gtype == G_TYPE_CHAR)
+    TRACE_C2S();
+    if (meta->gtype == G_TYPE_CHAR)
         *object = scm_from_int8(arg->v_int8);
     else if (meta->gtype == G_TYPE_UCHAR)
         *object = scm_from_uint8(arg->v_uint8);
-    else if (meta->gtype == G_TYPE_INT16)
+}
+
+static void
+c_boolean_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    *object = scm_from_bool(arg->v_boolean);
+}
+
+static void
+c_integer_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    if (meta->gtype == G_TYPE_INT16)
         *object = scm_from_int16(arg->v_int16);
     else if (meta->gtype == G_TYPE_UINT16)
         *object = scm_from_uint16(arg->v_uint16);
@@ -1265,72 +852,87 @@ c_immediate_to_scm(C2S_ARG_DECL)
         *object = scm_from_int64(arg->v_int64);
     else if (meta->gtype == G_TYPE_UINT64)
         *object = scm_from_uint64(arg->v_uint64);
-    else if (meta->gtype == G_TYPE_FLOAT)
-        *object = scm_from_double((double)arg->v_float);
-    else if (meta->gtype == G_TYPE_DOUBLE)
-        *object = scm_from_double(arg->v_double);
     else if (meta->gtype == G_TYPE_UNICHAR)
         *object = SCM_MAKE_CHAR(arg->v_uint32);
     else
-        g_error("Unhandled argument type '%s' %s %d", gig_type_meta_describe(meta), __FILE__,
-                __LINE__);
+        UNHANDLED;
 }
 
 static void
-c_interface_pointer_to_scm(C2S_ARG_DECL)
+c_real_to_scm(C2S_ARG_DECL)
 {
     TRACE_C2S();
-    g_assert_cmpint(meta->is_ptr, ==, TRUE);
-    g_assert_nonnull(arg);
-
-    GType fundamental_type = G_TYPE_FUNDAMENTAL(meta->gtype);
-    if (fundamental_type == G_TYPE_BOXED) {
-        if (meta->gtype == G_TYPE_BYTE_ARRAY)
-            c_byte_array_to_scm(C2S_ARGS);
-        else if (meta->gtype == G_TYPE_ARRAY)
-            c_garray_to_scm(C2S_ARGS);
-        else if (meta->gtype == G_TYPE_PTR_ARRAY)
-            c_gptrarray_to_scm(C2S_ARGS);
-        else if (meta->gtype == G_TYPE_LIST || meta->gtype == G_TYPE_SLIST)
-            c_list_to_scm(C2S_ARGS);
-        else
-            *object =
-                gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
-    }
-    else if (fundamental_type == G_TYPE_INTERFACE || fundamental_type == G_TYPE_OBJECT) {
-        *object =
-            gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
-    }
-    else if (fundamental_type == G_TYPE_VARIANT) {
-        // FIXME: is there special processing for floating refs?
-        *object =
-            gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
-    }
-    else if (fundamental_type == G_TYPE_PARAM) {
-        // FIXME: is there special processing for GParamSpec
-        *object =
-            gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
-    }
+    if (meta->gtype == G_TYPE_FLOAT)
+        *object = scm_from_double((double)arg->v_float);
+    else if (meta->gtype == G_TYPE_DOUBLE)
+        *object = scm_from_double(arg->v_double);
     else
-        g_assert_not_reached();
+        UNHANDLED;
+}
+
+static void
+c_boxed_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    if (meta->gtype == G_TYPE_LENGTH_CARRAY) {
+        meta->length = size;
+        c_native_array_to_scm(C2S_ARGS);
+    }
+    else if (meta->gtype == G_TYPE_FIXED_SIZE_CARRAY ||
+             meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY)
+        c_native_array_to_scm(C2S_ARGS);
+    else if (meta->gtype == G_TYPE_BYTE_ARRAY)
+        c_byte_array_to_scm(C2S_ARGS);
+    else if (meta->gtype == G_TYPE_ARRAY)
+        c_garray_to_scm(C2S_ARGS);
+    else if (meta->gtype == G_TYPE_PTR_ARRAY)
+        c_gptrarray_to_scm(C2S_ARGS);
+    else if (meta->gtype == G_TYPE_LIST || meta->gtype == G_TYPE_SLIST)
+        c_list_to_scm(C2S_ARGS);
+    else
+        *object =
+            gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
 }
 
 static void
 c_interface_to_scm(C2S_ARG_DECL)
 {
     TRACE_C2S();
-    GType fundamental_type = G_TYPE_FUNDAMENTAL(meta->gtype);
-    if (fundamental_type == G_TYPE_ENUM || fundamental_type == G_TYPE_FLAGS)
-        *object = scm_from_uint32(arg->v_uint32);
-    else
-        g_error("Unhandled argument type '%s' %s %d", gig_type_meta_describe(meta), __FILE__,
-                __LINE__);
+    *object = gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
+}
 
+static void
+c_object_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    *object = gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
+}
+
+static void
+c_variant_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    *object = gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
+}
+
+static void
+c_param_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    *object = gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
+}
+
+static void
+c_enum_to_scm(C2S_ARG_DECL)
+{
+    TRACE_C2S();
+    *object = scm_from_uint32(arg->v_uint32);
 }
 
 static void
 c_string_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     // We can't transfer strings directly, since GObject and Guile use
     // different internal encodings.  So for GI_TRANSFER_EVERYTHGING,
     // we just free.
@@ -1363,6 +965,7 @@ c_string_to_scm(C2S_ARG_DECL)
 static void
 c_array_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     if (meta->gtype == G_TYPE_LENGTH_CARRAY)
         meta->length = size;
     if (meta->gtype == G_TYPE_LENGTH_CARRAY
@@ -1377,9 +980,14 @@ c_array_to_scm(C2S_ARG_DECL)
 static void
 c_native_array_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     gsize length = array_length(meta, arg);
     if (length == GIG_ARRAY_SIZE_UNKNOWN) {
         length = size;
+    }
+    if (length == 0 && meta->is_nullable) {
+        *object = SCM_BOOL_F;
+        return;
     }
 
 #define TRANSFER(_type,_short_type)                                     \
@@ -1519,6 +1127,7 @@ c_native_array_to_scm(C2S_ARG_DECL)
 static void
 c_byte_array_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     GByteArray *byte_array = arg->v_pointer;
     *object = scm_c_make_bytevector(byte_array->len);
     memcpy(SCM_BYTEVECTOR_CONTENTS(*object), byte_array->data, byte_array->len);
@@ -1531,6 +1140,7 @@ c_byte_array_to_scm(C2S_ARG_DECL)
 static void
 c_garray_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     GigTypeMeta _meta = *meta;
     GIArgument _arg;
     GArray *array = arg->v_pointer;
@@ -1545,6 +1155,7 @@ c_garray_to_scm(C2S_ARG_DECL)
 static void
 c_gptrarray_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     GigTypeMeta _meta = *meta;
     GIArgument _arg;
     GPtrArray *array = arg->v_pointer;
@@ -1558,6 +1169,7 @@ c_gptrarray_to_scm(C2S_ARG_DECL)
 static void
 c_list_to_scm(C2S_ARG_DECL)
 {
+    TRACE_C2S();
     // Actual conversion
     gpointer list = arg->v_pointer, data;
     GList *_list = NULL;
@@ -1644,9 +1256,17 @@ c_list_to_scm(C2S_ARG_DECL)
 }
 
 static void
-c_void_pointer_to_scm(C2S_ARG_DECL)
+c_pointer_to_scm(C2S_ARG_DECL)
 {
-    if (size != GIG_ARRAY_SIZE_UNKNOWN) {
+    TRACE_C2S();
+    if (arg->v_pointer == NULL && meta->is_nullable)
+        *object = SCM_BOOL_F;
+    else if (meta->gtype == G_TYPE_GTYPE)
+        *object = scm_from_uintptr_t(arg->v_pointer);
+    else if (meta->gtype == G_TYPE_CALLBACK)
+        *object =
+            gig_type_transfer_object(meta->gtype, arg->v_pointer, meta->is_transfer_ownership);
+    else if (size != GIG_ARRAY_SIZE_UNKNOWN) {
         SCM bv = scm_c_make_bytevector(size);
         memcpy(SCM_BYTEVECTOR_CONTENTS(bv), arg->v_pointer, size);
         *object = bv;
@@ -1654,8 +1274,6 @@ c_void_pointer_to_scm(C2S_ARG_DECL)
     else
         *object = scm_from_pointer(arg->v_pointer, NULL);
 }
-
-
 
 #define SCONSTX(NAME) scm_permanent_object(scm_c_define(#NAME, scm_from_int(NAME)))
 

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -229,18 +229,17 @@ gig_argument_scm_to_c(S2C_ARG_DECL)
             scm_to_c_string(S2C_ARGS);
             break;
         case G_TYPE_POINTER:
-            if (meta->gtype == G_TYPE_LENGTH_CARRAY
-                || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
-                || meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY)
-                scm_to_c_array(S2C_ARGS);
-            else if (meta->gtype == G_TYPE_POINTER)
+            if (meta->gtype == G_TYPE_POINTER)
                 scm_to_c_void_pointer(S2C_ARGS);
             else
                 UNHANDLED;
             break;
         case G_TYPE_BOXED:
         case G_TYPE_OBJECT:
-            if (meta->gtype == G_TYPE_ARRAY)
+            if (meta->gtype == G_TYPE_LENGTH_CARRAY
+                || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
+                || meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY
+                || meta->gtype == G_TYPE_ARRAY)
                 scm_to_c_array(S2C_ARGS);
             else
                 scm_to_c_interface(S2C_ARGS);
@@ -1125,15 +1124,16 @@ gig_argument_c_to_scm(C2S_ARG_DECL)
             break;
         case G_TYPE_BOXED:
         case G_TYPE_INTERFACE:
-            c_interface_pointer_to_scm(C2S_ARGS);
+            if (meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY
+                || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
+                || meta->gtype == G_TYPE_LENGTH_CARRAY)
+                c_native_array_to_scm(C2S_ARGS);
+            else
+                c_interface_pointer_to_scm(C2S_ARGS);
             break;
         case G_TYPE_POINTER:
             if (meta->gtype == G_TYPE_POINTER)
                 c_void_pointer_to_scm(C2S_ARGS);
-            else if (meta->gtype == G_TYPE_ZERO_TERMINATED_CARRAY
-                     || meta->gtype == G_TYPE_FIXED_SIZE_CARRAY
-                     || meta->gtype == G_TYPE_LENGTH_CARRAY)
-                c_native_array_to_scm(C2S_ARGS);
             else
                 UNHANDLED;
             break;

--- a/src/gig_argument.h
+++ b/src/gig_argument.h
@@ -12,14 +12,14 @@ G_BEGIN_DECLS
 #define GIG_ARRAY_SIZE_UNKNOWN ((gsize)-1)
 
 #define S2C_ARG_DECL const gchar *subr, gint argpos,    \
-        GigArgMapEntry *entry, SCM object,               \
+        GigTypeMeta *meta, SCM object,               \
         GPtrArray *must_free, GIArgument *arg, gsize *size
-#define S2C_ARGS subr, argpos, entry, object, must_free, arg, size
+#define S2C_ARGS subr, argpos, meta, object, must_free, arg, size
 
 #define C2S_ARG_DECL const gchar *subr, gint argpos,    \
-        GigArgMapEntry *entry, GIArgument *arg,       \
+        GigTypeMeta *meta, GIArgument *arg,       \
         SCM *object, gsize size
-#define C2S_ARGS subr, argpos, entry, arg, object, size
+#define C2S_ARGS subr, argpos, meta, arg, object, size
 
 void gig_argument_scm_to_c(S2C_ARG_DECL);
 void gig_argument_c_to_scm(C2S_ARG_DECL);

--- a/src/gig_argument.h
+++ b/src/gig_argument.h
@@ -9,8 +9,6 @@
 G_BEGIN_DECLS
 // *INDENT-ON*
 
-#define GIG_ARRAY_SIZE_UNKNOWN ((gsize)-1)
-
 #define S2C_ARG_DECL const gchar *subr, gint argpos,    \
         GigTypeMeta *meta, SCM object,               \
         GPtrArray *must_free, GIArgument *arg, gsize *size

--- a/src/gig_argument.h
+++ b/src/gig_argument.h
@@ -17,7 +17,7 @@ G_BEGIN_DECLS
 #define S2C_ARGS subr, argpos, meta, object, must_free, arg, size
 
 #define C2S_ARG_DECL const gchar *subr, gint argpos,    \
-        GigTypeMeta *meta, GIArgument *arg,       \
+        GigTypeMeta *meta, GIArgument *arg,             \
         SCM *object, gsize size
 #define C2S_ARGS subr, argpos, meta, arg, object, size
 
@@ -26,8 +26,6 @@ void gig_argument_c_to_scm(C2S_ARG_DECL);
 char *gig_argument_describe_arg(GIArgInfo *arg_info);
 char *gig_argument_describe_return(GITypeInfo *type_info, GITransfer transfer, gboolean null_ok,
                                    gboolean skip);
-void gig_argument_preallocate_output_arg_and_object(GIArgInfo *arg_info, GIArgument *arg,
-                                                    SCM *obj);
 
 void gig_init_argument(void);
 

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -45,7 +45,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     g_assert_cmpint(n_args, ==, g_callable_info_get_n_args(gcb->callback_info));
 
     // FIXME: cache this
-    GigArgMap *amap = gig_arg_map_new(gcb->callback_info);
+    GigArgMap *amap = gig_amap_new(gcb->callback_info);
 
     for (guint i = 0; i < n_args; i++) {
         SCM s_entry = SCM_BOOL_F;
@@ -109,7 +109,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
         // I'll try brutally coercing the data, and see what happens.
         *(ffi_arg *) ret = giarg.v_uint64;
     }
-    gig_arg_map_free(amap);
+    gig_amap_free(amap);
 }
 
 static SCM

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -91,7 +91,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
             giarg.v_pointer = ffi_args[i];
         }
 
-        gig_argument_c_to_scm("callback", i, &amap->pdata[i], &giarg, &s_entry, -1);
+        gig_argument_c_to_scm("callback", i, &amap->pdata[i].meta, &giarg, &s_entry, -1);
         s_args = scm_append(scm_list_2(s_args, scm_list_1(s_entry)));
     }
 
@@ -104,7 +104,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     else {
         GIArgument giarg;
         gsize size;
-        gig_argument_scm_to_c("callback", 0, &amap->return_val, s_ret, NULL, &giarg, &size);
+        gig_argument_scm_to_c("callback", 0, &amap->return_val.meta, s_ret, NULL, &giarg, &size);
         // I'm pretty sure I don't need a big type case/switch block here.
         // I'll try brutally coercing the data, and see what happens.
         *(ffi_arg *) ret = giarg.v_uint64;

--- a/src/gig_callback.c
+++ b/src/gig_callback.c
@@ -91,7 +91,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
             giarg.v_pointer = ffi_args[i];
         }
 
-        gig_argument_c_to_scm("callback", i, amap->pdata[i], &giarg, &s_entry, -1);
+        gig_argument_c_to_scm("callback", i, &amap->pdata[i], &giarg, &s_entry, -1);
         s_args = scm_append(scm_list_2(s_args, scm_list_1(s_entry)));
     }
 
@@ -104,7 +104,7 @@ callback_binding(ffi_cif *cif, gpointer ret, gpointer *ffi_args, gpointer user_d
     else {
         GIArgument giarg;
         gsize size;
-        gig_argument_scm_to_c("callback", 0, amap->return_val, s_ret, NULL, &giarg, &size);
+        gig_argument_scm_to_c("callback", 0, &amap->return_val, s_ret, NULL, &giarg, &size);
         // I'm pretty sure I don't need a big type case/switch block here.
         // I'll try brutally coercing the data, and see what happens.
         *(ffi_arg *) ret = giarg.v_uint64;
@@ -143,8 +143,7 @@ callback_handler_proc(gpointer user_data, SCM key, SCM params)
     SCM pre_error_frame = scm_frame_previous(frame);
     scm_display_error(pre_error_frame, port, scm_frame_procedure_name(pre_error_frame),
                       scm_from_utf8_string("throw to key ~A with ~A~%"),
-                      scm_list_2(key, params),
-                      SCM_UNDEFINED);
+                      scm_list_2(key, params), SCM_UNDEFINED);
     scm_display_backtrace(stack, port, SCM_BOOL_F, SCM_BOOL_F);
     gchar *trace = scm_to_utf8_string(scm_get_output_string(port));
     scm_close(port);

--- a/src/gig_constant.c
+++ b/src/gig_constant.c
@@ -85,7 +85,7 @@ gig_constant_define(GIConstantInfo *info, SCM defs)
     g_base_info_unref(typeinfo);
 
     scm_permanent_object(scm_c_define(public_name, ret));
-    return scm_cons (scm_from_utf8_symbol(public_name), defs);
+    return scm_cons(scm_from_utf8_symbol(public_name), defs);
 }
 
 void

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -15,7 +15,7 @@
 
 #include <glib-object.h>
 #include "gig_data_type.h"
-
+#include "gig_util.h"
 
 GType g_type_unichar;
 GType g_type_int16;
@@ -214,8 +214,10 @@ gig_type_meta_init_from_type_info(GigTypeMeta *meta, GITypeInfo *type_info)
         if (itype == GI_INFO_TYPE_UNRESOLVED) {
             meta->gtype = G_TYPE_INVALID;
             meta->is_invalid = TRUE;
-            g_warning("Unrepresentable type %s %s %s", g_info_type_to_string(itype),
-                      g_base_info_get_name(referenced_base_info), g_base_info_get_name(type_info));
+            g_warning("Unrepresentable type: %s, %s, %s",
+                      g_base_info_get_name_safe(type_info),
+                      g_base_info_get_name_safe(referenced_base_info),
+                      g_info_type_to_string(itype));
         }
         else if (itype == GI_INFO_TYPE_ENUM || itype == GI_INFO_TYPE_FLAGS) {
             meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -49,10 +49,7 @@ gig_type_meta_init_from_arg_info(GigTypeMeta *meta, GIArgInfo *ai)
     meta->is_optional = g_arg_info_is_optional(ai);
     meta->is_nullable = g_arg_info_may_be_null(ai);
 
-    meta->is_transfer_ownership = (transfer == GI_TRANSFER_EVERYTHING);
-    meta->is_transfer_container = (transfer == GI_TRANSFER_CONTAINER ||
-                                   transfer == GI_TRANSFER_EVERYTHING);
-
+    meta->transfer = transfer;
 }
 
 void
@@ -74,10 +71,7 @@ gig_type_meta_init_from_callable_info(GigTypeMeta *meta, GICallableInfo *ci)
     meta->is_optional = FALSE;
     meta->is_nullable = g_callable_info_may_return_null(ci);
 
-    meta->is_transfer_ownership = (transfer == GI_TRANSFER_EVERYTHING);
-    meta->is_transfer_container = (transfer == GI_TRANSFER_CONTAINER ||
-                                   transfer == GI_TRANSFER_EVERYTHING);
-
+    meta->transfer = transfer;
 }
 
 void
@@ -98,14 +92,10 @@ add_child_params(GigTypeMeta *meta, GITypeInfo *type_info, gint n)
         gig_type_meta_init_from_type_info(meta->params, param_type);
         g_base_info_unref(param_type);
 
-        if (meta->is_transfer_ownership && meta->is_transfer_container) {
-            meta->params[i].is_transfer_ownership = 1;
-            meta->params[i].is_transfer_container = 1;
-        }
-        else {
-            meta->params[i].is_transfer_ownership = 0;
-            meta->params[i].is_transfer_container = 0;
-        }
+        if (meta->transfer == GI_TRANSFER_EVERYTHING)
+            meta->params[i].transfer = GI_TRANSFER_EVERYTHING;
+        else
+            meta->params[i].transfer = GI_TRANSFER_NOTHING;
     }
 }
 

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -13,177 +13,334 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <glib-object.h>
 #include "gig_data_type.h"
 
 
-static gboolean
-fill_array_info(GigTypeMeta * meta)
+GType g_type_unichar;
+GType g_type_int16;
+GType g_type_int32;
+GType g_type_uint16;
+GType g_type_uint32;
+GType g_type_locale_string;
+
+GType g_type_fixed_size_carray;
+GType g_type_zero_terminated_carray;
+GType g_type_length_carray;
+GType g_type_list;
+GType g_type_slist;
+GType g_type_callback;
+
+static void gig_type_meta_init_from_type_info(GigTypeMeta *type, GITypeInfo *ti);
+static void gig_type_meta_init_from_basic_type_tag(GigTypeMeta *meta, GITypeTag tag);
+
+void
+gig_type_meta_init_from_arg_info(GigTypeMeta *meta, GIArgInfo *ai)
 {
-    g_assert_cmpint(meta->type_tag, ==, GI_TYPE_TAG_ARRAY);
-    g_assert_true(meta->is_ptr);
+    GITypeInfo *type_info = g_arg_info_get_type(ai);
+    GIDirection dir = g_arg_info_get_direction(ai);
+    GITransfer transfer = g_arg_info_get_ownership_transfer(ai);
 
-    gboolean ret = TRUE;
+    meta->name = g_strdup(g_base_info_get_name(ai));
+    gig_type_meta_init_from_type_info(meta, type_info);
 
-    // So there are layers to all this ArgInfo stuff.
-    // First, GIArgInfo tells us what type of array.
-    meta->array_type = g_type_info_get_array_type(meta->type_info);
-    meta->array_is_zero_terminated = g_type_info_is_zero_terminated(meta->type_info);
-    meta->array_length_index = g_type_info_get_array_length(meta->type_info);
-    meta->array_fixed_size = g_type_info_get_array_fixed_size(meta->type_info);
+    meta->is_in = (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT);
+    meta->is_out = (dir == GI_DIRECTION_OUT || dir == GI_DIRECTION_INOUT);
+    meta->is_skip = g_arg_info_is_skip(ai);
 
-    if ((meta->transfer == GI_TRANSFER_CONTAINER)
-        || meta->transfer == GI_TRANSFER_NOTHING)
-        meta->transfer = GI_TRANSFER_NOTHING;
+    meta->is_caller_allocates = g_arg_info_is_caller_allocates(ai);
+    meta->is_optional = g_arg_info_is_optional(ai);
+    meta->is_nullable = g_arg_info_may_be_null(ai);
+
+    meta->is_transfer_ownership = (transfer == GI_TRANSFER_EVERYTHING);
+    meta->is_transfer_container = (transfer == GI_TRANSFER_CONTAINER ||
+                                   transfer == GI_TRANSFER_EVERYTHING);
+
+}
+
+void
+gig_type_meta_init_from_callable_info(GigTypeMeta *meta, GICallableInfo *ci)
+{
+    GITypeInfo *type_info = g_callable_info_get_return_type(ci);
+    GITransfer transfer = g_callable_info_get_caller_owns(ci);
+
+    gig_type_meta_init_from_type_info(meta, type_info);
+
+    meta->is_in = FALSE;
+    if (meta->gtype != G_TYPE_NONE && meta->gtype != G_TYPE_INVALID)
+        meta->is_out = TRUE;
     else
-        meta->transfer = GI_TRANSFER_EVERYTHING;
+        meta->is_out = FALSE;
+    meta->is_skip = g_callable_info_skip_return(ci);
 
-    // Second, we figure out what the element type of the array is.
-    GITypeInfo *item_type_info = g_type_info_get_param_type(meta->type_info, 0);
-    meta->item_type_tag = g_type_info_get_tag(item_type_info);
-    meta->item_is_ptr = g_type_info_is_pointer(item_type_info);
+    meta->is_caller_allocates = FALSE;
+    meta->is_optional = FALSE;
+    meta->is_nullable = g_callable_info_may_return_null(ci);
 
-    if (meta->item_is_ptr)
-        meta->item_size = sizeof(void *);
+    meta->is_transfer_ownership = (transfer == GI_TRANSFER_EVERYTHING);
+    meta->is_transfer_container = (transfer == GI_TRANSFER_CONTAINER ||
+                                   transfer == GI_TRANSFER_EVERYTHING);
 
-    switch (meta->item_type_tag) {
-    case GI_TYPE_TAG_INT8:
-    case GI_TYPE_TAG_UINT8:
-        meta->item_size = 1;
-        break;
-    case GI_TYPE_TAG_INT16:
-    case GI_TYPE_TAG_UINT16:
-        meta->item_size = 2;
-        break;
-    case GI_TYPE_TAG_INT32:
-    case GI_TYPE_TAG_UINT32:
-    case GI_TYPE_TAG_UNICHAR:
-        meta->item_size = 4;
-        break;
-    case GI_TYPE_TAG_INT64:
-    case GI_TYPE_TAG_UINT64:
-        meta->item_size = 8;
-        break;
-    case GI_TYPE_TAG_FLOAT:
-        meta->item_size = sizeof(float);
-        break;
-    case GI_TYPE_TAG_DOUBLE:
-        meta->item_size = sizeof(double);
-        break;
-    case GI_TYPE_TAG_GTYPE:
-        meta->item_size = sizeof(GType);
-        break;
-    case GI_TYPE_TAG_BOOLEAN:
-        meta->item_size = sizeof(gboolean);
-        break;
-    case GI_TYPE_TAG_INTERFACE:
-    {
-        GIBaseInfo *referenced_base_info = g_type_info_get_interface(item_type_info);
-        meta->referenced_base_type = g_base_info_get_type(referenced_base_info);
+}
 
-        switch (meta->referenced_base_type) {
-        case GI_INFO_TYPE_ENUM:
-        case GI_INFO_TYPE_FLAGS:
+void
+add_params(GigTypeMeta *meta, gint n)
+{
+    meta->params = g_new0(GigTypeMeta, n);
+    meta->n_params = n;
 
-            g_assert_false(meta->item_is_ptr);
-            meta->item_size = sizeof(int);
-            break;
-        case GI_INFO_TYPE_STRUCT:
-            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
-            if (!meta->item_is_ptr)
+    for (int i = 0; i < n; i++) {
+        meta->params[i].name = g_strdup("(uninitialized)");
+    }
+}
+
+static void
+add_child_params(GigTypeMeta *meta, GITypeInfo *type_info, gint n)
+{
+    GITypeInfo *param_type;
+    add_params(meta, n);
+
+    for (int i = 0; i < n; i++) {
+        param_type = g_type_info_get_param_type((GITypeInfo *)type_info, i);
+        gig_type_meta_init_from_type_info(meta->params, param_type);
+        g_base_info_unref(param_type);
+
+        if (meta->is_transfer_ownership && meta->is_transfer_container) {
+            meta->params[i].is_transfer_ownership = 1;
+            meta->params[i].is_transfer_container = 1;
+        }
+        else {
+            meta->params[i].is_transfer_ownership = 0;
+            meta->params[i].is_transfer_container = 0;
+        }
+    }
+}
+
+static void
+gig_type_meta_init_from_basic_type_tag(GigTypeMeta *meta, GITypeTag tag)
+{
+#define T(TYPETAG,GTYPE,CTYPE)                                          \
+    do {                                                                \
+        if (tag == TYPETAG) {                                           \
+            meta->gtype = GTYPE;                                        \
+            meta->item_size = meta->is_ptr ? sizeof(gpointer) : sizeof (CTYPE); \
+            return;                                                     \
+        }                                                               \
+    } while(FALSE)
+
+    T(GI_TYPE_TAG_BOOLEAN, G_TYPE_BOOLEAN, gboolean);
+    T(GI_TYPE_TAG_DOUBLE, G_TYPE_DOUBLE, gdouble);
+    T(GI_TYPE_TAG_FLOAT, G_TYPE_FLOAT, gfloat);
+    T(GI_TYPE_TAG_GTYPE, G_TYPE_GTYPE, GType);
+    T(GI_TYPE_TAG_INT8, G_TYPE_CHAR, gint8);
+    T(GI_TYPE_TAG_INT16, G_TYPE_INT16, gint16);
+    T(GI_TYPE_TAG_INT32, G_TYPE_INT32, gint32);
+    T(GI_TYPE_TAG_INT64, G_TYPE_INT64, gint64);
+    T(GI_TYPE_TAG_UINT8, G_TYPE_UCHAR, guint8);
+    T(GI_TYPE_TAG_UINT16, G_TYPE_UINT16, guint16);
+    T(GI_TYPE_TAG_UINT32, G_TYPE_UINT32, guint32);
+    T(GI_TYPE_TAG_UINT64, G_TYPE_UINT64, guint64);
+    T(GI_TYPE_TAG_UNICHAR, G_TYPE_UNICHAR, gunichar);
+    T(GI_TYPE_TAG_UTF8, G_TYPE_STRING, 0);
+    T(GI_TYPE_TAG_FILENAME, G_TYPE_LOCALE_STRING, 0);
+    T(GI_TYPE_TAG_ERROR, G_TYPE_ERROR, GError);
+    g_error("Unhandled type '%s' %s %d", g_type_tag_to_string(tag), __FILE__, __LINE__);
+#undef T
+}
+
+static void
+gig_type_meta_init_from_type_info(GigTypeMeta *meta, GITypeInfo *type_info)
+{
+    GITypeTag tag = g_type_info_get_tag(type_info);
+    meta->is_ptr = g_type_info_is_pointer(type_info);
+
+    if (tag == GI_TYPE_TAG_VOID) {
+        if (meta->is_ptr) {
+            meta->gtype = G_TYPE_POINTER;
+            meta->item_size = sizeof(gpointer);
+        }
+        else {
+            meta->gtype = G_TYPE_NONE;
+            meta->item_size = 0;
+        }
+    }
+    else if (tag == GI_TYPE_TAG_ARRAY) {
+        GIArrayType array_type = g_type_info_get_array_type(type_info);
+        gint len;
+
+        add_child_params(meta, type_info, 1);
+
+        if (array_type == GI_ARRAY_TYPE_C) {
+            if ((len = g_type_info_get_array_length(type_info)) != -1) {
+                meta->gtype = G_TYPE_LENGTH_CARRAY;
+                meta->length = len;
+            }
+            else if ((len = g_type_info_get_array_fixed_size(type_info)) != -1) {
+                meta->gtype = G_TYPE_FIXED_SIZE_CARRAY;
+                meta->length = len;
+            }
+            else if (g_type_info_is_zero_terminated(type_info)) {
+                meta->gtype = G_TYPE_ZERO_TERMINATED_CARRAY;
+            }
+            else {
+                g_warning("unsized C array");
+                meta->gtype = G_TYPE_POINTER;
+            }
+        }
+        else if (array_type == GI_ARRAY_TYPE_ARRAY)
+            meta->gtype = G_TYPE_ARRAY;
+        else if (array_type == GI_ARRAY_TYPE_BYTE_ARRAY)
+            meta->gtype = G_TYPE_BYTE_ARRAY;
+        else if (array_type == GI_ARRAY_TYPE_PTR_ARRAY)
+            meta->gtype = G_TYPE_PTR_ARRAY;
+        else
+            g_assert_not_reached();
+    }
+    else if (tag == GI_TYPE_TAG_GHASH) {
+        meta->gtype = G_TYPE_HASH_TABLE;
+        add_child_params(meta, type_info, 2);
+    }
+    else if (tag == GI_TYPE_TAG_GLIST) {
+        meta->gtype = G_TYPE_LIST;
+        add_child_params(meta, type_info, 1);
+    }
+    else if (tag == GI_TYPE_TAG_GSLIST) {
+        meta->gtype = G_TYPE_SLIST;
+        add_child_params(meta, type_info, 1);
+    }
+    else if (tag == GI_TYPE_TAG_INTERFACE) {
+        GIBaseInfo *referenced_base_info = g_type_info_get_interface(type_info);
+        GIInfoType itype = g_base_info_get_type(referenced_base_info);
+        if (itype == GI_INFO_TYPE_UNRESOLVED) {
+            meta->gtype = G_TYPE_INVALID;
+            meta->is_invalid = TRUE;
+            g_warning("Unrepresentable type %s %s %s", g_info_type_to_string(itype),
+                      g_base_info_get_name(referenced_base_info), g_base_info_get_name(type_info));
+        }
+        else if (itype == GI_INFO_TYPE_ENUM || itype == GI_INFO_TYPE_FLAGS) {
+            meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);
+            // Not all enum or flag types have an associated GType
+            add_params(meta, 1);
+            if (meta->gtype == G_TYPE_NONE || meta->gtype == 0) {
+                if (itype == GI_INFO_TYPE_ENUM) {
+                    meta->gtype = G_TYPE_ENUM;
+                    gig_type_meta_init_from_basic_type_tag(meta->params, GI_TYPE_TAG_INT32);
+                }
+                else {
+                    meta->gtype = G_TYPE_FLAGS;
+                    gig_type_meta_init_from_basic_type_tag(meta->params, GI_TYPE_TAG_UINT32);
+                }
+            }
+            else {
+                gig_type_meta_init_from_basic_type_tag(meta->params,
+                                                       g_enum_info_get_storage_type
+                                                       (referenced_base_info));
+            }
+        }
+        else if (itype == GI_INFO_TYPE_STRUCT) {
+            meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->is_ptr)
                 meta->item_size = g_struct_info_get_size(referenced_base_info);
-            break;
-        case GI_INFO_TYPE_UNION:
-            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
-            if (!meta->item_is_ptr)
+            else
+                meta->item_size = sizeof(gpointer);
+        }
+        else if (itype == GI_INFO_TYPE_UNION) {
+            meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->is_ptr)
                 meta->item_size = g_union_info_get_size(referenced_base_info);
-            break;
-        case GI_INFO_TYPE_OBJECT:
-        case GI_INFO_TYPE_INTERFACE:
-            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
-            if (!meta->item_is_ptr)
-                meta->item_size = sizeof(void *);
-            break;
-        default:
+            else
+                meta->item_size = sizeof(gpointer);
+        }
+        else if (itype == GI_INFO_TYPE_OBJECT || itype == GI_INFO_TYPE_INTERFACE) {
+            meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->is_ptr)
+                meta->item_size = 0;
+            else
+                meta->item_size = sizeof(gpointer);
+        }
+        else if (GI_IS_REGISTERED_TYPE_INFO(referenced_base_info)) {
+            meta->gtype = g_registered_type_info_get_g_type(referenced_base_info);
+        }
+        else if (itype == GI_INFO_TYPE_CALLBACK) {
+            meta->gtype = G_TYPE_CALLBACK;
+            g_base_info_ref(referenced_base_info);
+            meta->callable_info = referenced_base_info;
+        }
+        else {
             g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
-            ret = FALSE;
         }
         g_base_info_unref(referenced_base_info);
-        break;
     }
-    case GI_TYPE_TAG_UTF8:
-    case GI_TYPE_TAG_FILENAME:
-        break;
+    else
+        gig_type_meta_init_from_basic_type_tag(meta, tag);
 
-    case GI_TYPE_TAG_ARRAY:
-    case GI_TYPE_TAG_GLIST:
-    case GI_TYPE_TAG_GSLIST:
-    case GI_TYPE_TAG_GHASH:
-        g_critical("nested array objects are unhandled in %s:%d", __FILE__, __LINE__);
-        ret = FALSE;
-        break;
+    //
+    if (meta->gtype == 0) {
+        if (meta->is_ptr) {
+            meta->gtype = G_TYPE_POINTER;
+            meta->item_size = sizeof(gpointer);
+        }
+        else {
+            meta->gtype = G_TYPE_NONE;
+            meta->item_size = 0;
+        }
 
-    default:
-        g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
-        ret = FALSE;
+        if (meta->gtype == 0)
+            g_warning("gtype of %s is zero", g_base_info_get_name(type_info));
     }
-
-    if (ret == FALSE) {
-        // Set the unhandled array type to be a simple null pointer.
-        meta->type_tag = GI_TYPE_TAG_VOID;
-    }
-
-    g_base_info_unref(item_type_info);
-    return ret;
+    if (meta->gtype)
+        meta->name = g_strdup_printf("%s%s", g_type_name(meta->gtype), meta->is_ptr ? "*" : "");
+    else
+        meta->name = g_strdup("(invalid)");
 }
 
+#define STRLEN 128
+gchar gig_data_type_describe_buf[STRLEN];
+
+const gchar *
+gig_type_meta_describe(GigTypeMeta *meta)
+{
+    GString *s = g_string_new(NULL);
+    g_string_append_printf(s, "'%s' %s%s%s",
+                           meta->name,
+                           meta->is_ptr ? "pointer to " : "",
+                           meta->is_caller_allocates ? "caller allocated " : "",
+                           g_type_name(meta->gtype));
+    if (!G_TYPE_IS_FUNDAMENTAL(meta->gtype))
+        g_string_append_printf(s, " of type %s", g_type_name(G_TYPE_FUNDAMENTAL(meta->gtype)));
+    if (meta->is_nullable)
+        g_string_append_printf(s, " or NULL");
+    strncpy(gig_data_type_describe_buf, s->str, STRLEN - 1);
+    gig_data_type_describe_buf[STRLEN - 1] = '\0';
+    g_string_free(s, TRUE);
+    return gig_data_type_describe_buf;
+}
+
+#undef STRLEN
+
+G_DEFINE_BOXED_TYPE(GList, g_list, g_list_copy, g_list_free);
+G_DEFINE_BOXED_TYPE(GSList, g_slist, g_slist_copy, g_slist_free);
 
 void
-gig_type_meta_init_from_arg_info(GigTypeMeta * meta, GIArgInfo *ai)
+gig_init_data_type(void)
 {
-    g_assert_nonnull(meta);
-    g_assert_nonnull(ai);
+    g_type_unichar = g_type_register_static_simple(G_TYPE_INT, "gunichar", 0, NULL, 0, NULL, 0);
+    g_type_int16 = g_type_register_static_simple(G_TYPE_INT, "gint16", 0, NULL, 0, NULL, 0);
+    g_type_int32 = g_type_register_static_simple(G_TYPE_INT, "gint32", 0, NULL, 0, NULL, 0);
+    g_type_uint16 = g_type_register_static_simple(G_TYPE_UINT, "guint16", 0, NULL, 0, NULL, 0);
+    g_type_uint32 = g_type_register_static_simple(G_TYPE_UINT, "guint32", 0, NULL, 0, NULL, 0);
+    g_type_locale_string = g_type_register_static_simple(G_TYPE_STRING,
+                                                         "locale-string", 0, NULL, 0, NULL, 0);
 
-    meta->type_info = g_arg_info_get_type(ai);
-    meta->type_tag = g_type_info_get_tag(meta->type_info);
-    meta->is_ptr = g_type_info_is_pointer(meta->type_info);
-    meta->c_direction = g_arg_info_get_direction(ai);
-    meta->transfer = g_arg_info_get_ownership_transfer(ai);
-    meta->may_be_null = g_arg_info_may_be_null(ai);
-    meta->is_caller_allocates = g_arg_info_is_caller_allocates(ai);
-    meta->array_length_index = -1;
+    // g_type_fixed_size_carray = g_type_register_static_simple(G_TYPE_ARRAY, "fixed-size-carray", 0, NULL, 0, NULL, 0);
+    // g_type_zero_terminated_carray = g_type_register_static_simple(G_TYPE_ARRAY, "zero-terminated-carray", 0, NULL, 0, NULL, 0);
+    // g_type_length_carray = g_type_register_static_simple(G_TYPE_ARRAY, "length+carray", 0, NULL, 0, NULL, 0);
+    g_type_fixed_size_carray = g_pointer_type_register_static("fixed-size-carray");
+    g_type_zero_terminated_carray = g_pointer_type_register_static("zero-terminated-carray");
+    g_type_length_carray = g_pointer_type_register_static("length+carray");
 
+    g_type_list = g_list_get_type();
+    g_type_slist = g_slist_get_type();
 
-    if (meta->type_tag == GI_TYPE_TAG_ARRAY)
-        fill_array_info(meta);
-
-}
-
-void
-gig_type_meta_init_from_callable_info(GigTypeMeta * meta, GICallableInfo *ci)
-{
-    g_assert_nonnull(meta);
-    g_assert_nonnull(ci);
-
-    meta->type_info = g_callable_info_get_return_type(ci);
-    meta->type_tag = g_type_info_get_tag(meta->type_info);
-    meta->is_ptr = g_type_info_is_pointer(meta->type_info);
-    meta->c_direction = GI_DIRECTION_OUT;
-    meta->transfer = g_callable_info_get_caller_owns(ci);
-    meta->may_be_null = g_callable_info_may_return_null(ci);
-    meta->is_caller_allocates = FALSE;
-    meta->array_length_index = -1;
-
-    if (meta->type_tag == GI_TYPE_TAG_ARRAY)
-        fill_array_info(meta);
-}
-
-const char *
-gig_type_meta_describe(GigTypeMeta * meta)
-{
-    gchar buf[80];
-    g_snprintf(buf, "%s%s%s%s",
-               meta->is_ptr ? "pointer to " : "",
-               meta->is_caller_allocates ? "caller allocated " : "",
-               g_type_tag_to_string(meta->type_tag), meta->may_be_null ? " or NULL" : "");
-    return buf;
+    g_type_callback = g_pointer_type_register_static("callback");
 }

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -41,7 +41,6 @@ gig_type_meta_init_from_arg_info(GigTypeMeta *meta, GIArgInfo *ai)
     GIDirection dir = g_arg_info_get_direction(ai);
     GITransfer transfer = g_arg_info_get_ownership_transfer(ai);
 
-    meta->name = g_strdup(g_base_info_get_name(ai));
     gig_type_meta_init_from_type_info(meta, type_info);
 
     meta->is_in = (dir == GI_DIRECTION_IN || dir == GI_DIRECTION_INOUT);
@@ -88,10 +87,6 @@ add_params(GigTypeMeta *meta, gint n)
 {
     meta->params = g_new0(GigTypeMeta, n);
     meta->n_params = n;
-
-    for (int i = 0; i < n; i++) {
-        meta->params[i].name = g_strdup("(uninitialized)");
-    }
 }
 
 static void
@@ -290,10 +285,6 @@ gig_type_meta_init_from_type_info(GigTypeMeta *meta, GITypeInfo *type_info)
         if (meta->gtype == 0)
             g_warning("gtype of %s is zero", g_base_info_get_name(type_info));
     }
-    if (meta->gtype)
-        meta->name = g_strdup_printf("%s%s", g_type_name(meta->gtype), meta->is_ptr ? "*" : "");
-    else
-        meta->name = g_strdup("(invalid)");
 }
 
 #define STRLEN 128
@@ -303,8 +294,7 @@ const gchar *
 gig_type_meta_describe(GigTypeMeta *meta)
 {
     GString *s = g_string_new(NULL);
-    g_string_append_printf(s, "'%s' %s%s%s",
-                           meta->name,
+    g_string_append_printf(s, "%s%s%s",
                            meta->is_ptr ? "pointer to " : "",
                            meta->is_caller_allocates ? "caller allocated " : "",
                            g_type_name(meta->gtype));

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -324,12 +324,11 @@ gig_init_data_type(void)
     g_type_locale_string = g_type_register_static_simple(G_TYPE_STRING,
                                                          "locale-string", 0, NULL, 0, NULL, 0);
 
-    // g_type_fixed_size_carray = g_type_register_static_simple(G_TYPE_ARRAY, "fixed-size-carray", 0, NULL, 0, NULL, 0);
-    // g_type_zero_terminated_carray = g_type_register_static_simple(G_TYPE_ARRAY, "zero-terminated-carray", 0, NULL, 0, NULL, 0);
-    // g_type_length_carray = g_type_register_static_simple(G_TYPE_ARRAY, "length+carray", 0, NULL, 0, NULL, 0);
-    g_type_fixed_size_carray = g_pointer_type_register_static("fixed-size-carray");
-    g_type_zero_terminated_carray = g_pointer_type_register_static("zero-terminated-carray");
-    g_type_length_carray = g_pointer_type_register_static("length+carray");
+    // These 3 array types are all just aliases for GArray, but, their
+    // types designate how that interacted with the GObject C FFI.
+    g_type_fixed_size_carray = g_boxed_type_register_static("fixed-size-carray", g_array_ref, g_array_unref);
+    g_type_zero_terminated_carray = g_boxed_type_register_static("zero-terminated-carray", g_array_ref, g_array_unref);
+    g_type_length_carray = g_boxed_type_register_static("length+carray", g_array_ref, g_array_unref);
 
     g_type_list = g_list_get_type();
     g_type_slist = g_slist_get_type();

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -1,0 +1,189 @@
+// Copyright (C) 2019 Michael L. Gran
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "gig_data_type.h"
+
+
+static gboolean
+fill_array_info(GigTypeMeta * meta)
+{
+    g_assert_cmpint(meta->type_tag, ==, GI_TYPE_TAG_ARRAY);
+    g_assert_true(meta->is_ptr);
+
+    gboolean ret = TRUE;
+
+    // So there are layers to all this ArgInfo stuff.
+    // First, GIArgInfo tells us what type of array.
+    meta->array_type = g_type_info_get_array_type(meta->type_info);
+    meta->array_is_zero_terminated = g_type_info_is_zero_terminated(meta->type_info);
+    meta->array_length_index = g_type_info_get_array_length(meta->type_info);
+    meta->array_fixed_size = g_type_info_get_array_fixed_size(meta->type_info);
+
+    if ((meta->transfer == GI_TRANSFER_CONTAINER)
+        || meta->transfer == GI_TRANSFER_NOTHING)
+        meta->transfer = GI_TRANSFER_NOTHING;
+    else
+        meta->transfer = GI_TRANSFER_EVERYTHING;
+
+    // Second, we figure out what the element type of the array is.
+    GITypeInfo *item_type_info = g_type_info_get_param_type(meta->type_info, 0);
+    meta->item_type_tag = g_type_info_get_tag(item_type_info);
+    meta->item_is_ptr = g_type_info_is_pointer(item_type_info);
+
+    if (meta->item_is_ptr)
+        meta->item_size = sizeof(void *);
+
+    switch (meta->item_type_tag) {
+    case GI_TYPE_TAG_INT8:
+    case GI_TYPE_TAG_UINT8:
+        meta->item_size = 1;
+        break;
+    case GI_TYPE_TAG_INT16:
+    case GI_TYPE_TAG_UINT16:
+        meta->item_size = 2;
+        break;
+    case GI_TYPE_TAG_INT32:
+    case GI_TYPE_TAG_UINT32:
+    case GI_TYPE_TAG_UNICHAR:
+        meta->item_size = 4;
+        break;
+    case GI_TYPE_TAG_INT64:
+    case GI_TYPE_TAG_UINT64:
+        meta->item_size = 8;
+        break;
+    case GI_TYPE_TAG_FLOAT:
+        meta->item_size = sizeof(float);
+        break;
+    case GI_TYPE_TAG_DOUBLE:
+        meta->item_size = sizeof(double);
+        break;
+    case GI_TYPE_TAG_GTYPE:
+        meta->item_size = sizeof(GType);
+        break;
+    case GI_TYPE_TAG_BOOLEAN:
+        meta->item_size = sizeof(gboolean);
+        break;
+    case GI_TYPE_TAG_INTERFACE:
+    {
+        GIBaseInfo *referenced_base_info = g_type_info_get_interface(item_type_info);
+        meta->referenced_base_type = g_base_info_get_type(referenced_base_info);
+
+        switch (meta->referenced_base_type) {
+        case GI_INFO_TYPE_ENUM:
+        case GI_INFO_TYPE_FLAGS:
+
+            g_assert_false(meta->item_is_ptr);
+            meta->item_size = sizeof(int);
+            break;
+        case GI_INFO_TYPE_STRUCT:
+            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->item_is_ptr)
+                meta->item_size = g_struct_info_get_size(referenced_base_info);
+            break;
+        case GI_INFO_TYPE_UNION:
+            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->item_is_ptr)
+                meta->item_size = g_union_info_get_size(referenced_base_info);
+            break;
+        case GI_INFO_TYPE_OBJECT:
+        case GI_INFO_TYPE_INTERFACE:
+            meta->referenced_object_type = g_registered_type_info_get_g_type(referenced_base_info);
+            if (!meta->item_is_ptr)
+                meta->item_size = sizeof(void *);
+            break;
+        default:
+            g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
+            ret = FALSE;
+        }
+        g_base_info_unref(referenced_base_info);
+        break;
+    }
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME:
+        break;
+
+    case GI_TYPE_TAG_ARRAY:
+    case GI_TYPE_TAG_GLIST:
+    case GI_TYPE_TAG_GSLIST:
+    case GI_TYPE_TAG_GHASH:
+        g_critical("nested array objects are unhandled in %s:%d", __FILE__, __LINE__);
+        ret = FALSE;
+        break;
+
+    default:
+        g_critical("Unhandled item type in %s:%d", __FILE__, __LINE__);
+        ret = FALSE;
+    }
+
+    if (ret == FALSE) {
+        // Set the unhandled array type to be a simple null pointer.
+        meta->type_tag = GI_TYPE_TAG_VOID;
+    }
+
+    g_base_info_unref(item_type_info);
+    return ret;
+}
+
+
+void
+gig_type_meta_init_from_arg_info(GigTypeMeta * meta, GIArgInfo *ai)
+{
+    g_assert_nonnull(meta);
+    g_assert_nonnull(ai);
+
+    meta->type_info = g_arg_info_get_type(ai);
+    meta->type_tag = g_type_info_get_tag(meta->type_info);
+    meta->is_ptr = g_type_info_is_pointer(meta->type_info);
+    meta->c_direction = g_arg_info_get_direction(ai);
+    meta->transfer = g_arg_info_get_ownership_transfer(ai);
+    meta->may_be_null = g_arg_info_may_be_null(ai);
+    meta->is_caller_allocates = g_arg_info_is_caller_allocates(ai);
+    meta->array_length_index = -1;
+
+
+    if (meta->type_tag == GI_TYPE_TAG_ARRAY)
+        fill_array_info(meta);
+
+}
+
+void
+gig_type_meta_init_from_callable_info(GigTypeMeta * meta, GICallableInfo *ci)
+{
+    g_assert_nonnull(meta);
+    g_assert_nonnull(ci);
+
+    meta->type_info = g_callable_info_get_return_type(ci);
+    meta->type_tag = g_type_info_get_tag(meta->type_info);
+    meta->is_ptr = g_type_info_is_pointer(meta->type_info);
+    meta->c_direction = GI_DIRECTION_OUT;
+    meta->transfer = g_callable_info_get_caller_owns(ci);
+    meta->may_be_null = g_callable_info_may_return_null(ci);
+    meta->is_caller_allocates = FALSE;
+    meta->array_length_index = -1;
+
+    if (meta->type_tag == GI_TYPE_TAG_ARRAY)
+        fill_array_info(meta);
+}
+
+const char *
+gig_type_meta_describe(GigTypeMeta * meta)
+{
+    gchar buf[80];
+    g_snprintf(buf, "%s%s%s%s",
+               meta->is_ptr ? "pointer to " : "",
+               meta->is_caller_allocates ? "caller allocated " : "",
+               g_type_tag_to_string(meta->type_tag), meta->may_be_null ? " or NULL" : "");
+    return buf;
+}

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -291,7 +291,7 @@ gig_type_meta_init_from_type_info(GigTypeMeta *meta, GITypeInfo *type_info)
 gchar gig_data_type_describe_buf[STRLEN];
 
 const gchar *
-gig_type_meta_describe(GigTypeMeta *meta)
+gig_type_meta_describe(const GigTypeMeta *meta)
 {
     GString *s = g_string_new(NULL);
     g_string_append_printf(s, "%s%s%s",
@@ -326,9 +326,12 @@ gig_init_data_type(void)
 
     // These 3 array types are all just aliases for GArray, but, their
     // types designate how that interacted with the GObject C FFI.
-    g_type_fixed_size_carray = g_boxed_type_register_static("fixed-size-carray", g_array_ref, g_array_unref);
-    g_type_zero_terminated_carray = g_boxed_type_register_static("zero-terminated-carray", g_array_ref, g_array_unref);
-    g_type_length_carray = g_boxed_type_register_static("length+carray", g_array_ref, g_array_unref);
+    g_type_fixed_size_carray =
+        g_boxed_type_register_static("fixed-size-carray", g_array_ref, g_array_unref);
+    g_type_zero_terminated_carray =
+        g_boxed_type_register_static("zero-terminated-carray", g_array_ref, g_array_unref);
+    g_type_length_carray =
+        g_boxed_type_register_static("length+carray", g_array_ref, g_array_unref);
 
     g_type_list = g_list_get_type();
     g_type_slist = g_slist_get_type();

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -1,0 +1,70 @@
+// Copyright (C) 2019 Michael L. Gran
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GIG_DATA_TYPE_H
+#define GIG_DATA_TYPE_H
+#include <glib.h>
+#include <girepository.h>
+
+// *INDENT-OFF*
+G_BEGIN_DECLS
+// *INDENT-ON*
+
+typedef struct _GigTypeMeta GigTypeMeta;
+struct _GigTypeMeta
+{
+    ////////////////////////////////////////////////////////////////
+    // This block is similar to GIArgInfo, except it is generic for
+    // both arguments and return types
+    GITypeInfo *type_info;
+    GITypeTag type_tag;
+    gboolean is_ptr;
+    // The direction of the C argument, which may differ from the SCM
+    GIDirection c_direction;
+    // Nothing, container, or everything
+    GITransfer transfer;
+    // For C 'in' values, whether NULL is a valid value.  For 'out'
+    // values, whether NULL may be returned.
+    gboolean may_be_null;
+    // For C 'out' values, whether this argument is allocated by the
+    // caller.
+    gboolean is_caller_allocates;
+
+    ////////////////////////////////////////////////////////////////
+    // This block is additional data that is valid only for arrays
+
+    // The array itself
+    GIArrayType array_type;
+    gsize array_fixed_size;
+    gint array_length_index;
+    gboolean array_is_zero_terminated;
+
+    // The elements of the array
+    GITransfer item_transfer;
+    GITypeTag item_type_tag;
+    gboolean item_is_ptr;
+    gsize item_size;
+
+    // The objects held by elements of the array
+    GIInfoType referenced_base_type;
+    GType referenced_object_type;
+};
+
+void gig_type_meta_init_from_arg_info(GigTypeMeta * type, GIArgInfo *ai);
+void gig_type_meta_init_from_callable_info(GigTypeMeta * type, GICallableInfo *ci);
+const char *gig_type_meta_describe(GigTypeMeta * meta);
+
+G_END_DECLS
+#endif

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -53,7 +53,6 @@ extern GType g_type_callback;
 typedef struct _GigTypeMeta GigTypeMeta;
 struct _GigTypeMeta
 {
-    gchar *name;
     GType gtype;
     guint16 is_ptr:1;
 

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -92,7 +92,7 @@ struct _GigTypeMeta
 
 void gig_type_meta_init_from_arg_info(GigTypeMeta *type, GIArgInfo *ai);
 void gig_type_meta_init_from_callable_info(GigTypeMeta *type, GICallableInfo *ci);
-const char *gig_type_meta_describe(GigTypeMeta *meta);
+const char *gig_type_meta_describe(const GigTypeMeta *meta);
 void gig_init_data_type(void);
 
 G_END_DECLS

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -29,9 +29,6 @@ extern GType g_type_uint16;
 extern GType g_type_uint32;
 extern GType g_type_locale_string;
 
-extern GType g_type_fixed_size_carray;
-extern GType g_type_zero_terminated_carray;
-extern GType g_type_length_carray;
 extern GType g_type_list;
 extern GType g_type_slist;
 extern GType g_type_callback;
@@ -42,13 +39,12 @@ extern GType g_type_callback;
 #define G_TYPE_UINT16 (g_type_uint16)
 #define G_TYPE_UINT32 (g_type_uint32)
 
-#define G_TYPE_LENGTH_CARRAY (g_type_length_carray)
-#define G_TYPE_ZERO_TERMINATED_CARRAY (g_type_zero_terminated_carray)
-#define G_TYPE_FIXED_SIZE_CARRAY (g_type_fixed_size_carray)
 #define G_TYPE_LIST (g_type_list)
 #define G_TYPE_SLIST (g_type_slist)
 #define G_TYPE_LOCALE_STRING (g_type_locale_string)
 #define G_TYPE_CALLBACK (g_type_callback)
+
+#define GIG_ARRAY_SIZE_UNKNOWN ((gsize)-1)
 
 typedef struct _GigTypeMeta GigTypeMeta;
 struct _GigTypeMeta
@@ -73,13 +69,15 @@ struct _GigTypeMeta
     guint16 is_transfer_container:1;
 
     // Error status
-    guint16 is_invalid:1;       // True when one of the arguments has
-    // invalid type
-    guint16 padding1:6;
+    guint16 is_invalid:1;       // True when one of the arguments has invalid type
+    guint16 is_raw_array:1;
+    guint16 is_zero_terminated:1;
+    guint16 has_size:1;
+    guint16 padding1:3;
 
     // For C array types
-    guint16 length;
-    guint16 item_size;
+    gsize length;
+    gsize item_size;
 
     // Subtypes and callables
     guint16 n_params;

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -64,20 +64,18 @@ struct _GigTypeMeta
     guint16 is_optional:1;      // Out-only. Pass in NULL to ignore this.
     guint16 is_nullable:1;      // For in, can pass in NULL. For out, may return NULL.
 
-    // For container types
-    guint16 is_transfer_ownership:1;
-    guint16 is_transfer_container:1;
-
     // Error status
     guint16 is_invalid:1;       // True when one of the arguments has invalid type
     guint16 is_raw_array:1;
     guint16 is_zero_terminated:1;
     guint16 has_size:1;
-    guint16 padding1:3;
+    guint16 padding1:5;
 
     // For C array types
     gsize length;
     gsize item_size;
+
+    GITransfer transfer;
 
     // Subtypes and callables
     guint16 n_params;

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -22,49 +22,79 @@
 G_BEGIN_DECLS
 // *INDENT-ON*
 
+extern GType g_type_unichar;
+extern GType g_type_int16;
+extern GType g_type_int32;
+extern GType g_type_uint16;
+extern GType g_type_uint32;
+extern GType g_type_locale_string;
+
+extern GType g_type_fixed_size_carray;
+extern GType g_type_zero_terminated_carray;
+extern GType g_type_length_carray;
+extern GType g_type_list;
+extern GType g_type_slist;
+extern GType g_type_callback;
+
+#define G_TYPE_UNICHAR (g_type_unichar)
+#define G_TYPE_INT16 (g_type_int16)
+#define G_TYPE_INT32 (g_type_int32)
+#define G_TYPE_UINT16 (g_type_uint16)
+#define G_TYPE_UINT32 (g_type_uint32)
+
+#define G_TYPE_LENGTH_CARRAY (g_type_length_carray)
+#define G_TYPE_ZERO_TERMINATED_CARRAY (g_type_zero_terminated_carray)
+#define G_TYPE_FIXED_SIZE_CARRAY (g_type_fixed_size_carray)
+#define G_TYPE_LIST (g_type_list)
+#define G_TYPE_SLIST (g_type_slist)
+#define G_TYPE_LOCALE_STRING (g_type_locale_string)
+#define G_TYPE_CALLBACK (g_type_callback)
+
 typedef struct _GigTypeMeta GigTypeMeta;
 struct _GigTypeMeta
 {
-    ////////////////////////////////////////////////////////////////
-    // This block is similar to GIArgInfo, except it is generic for
-    // both arguments and return types
-    GITypeInfo *type_info;
-    GITypeTag type_tag;
-    gboolean is_ptr;
-    // The direction of the C argument, which may differ from the SCM
-    GIDirection c_direction;
-    // Nothing, container, or everything
-    GITransfer transfer;
-    // For C 'in' values, whether NULL is a valid value.  For 'out'
-    // values, whether NULL may be returned.
-    gboolean may_be_null;
-    // For C 'out' values, whether this argument is allocated by the
-    // caller.
-    gboolean is_caller_allocates;
+    gchar *name;
+    GType gtype;
+    guint16 is_ptr:1;
 
-    ////////////////////////////////////////////////////////////////
-    // This block is additional data that is valid only for arrays
+    // For argument and return values
+    guint16 is_in:1;
+    guint16 is_out:1;
 
-    // The array itself
-    GIArrayType array_type;
-    gsize array_fixed_size;
-    gint array_length_index;
-    gboolean array_is_zero_terminated;
+    // For return values
+    guint16 is_skip:1;          // TRUE when output is ignored
 
-    // The elements of the array
-    GITransfer item_transfer;
-    GITypeTag item_type_tag;
-    gboolean item_is_ptr;
-    gsize item_size;
+    // For pointers
+    guint16 is_caller_allocates:1;
+    guint16 is_optional:1;      // Out-only. Pass in NULL to ignore this.
+    guint16 is_nullable:1;      // For in, can pass in NULL. For out, may return NULL.
 
-    // The objects held by elements of the array
-    GIInfoType referenced_base_type;
-    GType referenced_object_type;
+    // For container types
+    guint16 is_transfer_ownership:1;
+    guint16 is_transfer_container:1;
+
+    // Error status
+    guint16 is_invalid:1;       // True when one of the arguments has
+    // invalid type
+    guint16 padding1:6;
+
+    // For C array types
+    guint16 length;
+    guint16 item_size;
+
+    // Subtypes and callables
+    guint16 n_params;
+    union
+    {
+        GigTypeMeta *params;
+        GICallableInfo *callable_info;
+    };
 };
 
-void gig_type_meta_init_from_arg_info(GigTypeMeta * type, GIArgInfo *ai);
-void gig_type_meta_init_from_callable_info(GigTypeMeta * type, GICallableInfo *ci);
-const char *gig_type_meta_describe(GigTypeMeta * meta);
+void gig_type_meta_init_from_arg_info(GigTypeMeta *type, GIArgInfo *ai);
+void gig_type_meta_init_from_callable_info(GigTypeMeta *type, GICallableInfo *ci);
+const char *gig_type_meta_describe(GigTypeMeta *meta);
+void gig_init_data_type(void);
 
 G_END_DECLS
 #endif

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -105,7 +105,7 @@ do_document(GIBaseInfo *info, const gchar *namespace)
             GigArgMapEntry *entry = gig_amap_get_input_entry_by_s(arg_map, i);
             document_arg_entry("argument", entry);
         }
-        if (arg_map->return_val.type_tag != GI_TYPE_TAG_VOID)
+        if (arg_map->return_val.meta.type_tag != GI_TYPE_TAG_VOID)
             document_arg_entry("return", &arg_map->return_val);
 
         for (gint i = 0; i < out; i++) {

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -91,26 +91,28 @@ do_document(GIBaseInfo *info, const gchar *namespace)
 
 
         arg_map = gig_amap_new(info);
-        scm_dynwind_unwind_handler((scm_t_pointer_finalizer) gig_amap_free,
-                                   arg_map, SCM_F_WIND_EXPLICITLY);
-        gig_amap_c_count(arg_map, &in, &out);
-        gig_amap_s_input_count(arg_map, &req, &opt);
+        if (arg_map)
+            scm_dynwind_unwind_handler((scm_t_pointer_finalizer) gig_amap_free,
+                                       arg_map, SCM_F_WIND_EXPLICITLY);
+        if (arg_map) {
+            gig_amap_c_count(arg_map, &in, &out);
+            gig_amap_s_input_count(arg_map, &req, &opt);
 
-        if (g_callable_info_is_method(info)) {
-            scm_printf(SCM_UNDEFINED, "<argument name=\"self\">");
-            scm_printf(SCM_UNDEFINED, "</argument>");
-        }
+            if (g_callable_info_is_method(info)) {
+                scm_printf(SCM_UNDEFINED, "<argument name=\"self\">");
+                scm_printf(SCM_UNDEFINED, "</argument>");
+            }
+            for (gint i = 0; i < req + opt; i++) {
+                GigArgMapEntry *entry = gig_amap_get_input_entry_by_s(arg_map, i);
+                document_arg_entry("argument", entry);
+            }
+            if (arg_map->return_val.meta.gtype != G_TYPE_NONE)
+                document_arg_entry("return", &arg_map->return_val);
 
-        for (gint i = 0; i < req + opt; i++) {
-            GigArgMapEntry *entry = gig_amap_get_input_entry_by_s(arg_map, i);
-            document_arg_entry("argument", entry);
-        }
-        if (arg_map->return_val.meta.type_tag != GI_TYPE_TAG_VOID)
-            document_arg_entry("return", &arg_map->return_val);
-
-        for (gint i = 0; i < out; i++) {
-            GigArgMapEntry *entry = gig_amap_get_output_entry_by_c(arg_map, i);
-            document_arg_entry("return", entry);
+            for (gint i = 0; i < out; i++) {
+                GigArgMapEntry *entry = gig_amap_get_output_entry_by_c(arg_map, i);
+                document_arg_entry("return", entry);
+            }
         }
         scm_printf(SCM_UNDEFINED, "</procedure></scheme></%s>", kind);
         break;

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -93,8 +93,8 @@ do_document(GIBaseInfo *info, const gchar *namespace)
         arg_map = gig_amap_new(info);
         scm_dynwind_unwind_handler((scm_t_pointer_finalizer) gig_amap_free,
                                    arg_map, SCM_F_WIND_EXPLICITLY);
-        gig_amap_get_cinvoke_args_count(arg_map, &in, &out);
-        gig_amap_get_gsubr_args_count(arg_map, &req, &opt);
+        gig_amap_c_count(arg_map, &in, &out);
+        gig_amap_s_input_count(arg_map, &req, &opt);
 
         if (g_callable_info_is_method(info)) {
             scm_printf(SCM_UNDEFINED, "<argument name=\"self\">");
@@ -102,14 +102,14 @@ do_document(GIBaseInfo *info, const gchar *namespace)
         }
 
         for (gint i = 0; i < req + opt; i++) {
-            GigArgMapEntry *entry = gig_amap_get_entry(arg_map, i);
+            GigArgMapEntry *entry = gig_amap_get_input_entry_by_s(arg_map, i);
             document_arg_entry("argument", entry);
         }
         if (arg_map->return_val.type_tag != GI_TYPE_TAG_VOID)
             document_arg_entry("return", &arg_map->return_val);
 
         for (gint i = 0; i < out; i++) {
-            GigArgMapEntry *entry = gig_amap_get_output_entry(arg_map, i);
+            GigArgMapEntry *entry = gig_amap_get_output_entry_by_c(arg_map, i);
             document_arg_entry("return", entry);
         }
         scm_printf(SCM_UNDEFINED, "</procedure></scheme></%s>", kind);

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -105,8 +105,8 @@ do_document(GIBaseInfo *info, const gchar *namespace)
             GigArgMapEntry *entry = gig_amap_get_entry(arg_map, i);
             document_arg_entry("argument", entry);
         }
-        if (arg_map->return_val->type_tag != GI_TYPE_TAG_VOID)
-            document_arg_entry("return", arg_map->return_val);
+        if (arg_map->return_val.type_tag != GI_TYPE_TAG_VOID)
+            document_arg_entry("return", &arg_map->return_val);
 
         for (gint i = 0; i < out; i++) {
             GigArgMapEntry *entry = gig_amap_get_output_entry(arg_map, i);

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -90,11 +90,11 @@ do_document(GIBaseInfo *info, const gchar *namespace)
             scm_printf(SCM_UNDEFINED, "<scheme><procedure name=\"%s\">", scheme_name);
 
 
-        arg_map = gig_arg_map_new(info);
-        scm_dynwind_unwind_handler((scm_t_pointer_finalizer) gig_arg_map_free,
+        arg_map = gig_amap_new(info);
+        scm_dynwind_unwind_handler((scm_t_pointer_finalizer) gig_amap_free,
                                    arg_map, SCM_F_WIND_EXPLICITLY);
-        gig_arg_map_get_cinvoke_args_count(arg_map, &in, &out);
-        gig_arg_map_get_gsubr_args_count(arg_map, &req, &opt);
+        gig_amap_get_cinvoke_args_count(arg_map, &in, &out);
+        gig_amap_get_gsubr_args_count(arg_map, &req, &opt);
 
         if (g_callable_info_is_method(info)) {
             scm_printf(SCM_UNDEFINED, "<argument name=\"self\">");
@@ -102,14 +102,14 @@ do_document(GIBaseInfo *info, const gchar *namespace)
         }
 
         for (gint i = 0; i < req + opt; i++) {
-            GigArgMapEntry *entry = gig_arg_map_get_entry(arg_map, i);
+            GigArgMapEntry *entry = gig_amap_get_entry(arg_map, i);
             document_arg_entry("argument", entry);
         }
         if (arg_map->return_val->type_tag != GI_TYPE_TAG_VOID)
             document_arg_entry("return", arg_map->return_val);
 
         for (gint i = 0; i < out; i++) {
-            GigArgMapEntry *entry = gig_arg_map_get_output_entry(arg_map, i);
+            GigArgMapEntry *entry = gig_amap_get_output_entry(arg_map, i);
             document_arg_entry("return", entry);
         }
         scm_printf(SCM_UNDEFINED, "</procedure></scheme></%s>", kind);

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -272,11 +272,11 @@ make_formals(GICallableInfo *callable,
         scm_set_car_x(i_formal, scm_from_utf8_symbol(formal));
         // don't force types on nullable input, as #f can also be used to represent
         // NULL.
-        if (entry->may_be_null)
+        if (entry->meta.may_be_null)
             continue;
 
-        if (entry->type_tag == GI_TYPE_TAG_INTERFACE) {
-            GIBaseInfo *iface = g_type_info_get_interface(entry->type_info);
+        if (entry->meta.type_tag == GI_TYPE_TAG_INTERFACE) {
+            GIBaseInfo *iface = g_type_info_get_interface(entry->meta.type_info);
             if (!GI_IS_REGISTERED_TYPE_INFO(iface))
                 continue;
             GType gtype = g_registered_type_info_get_g_type((GIRegisteredTypeInfo *) iface);
@@ -422,9 +422,9 @@ gig_function_invoke(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *nam
     if (ok) {
         SCM s_return;
         gsize sz = -1;
-        if (amap->return_val.array_length_index >= 0) {
-            g_assert_cmpint(amap->return_val.array_length_index, <, amap->len);
-            gsize idx = amap->pdata[amap->return_val.array_length_index].c_output_pos;
+        if (amap->return_val.meta.array_length_index >= 0) {
+            g_assert_cmpint(amap->return_val.meta.array_length_index, <, amap->len);
+            gsize idx = amap->pdata[amap->return_val.meta.array_length_index].c_output_pos;
             sz = ((GIArgument *)(cinvoke_output_arg_array->data))[idx].v_size;
         }
 
@@ -549,7 +549,7 @@ object_to_c_arg(GigArgMap *amap, gint s, const gchar *name, SCM obj,
     if (!is_out)
         c_invoke_out = -1;
     if (c_invoke_in >= 0 || c_invoke_out >= 0) {
-        GigArgMapEntry *size_entry = &amap->pdata[entry->array_length_index];
+        GigArgMapEntry *size_entry = &amap->pdata[entry->meta.array_length_index];
         GIArgument size_arg;
         gsize dummy_size;
 
@@ -678,7 +678,7 @@ rebox_inout_args(GIFunctionInfo *func_info, GigArgMap *amap,
         for (guint i = 0; i < amap->len; i++) {
             GigArgMapEntry *amap_entry = &amap->pdata[i];
             if ((amap_entry->c_input_pos == c_input_pos)
-                && (amap_entry->c_direction == GI_DIRECTION_INOUT)) {
+                && (amap_entry->meta.c_direction == GI_DIRECTION_INOUT)) {
                 GIArgument *ob = (GIArgument *)(in_args->data);
                 SCM obj;
                 gsize size = GIG_ARRAY_SIZE_UNKNOWN;

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -422,13 +422,13 @@ gig_function_invoke(GIFunctionInfo *func_info, GigArgMap *amap, const gchar *nam
     if (ok) {
         SCM s_return;
         gsize sz = -1;
-        if (amap->return_val->array_length_index >= 0) {
-            g_assert_cmpint(amap->return_val->array_length_index, <, amap->len);
-            gsize idx = amap->pdata[amap->return_val->array_length_index]->c_output_pos;
+        if (amap->return_val.array_length_index >= 0) {
+            g_assert_cmpint(amap->return_val.array_length_index, <, amap->len);
+            gsize idx = amap->pdata[amap->return_val.array_length_index].c_output_pos;
             sz = ((GIArgument *)(cinvoke_output_arg_array->data))[idx].v_size;
         }
 
-        gig_argument_c_to_scm(name, -1, amap->return_val, &return_arg, &s_return, sz);
+        gig_argument_c_to_scm(name, -1, &amap->return_val, &return_arg, &s_return, sz);
         if (scm_is_eq(s_return, SCM_UNSPECIFIED))
             output = SCM_EOL;
         else
@@ -538,7 +538,7 @@ object_to_c_arg(GigArgMap *amap, gint i, const gchar *name, SCM obj,
     // array size as well.
     gig_amap_get_cinvoke_array_length_indices(amap, i, &invoke_in, &invoke_out);
     if (invoke_in >= 0 || invoke_out >= 0) {
-        GigArgMapEntry *size_entry = amap->pdata[entry->array_length_index];
+        GigArgMapEntry *size_entry = &amap->pdata[entry->array_length_index];
         GIArgument size_arg;
         gsize dummy_size;
 
@@ -674,7 +674,7 @@ rebox_inout_args(GIFunctionInfo *func_info, GigArgMap *amap,
 
     for (guint c_input_pos = 0; c_input_pos < out_args->len; c_input_pos++) {
         for (guint i = 0; i < amap->len; i++) {
-            GigArgMapEntry *amap_entry = amap->pdata[i];
+            GigArgMapEntry *amap_entry = &amap->pdata[i];
             if ((amap_entry->c_input_pos == c_input_pos)
                 && (amap_entry->c_direction == GI_DIRECTION_INOUT)) {
                 GIArgument *ob = (GIArgument *)(in_args->data);
@@ -684,8 +684,8 @@ rebox_inout_args(GIFunctionInfo *func_info, GigArgMap *amap,
                     gint size_index = amap_entry->child->i;
                     g_assert_cmpint(size_index, >=, 0);
 
-                    gig_argument_c_to_scm(func_name, size_index, amap->pdata[size_index],
-                                          ob[amap->pdata[size_index]->c_input_pos].v_pointer, &obj,
+                    gig_argument_c_to_scm(func_name, size_index, &amap->pdata[size_index],
+                                          ob[amap->pdata[size_index].c_input_pos].v_pointer, &obj,
                                           GIG_ARRAY_SIZE_UNKNOWN);
                     size = scm_to_size_t(obj);
                 }

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -269,7 +269,7 @@ gig_i_scm_set_property_x(SCM self, SCM property, SCM svalue)
     }
 
     g_value_init(&value, G_PARAM_SPEC_VALUE_TYPE(pspec));
-    gig_value_from_scm_with_error("%set-property!", &value, svalue, SCM_ARG3);
+    gig_value_from_scm_with_error(&value, svalue, "%set-property!", SCM_ARG3);
     g_object_set_property(obj, pspec->name, &value);
 
     return SCM_UNSPECIFIED;
@@ -546,11 +546,11 @@ gig_i_scm_emit(SCM self, SCM signal, SCM s_detail, SCM args)
 
     values = g_new0(GValue, query_info.n_params + 1);
     g_value_init(values, G_OBJECT_TYPE(obj));
-    gig_value_from_scm_with_error("%emit", values, self, SCM_ARG1);
+    gig_value_from_scm_with_error(values, self, "%emit", SCM_ARG1);
     SCM iter = args;
     for (guint i = 0; i < query_info.n_params; i++, iter = scm_cdr(iter)) {
         g_value_init(values + i + 1, query_info.param_types[i]);
-        gig_value_from_scm_with_error("%emit", values + i + 1, iter, SCM_ARGn);
+        gig_value_from_scm_with_error(values + i + 1, iter, "%emit", SCM_ARGn);
     }
 
     if (query_info.return_type != G_TYPE_NONE)
@@ -571,7 +571,6 @@ static SCM do_define_property(const gchar *, SCM, SCM, SCM);
 SCM
 gig_property_define(GType type, GIPropertyInfo *info, const gchar *namespace, SCM defs)
 {
-    SCM formals, specializers;
     GObjectClass *class;
     GParamSpec *prop;
     SCM s_prop, def;

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -569,7 +569,7 @@ static SCM ensure_accessor_proc;
 static SCM do_define_property(const gchar *, SCM, SCM, SCM);
 
 SCM
-gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace, SCM defs)
+gig_property_define(GType type, GIPropertyInfo *info, const gchar *namespace, SCM defs)
 {
     SCM formals, specializers;
     GObjectClass *class;
@@ -626,8 +626,7 @@ do_define_property(const gchar *public_name, SCM prop, SCM self_type, SCM value_
     scm_call_2(add_method_proc, generic,
                scm_call_7(make_proc, method_type,
                           kwd_specializers, specializers,
-                          kwd_formals, formals,
-                          kwd_procedure, proc));
+                          kwd_formals, formals, kwd_procedure, proc));
 
     // setter
     setter = scm_setter(prop);
@@ -637,8 +636,7 @@ do_define_property(const gchar *public_name, SCM prop, SCM self_type, SCM value_
     scm_call_2(add_method_proc, scm_setter(generic),
                scm_call_7(make_proc, method_type,
                           kwd_specializers, specializers,
-                          kwd_formals, formals,
-                          kwd_procedure, setter));
+                          kwd_formals, formals, kwd_procedure, setter));
 
     scm_define(sym_public_name, generic);
     return sym_public_name;

--- a/src/gig_object.h
+++ b/src/gig_object.h
@@ -7,6 +7,6 @@
 #include <girepository.h>
 
 void gig_init_object();
-SCM gig_property_define(GType type, GIPropertyInfo *info, const gchar* namespace, SCM defs);
+SCM gig_property_define(GType type, GIPropertyInfo *info, const gchar *namespace, SCM defs);
 
 #endif

--- a/src/gig_repository.h
+++ b/src/gig_repository.h
@@ -26,8 +26,7 @@ void gig_repository_nested_infos(GIBaseInfo *base,
                                  GigRepositoryNested *property,
                                  gint *n_signals,
                                  GigRepositoryNested *signal,
-                                 gint *n_fields,
-                                 GigRepositoryNested *field);
+                                 gint *n_fields, GigRepositoryNested *field);
 
 
 #endif

--- a/src/gig_type.c
+++ b/src/gig_type.c
@@ -229,8 +229,7 @@ gig_type_define(GType gtype, SCM defs)
         case G_TYPE_BOXED:
         {
             dsupers = scm_list_1(SCM_PACK_POINTER(sparent));
-            new_type = scm_call_4(make_class_proc, dsupers, slots, kwd_name,
-                                  type_class_name);
+            new_type = scm_call_4(make_class_proc, dsupers, slots, kwd_name, type_class_name);
 
             GigBoxedFuncs *funcs = _boxed_funcs_for_type(gtype);
 
@@ -274,8 +273,7 @@ gig_type_define(GType gtype, SCM defs)
 
             // dsupers need to be sorted, or else Guile will barf
             dsupers = scm_sort_x(dsupers, type_less_p_proc);
-            new_type = scm_call_4(make_class_proc, dsupers, slots, kwd_name,
-                                  type_class_name);
+            new_type = scm_call_4(make_class_proc, dsupers, slots, kwd_name, type_class_name);
             break;
 
         }

--- a/src/gig_util.c
+++ b/src/gig_util.c
@@ -174,3 +174,34 @@ scm_printf(SCM port, const gchar *fmt, ...)
     g_free(_message);
     scm_display(message, port);
 }
+
+const gchar *
+g_base_info_get_name_safe(GIBaseInfo *info)
+{
+    GIInfoType type = g_base_info_get_type(info);
+    switch (type) {
+    case GI_INFO_TYPE_FUNCTION:
+    case GI_INFO_TYPE_CALLBACK:
+    case GI_INFO_TYPE_STRUCT:
+    case GI_INFO_TYPE_BOXED:
+    case GI_INFO_TYPE_ENUM:
+    case GI_INFO_TYPE_FLAGS:
+    case GI_INFO_TYPE_OBJECT:
+    case GI_INFO_TYPE_INTERFACE:
+    case GI_INFO_TYPE_CONSTANT:
+    case GI_INFO_TYPE_UNION:
+    case GI_INFO_TYPE_VALUE:
+    case GI_INFO_TYPE_SIGNAL:
+    case GI_INFO_TYPE_PROPERTY:
+    case GI_INFO_TYPE_VFUNC:
+    case GI_INFO_TYPE_FIELD:
+    case GI_INFO_TYPE_ARG:
+    case GI_INFO_TYPE_UNRESOLVED:
+        return g_base_info_get_name(info);
+        break;
+    case GI_INFO_TYPE_TYPE:
+    default:
+        return "(unnamed)";
+        break;
+    }
+}

--- a/src/gig_util.h
+++ b/src/gig_util.h
@@ -3,6 +3,7 @@
 
 #include <glib.h>
 #include <libguile.h>
+#include <girepository.h>
 
 // *INDENT-OFF*
 G_BEGIN_DECLS
@@ -18,6 +19,7 @@ SCM scm_class_set_x(SCM cls, SCM slot, SCM val);
 SCM scm_drop_right_1(SCM lst);
 SCM scm_c_reexport(const gchar *name, ...);
 SCM scm_printf(SCM port, const gchar *fmt, ...);
+const gchar *g_base_info_get_name_safe(GIBaseInfo *info);
 
 #define scm_is_equal(a,b) scm_is_true(scm_equal_p(a,b))
 

--- a/src/gig_value.c
+++ b/src/gig_value.c
@@ -233,7 +233,7 @@ gig_value_from_scm(GValue *value, SCM obj)
 }
 
 void
-gig_value_from_scm_with_error(const gchar *subr, GValue *value, SCM obj, gint pos)
+gig_value_from_scm_with_error(GValue *value, SCM obj, const gchar *subr, gint pos)
 {
     gint res = gig_value_from_scm(value, obj);
     switch (res) {

--- a/src/gig_value.h
+++ b/src/gig_value.h
@@ -16,7 +16,7 @@ SCM gig_value_to_scm_basic_type(const GValue *value, GType fundamental, gboolean
 SCM gig_value_param_as_scm(const GValue *gvalue, gboolean copy_boxed, const GParamSpec *pspec);
 
 SCM gig_value_as_scm(const GValue *value, gboolean copy_boxed);
-void gig_value_from_scm_with_error(const gchar *subr, GValue *value, SCM obj, gint pos);
+void gig_value_from_scm_with_error(GValue *value, SCM obj, const gchar *subr, gint pos);
 int gig_value_from_scm(GValue *value, SCM obj);
 
 void gig_init_value(void);

--- a/test/everything/init-function-one.scm
+++ b/test/everything/init-function-one.scm
@@ -13,6 +13,6 @@
      (format #t "Input After: ~S~%" x)
      (format #t "Output: ~S~%" y)
      (format #t "Success: ~S~%" ret)
-     (and (vector-empty? y)
+     (and (not y)
           ret))))
  

--- a/test/everything/init-function-zero.scm
+++ b/test/everything/init-function-zero.scm
@@ -13,5 +13,5 @@
      (format #t "Input After: ~S~%" x)
      (format #t "Output: ~S~%" y)
      (format #t "Success: ~S~%" ret)
-     (and (vector-empty? y)
+     (and (not y)
           ret))))


### PR DESCRIPTION
This is a "fork" of dev-gig-meta2, rebased on master and adjusted, so that a merge is both possible and meaningful. It contains GigTypeMeta and GigTypeMeta-based argument conversion, plus a minor fix to gig_value and a reapplied fix to GVariant * arrays. It does not yet contain anything regarding the `SCM <-> GValue <-> GIArgument` conversion chain. The purpose of this pull request is to make GigTypeMeta available on master, so that other feature branches can rebase on it. This should also make it easier to implement aforementioned chain from a point that doesn't diverge so far from master.