### PR TITLE
Properly map GTypes to Guile types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,13 +190,6 @@ AC_ARG_ENABLE([hardening],
 AS_IF([test "x$enable_hardening" = xyes],
       [CC_CHECK_CFLAGS_APPEND([compiler_flags_common])])
 
-AC_ARG_ENABLE([reverse-hash],
-              [AS_HELP_STRING([--enable-reverse-hash],
-                              [have reverse type lookup hash])])
-AS_IF([test "x$enable_reverse_hash" = xyes],
-      [AC_DEFINE([ENABLE_GIG_TYPE_SCM_HASH], [1],
-                 [Define if SCM to GType hash is enabled.])])
-
 AC_ARG_ENABLE([coverage],
               [AS_HELP_STRING([--enable-coverage],
                               [compile with gcov support])],

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -1401,7 +1401,7 @@ c_list_to_scm(C2S_ARG_DECL)
             else if (item_type == G_TYPE_DOUBLE)
                 scm_set_car_x(out_iter, scm_from_double(*(double *)data));
             else if (item_type == G_TYPE_GTYPE) {
-                gig_type_register(*(gsize *)data);
+                gig_type_register(*(gsize *)data, SCM_UNDEFINED);
                 scm_set_car_x(out_iter, scm_from_size_t(*(gsize *)data));
             }
             else

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -478,11 +478,8 @@ scm_to_c_pointer(S2C_ARG_DECL)
         else
             scm_wrong_type_arg_msg(subr, argpos, object, "a procedure");
     }
-    else if (meta->gtype == G_TYPE_GTYPE) {
-        if (!scm_is_unsigned_integer(object, 0, UINT64_MAX))
-            scm_wrong_type_arg_msg(subr, argpos, object, "GType integer");
-        arg->v_size = scm_to_size_t(object);
-    }
+    else if (meta->gtype == G_TYPE_GTYPE)
+        arg->v_size = scm_to_gtype_full(object, subr, argpos);
     else if (SCM_POINTER_P(object))
         arg->v_pointer = scm_to_pointer(object);
     else if (scm_is_bytevector(object))
@@ -1400,10 +1397,8 @@ c_list_to_scm(C2S_ARG_DECL)
                 scm_set_car_x(out_iter, scm_from_double(*(float *)data));
             else if (item_type == G_TYPE_DOUBLE)
                 scm_set_car_x(out_iter, scm_from_double(*(double *)data));
-            else if (item_type == G_TYPE_GTYPE) {
-                gig_type_register(*(gsize *)data, SCM_UNDEFINED);
-                scm_set_car_x(out_iter, scm_from_size_t(*(gsize *)data));
-            }
+            else if (item_type == G_TYPE_GTYPE)
+                scm_set_car_x(out_iter, scm_from_gtype(*(gsize *)data));
             else
                 UNHANDLED;
         }
@@ -1435,7 +1430,7 @@ c_pointer_to_scm(C2S_ARG_DECL)
     if (arg->v_pointer == NULL && meta->is_nullable)
         *object = SCM_BOOL_F;
     else if (meta->gtype == G_TYPE_GTYPE)
-        *object = scm_from_uintptr_t(arg->v_pointer);
+        *object = scm_from_gtype(arg->v_size);
     else if (meta->pointer_type == GIG_DATA_CALLBACK) {
         gpointer cb = meta->is_ptr ? *(gpointer *)arg->v_pointer : arg->v_pointer;
         *object = gig_callback_to_scm(meta->callable_info, cb);

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -186,7 +186,7 @@ gig_type_meta_init_from_type_info(GigTypeMeta *meta, GITypeInfo *type_info)
     }
     else if (tag == GI_TYPE_TAG_GHASH) {
         meta->gtype = G_TYPE_HASH_TABLE;
-        meta->pointer_type = GIG_DATA_HASH_TABLE;
+        meta->item_size = sizeof(GHashTable *);
         add_child_params(meta, type_info, 2);
     }
     else if (tag == GI_TYPE_TAG_GLIST) {

--- a/src/gig_data_type.h
+++ b/src/gig_data_type.h
@@ -60,7 +60,6 @@ struct _GigTypeMeta
             GIG_DATA_LOCALE_STRING,
             GIG_DATA_LIST,
             GIG_DATA_SLIST,
-            GIG_DATA_HASH_TABLE,
             GIG_DATA_CALLBACK
         } pointer_type;
 

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -258,12 +258,27 @@ check_gsubr_cache(GICallableInfo *function_info, SCM self_type, gint *required_i
     return gfn->function_ptr;
 }
 
+SCM char_type;
+SCM list_type;
+SCM string_type;
+SCM applicable_type;
+
 static SCM
 type_specializer(GigTypeMeta *meta) {
     switch (meta->gtype) {
     case G_TYPE_POINTER:
-        // TODO: handle lists, procedures, etc.
-        return SCM_UNDEFINED;
+        switch(meta->pointer_type) {
+        case GIG_DATA_UTF8_STRING:
+        case GIG_DATA_LOCALE_STRING:
+            return string_type;
+        case GIG_DATA_LIST:
+        case GIG_DATA_SLIST:
+            return list_type;
+        case GIG_DATA_CALLBACK:
+            return applicable_type;
+        default:
+            return SCM_UNDEFINED;
+        }
     case G_TYPE_UINT:
         if (meta->is_unichar)
             return char_type;
@@ -823,6 +838,8 @@ gig_init_function(void)
     method_type = scm_c_public_ref("oop goops", "<method>");
     char_type = scm_c_public_ref("oop goops", "<char>");
     list_type = scm_c_public_ref("oop goops", "<list>");
+    string_type = scm_c_public_ref("oop goops", "<string>");
+    applicable_type = scm_c_public_ref("oop goops", "<applicable>");
 
     ensure_generic_proc = scm_c_public_ref("oop goops", "ensure-generic");
     make_proc = scm_c_public_ref("oop goops", "make");

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -106,7 +106,7 @@ gig_function_define(GType type, GICallableInfo *info, const gchar *namespace, SC
 
     if (is_method) {
         self_type = gig_type_get_scheme_type(type);
-        g_return_val_if_fail(scm_is_true(self_type), defs);
+        g_return_val_if_fail(!SCM_UNBNDP(self_type), defs);
         method_name = scm_dynwind_or_bust("%gig-function-define",
                                           gi_callable_info_make_name(info, NULL));
     }
@@ -258,6 +258,21 @@ check_gsubr_cache(GICallableInfo *function_info, SCM self_type, gint *required_i
     return gfn->function_ptr;
 }
 
+static SCM
+type_specializer(GigTypeMeta *meta) {
+    switch (meta->gtype) {
+    case G_TYPE_POINTER:
+        // TODO: handle lists, procedures, etc.
+        return SCM_UNDEFINED;
+    case G_TYPE_UINT:
+        if (meta->is_unichar)
+            return char_type;
+        /* fall through */
+    default:
+        return gig_type_get_scheme_type(meta->gtype);
+    }
+}
+
 static void
 make_formals(GICallableInfo *callable,
              GigArgMap *argmap, gint n_inputs, SCM self_type, SCM *formals, SCM *specializers)
@@ -287,11 +302,9 @@ make_formals(GICallableInfo *callable,
         if (entry->meta.is_nullable)
             continue;
 
-        if (!G_TYPE_IS_VALUE(entry->meta.gtype)) {
-            SCM s_type = gig_type_get_scheme_type(entry->meta.gtype);
-            if (scm_is_true(s_type))
-                scm_set_car_x(i_specializer, s_type);
-        }
+        SCM s_type = type_specializer(&entry->meta);
+        if (!SCM_UNBNDP(s_type))
+            scm_set_car_x(i_specializer, s_type);
     }
 }
 
@@ -805,8 +818,12 @@ gig_init_function(void)
 {
     function_cache =
         g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)function_free);
+
     top_type = scm_c_public_ref("oop goops", "<top>");
     method_type = scm_c_public_ref("oop goops", "<method>");
+    char_type = scm_c_public_ref("oop goops", "<char>");
+    list_type = scm_c_public_ref("oop goops", "<list>");
+
     ensure_generic_proc = scm_c_public_ref("oop goops", "ensure-generic");
     make_proc = scm_c_public_ref("oop goops", "make");
     add_method_proc = scm_c_public_ref("oop goops", "add-method!");

--- a/src/gig_function_private.h
+++ b/src/gig_function_private.h
@@ -7,8 +7,6 @@ SCM add_method_proc;
 
 SCM top_type;
 SCM method_type;
-SCM char_type;
-SCM list_type;
 
 SCM kwd_specializers;
 SCM kwd_formals;

--- a/src/gig_function_private.h
+++ b/src/gig_function_private.h
@@ -7,6 +7,8 @@ SCM add_method_proc;
 
 SCM top_type;
 SCM method_type;
+SCM char_type;
+SCM list_type;
 
 SCM kwd_specializers;
 SCM kwd_formals;

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -71,7 +71,7 @@ gig_i_scm_make_gobject(SCM s_gtype, SCM s_prop_keylist)
     SCM_ASSERT_TYPE(G_TYPE_IS_CLASSED(type), s_gtype, SCM_ARG1, FUNC,
                     "typeid derived from G_TYPE_OBJECT or scheme type derived from <GObject>");
 
-    if (scm_is_false(gig_type_get_scheme_type(type)))
+    if (SCM_UNBNDP(gig_type_get_scheme_type(type)))
         scm_misc_error(FUNC, "type ~S lacks introspection", scm_list_1(s_gtype));
 
     scm_dynwind_begin(0);
@@ -360,7 +360,7 @@ gig_i_scm_define_type(SCM s_type_name, SCM s_parent_type, SCM s_properties, SCM 
 
     parent_type = scm_to_gtype(s_parent_type);
 
-    if (scm_is_false(gig_type_get_scheme_type(parent_type)))
+    if (SCM_UNBNDP(gig_type_get_scheme_type(parent_type)))
         scm_misc_error("%define-type", "type ~S is dupe", scm_list_1(s_parent_type));
 
     SCM_UNBND_TO_BOOL_F(s_properties);

--- a/src/gig_type.c
+++ b/src/gig_type.c
@@ -95,14 +95,14 @@ gig_type_document_type_from_gtype(GType gtype)
 // that GType in our hash table of known types without creating an
 // associated foreign object type.
 void
-gig_type_register(GType gtype)
+gig_type_register(GType gtype, SCM stype)
 {
     GType parent = g_type_parent(gtype);
     if (parent != 0)
-        gig_type_register(parent);
+        gig_type_register(parent, SCM_UNDEFINED);
 
     if (!g_hash_table_contains(gig_type_gtype_hash, GSIZE_TO_POINTER(gtype))) {
-        g_hash_table_insert(gig_type_gtype_hash, GSIZE_TO_POINTER(gtype), NULL);
+        g_hash_table_insert(gig_type_gtype_hash, GSIZE_TO_POINTER(gtype), SCM_UNPACK_POINTER(stype));
         g_debug("Registering a new GType: %zu -> %s", gtype, g_type_name(gtype));
     }
 }
@@ -800,7 +800,7 @@ gig_init_types_once(void)
 #define D(x)                                                            \
     do                                                                  \
     {                                                                   \
-        gig_type_register(x);                                           \
+        gig_type_register(x, SCM_UNDEFINED);                            \
         scm_permanent_object(scm_c_define(#x, scm_from_uintptr_t(x)));  \
         scm_c_export(#x, NULL);                                         \
     } while (0)

--- a/src/gig_type.c
+++ b/src/gig_type.c
@@ -367,6 +367,9 @@ gig_type_define_full(GType gtype, SCM defs, SCM extra_supers)
         g_return_val_if_fail(orig_value != NULL, defs);
         SCM val = SCM_PACK_POINTER(orig_value);
 
+        // FIXME: The warning below should be infrequent enough to not need silencing
+        if (SCM_UNBNDP(val))
+            return defs;
         g_return_val_if_fail(!SCM_UNBNDP(val), defs);
         SCM key = scm_class_name(val);
         if (!SCM_UNBNDP(defs)) {

--- a/src/gig_type.h
+++ b/src/gig_type.h
@@ -33,7 +33,7 @@ SCM gig_closure_type;
 G_GNUC_MALLOC gchar *gig_type_document_type_from_gtype(GType gtype);
 G_GNUC_MALLOC gchar *gig_type_class_name_from_gtype(GType gtype);
 
-void gig_type_register(GType gtype);
+void gig_type_register(GType gtype, SCM stype);
 SCM gig_type_define(GType gtype, SCM defs);
 SCM gig_type_define_full(GType gtype, SCM defs, SCM extra_supers);
 SCM gig_type_define_with_info(GIRegisteredTypeInfo *info, SCM supers, SCM slots);

--- a/src/gig_type.h
+++ b/src/gig_type.h
@@ -39,6 +39,8 @@ SCM gig_type_define_full(GType gtype, SCM defs, SCM extra_supers);
 SCM gig_type_define_with_info(GIRegisteredTypeInfo *info, SCM supers, SCM slots);
 
 GType scm_to_gtype(SCM x);
+GType scm_to_gtype_full(SCM x, const gchar *subr, gint argpos);
+SCM scm_from_gtype(GType x);
 GType gig_type_get_gtype_from_obj(SCM x);
 SCM gig_type_get_scheme_type(GType gtype);
 SCM gig_type_get_scheme_type_with_info(GIRegisteredTypeInfo *info);

--- a/test/everything/const-return-gtype.scm
+++ b/test/everything/const-return-gtype.scm
@@ -7,4 +7,4 @@
  (let ((x (const-return-gtype)))
    (write x)
    (newline)
-   (eqv? x G_TYPE_OBJECT)))
+   (eq? x <GObject>)))

--- a/test/unichar/validate_zero.scm
+++ b/test/unichar/validate_zero.scm
@@ -4,4 +4,4 @@
 (typelib-require ("GLib" "2.0"))
 
 (automake-test
- (unichar-validate? #x0000))
+ (unichar-validate? #\x0000))


### PR DESCRIPTION
In short, make it so that `gig_type_gtype_hash` has a valid value for all existing types, including basic types. The invalid type should map to `#f`, whereas `void` (alias none) should map to `*unspecified*` or any other value with the same meaning. All other values should be GOOPS classes that can be used in specializers. (Note: For generated methods, we should then make sure to check, whether we have pointers to such objects or actual objects).

Once that is done, let's make all returns of GTypes return the respective type, similar to how ParamSpecs are wrapped.