### PR TITLE
Reduce GTypes

### DIFF
--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -18,7 +18,6 @@
 #include "gig_data_type.h"
 #include "gig_util.h"
 
-GType g_type_unichar;
 GType g_type_locale_string;
 
 GType g_type_list;
@@ -123,7 +122,12 @@ gig_type_meta_init_from_basic_type_tag(GigTypeMeta *meta, GITypeTag tag)
     T(GI_TYPE_TAG_UINT16, G_TYPE_UINT, guint16);
     T(GI_TYPE_TAG_UINT32, G_TYPE_UINT, guint32);
     T(GI_TYPE_TAG_UINT64, G_TYPE_UINT, guint64);
-    T(GI_TYPE_TAG_UNICHAR, G_TYPE_UNICHAR, gunichar);
+    if (tag == GI_TYPE_TAG_UNICHAR) {
+        meta->gtype = G_TYPE_UINT;
+        meta->item_size = sizeof (gunichar);
+        meta->is_unichar = TRUE;
+        return;
+    }
     T(GI_TYPE_TAG_UTF8, G_TYPE_STRING, gchar *);
     T(GI_TYPE_TAG_FILENAME, G_TYPE_LOCALE_STRING, gchar *);
     T(GI_TYPE_TAG_ERROR, G_TYPE_ERROR, GError);
@@ -314,7 +318,6 @@ G_DEFINE_BOXED_TYPE(GSList, g_slist, g_slist_copy, g_slist_free);
 void
 gig_init_data_type(void)
 {
-    g_type_unichar = g_type_register_static_simple(G_TYPE_INT, "gunichar", 0, NULL, 0, NULL, 0);
     g_type_locale_string = g_type_register_static_simple(G_TYPE_STRING,
                                                          "locale-string", 0, NULL, 0, NULL, 0);
 

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -23,10 +23,6 @@ G_BEGIN_DECLS
 // *INDENT-ON*
 
 extern GType g_type_unichar;
-extern GType g_type_int16;
-extern GType g_type_int32;
-extern GType g_type_uint16;
-extern GType g_type_uint32;
 extern GType g_type_locale_string;
 
 extern GType g_type_list;
@@ -34,10 +30,6 @@ extern GType g_type_slist;
 extern GType g_type_callback;
 
 #define G_TYPE_UNICHAR (g_type_unichar)
-#define G_TYPE_INT16 (g_type_int16)
-#define G_TYPE_INT32 (g_type_int32)
-#define G_TYPE_UINT16 (g_type_uint16)
-#define G_TYPE_UINT32 (g_type_uint32)
 
 #define G_TYPE_LIST (g_type_list)
 #define G_TYPE_SLIST (g_type_slist)
@@ -89,6 +81,7 @@ struct _GigTypeMeta
 
 void gig_type_meta_init_from_arg_info(GigTypeMeta *type, GIArgInfo *ai);
 void gig_type_meta_init_from_callable_info(GigTypeMeta *type, GICallableInfo *ci);
+G_GNUC_PURE gsize gig_meta_real_item_size(const GigTypeMeta *meta);
 const char *gig_type_meta_describe(const GigTypeMeta *meta);
 void gig_data_type_free(GigTypeMeta *meta);
 void gig_init_data_type(void);

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -64,8 +64,10 @@ struct _GigTypeMeta
     guint16 padding1:5;
 
     // For C array types
-    gsize length;
-    gsize item_size;
+    union {
+        gsize length;
+        gsize item_size;
+    };
 
     GITransfer transfer;
 

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -22,14 +22,11 @@
 G_BEGIN_DECLS
 // *INDENT-ON*
 
-extern GType g_type_unichar;
 extern GType g_type_locale_string;
 
 extern GType g_type_list;
 extern GType g_type_slist;
 extern GType g_type_callback;
-
-#define G_TYPE_UNICHAR (g_type_unichar)
 
 #define G_TYPE_LIST (g_type_list)
 #define G_TYPE_SLIST (g_type_slist)
@@ -61,7 +58,8 @@ struct _GigTypeMeta
     guint16 is_raw_array:1;
     guint16 is_zero_terminated:1;
     guint16 has_size:1;
-    guint16 padding1:5;
+    guint16 is_unichar:1;
+    guint16 padding1:4;
 
     // For C array types
     union {

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -22,17 +22,6 @@
 G_BEGIN_DECLS
 // *INDENT-ON*
 
-extern GType g_type_locale_string;
-
-extern GType g_type_list;
-extern GType g_type_slist;
-extern GType g_type_callback;
-
-#define G_TYPE_LIST (g_type_list)
-#define G_TYPE_SLIST (g_type_slist)
-#define G_TYPE_LOCALE_STRING (g_type_locale_string)
-#define G_TYPE_CALLBACK (g_type_callback)
-
 #define GIG_ARRAY_SIZE_UNKNOWN ((gsize)-1)
 
 typedef struct _GigTypeMeta GigTypeMeta;
@@ -61,9 +50,23 @@ struct _GigTypeMeta
     guint16 is_unichar:1;
     guint16 padding1:4;
 
-    // For C array types
-    union {
+    union
+    {
+        // For string and pointer types
+        enum
+        {
+            GIG_DATA_VOID = 0,
+            GIG_DATA_UTF8_STRING,
+            GIG_DATA_LOCALE_STRING,
+            GIG_DATA_LIST,
+            GIG_DATA_SLIST,
+            GIG_DATA_HASH_TABLE,
+            GIG_DATA_CALLBACK
+        } pointer_type;
+
+        // For C array types
         gsize length;
+        // For C element types
         gsize item_size;
     };
 


### PR DESCRIPTION
This patch removes all of our special GTypes and replaces them with "edge cases" of G_TYPE_INT, G_TYPE_UINT and G_TYPE_POINTER.

With this, we can write or use a language-agnostic GValue <-> GIArgument conversion, if we ever get around to creating an SCM <-> GValue <-> GIArgument conversion chain. The initial step (SCM <-> GValue) becomes slightly harder, because we no longer have our special types, but if we're doing this correctly, values created from our code should be able to interact with other automatic bindings, e.g. the way Vala packs lists etc. into values.