### PR TITLE
Add procedures to make symbols lists from flag and enum classes

### DIFF
--- a/doc/guile-gi.texi
+++ b/doc/guile-gi.texi
@@ -865,7 +865,7 @@ bitwise, the result will make some sense.
 
 In Scheme, the closest analogues to enumerations and flags are symbols
 and symbol lists.  Symbol equality can be checked with @code{eq?},
-symbol list equality with @code{equal?}  and in Guile specifically, the
+symbol list equality with @code{equal?} and in Guile specifically, the
 other operations can be implemented based on the @code{lset-*}
 procedures.@footnote{Other implementations may offer similar functions
 -- otherwise they can be implemented by the user themselves.}  However,
@@ -877,6 +877,8 @@ with every other object type. Specifically, enums derive from
 @code{<GEnum>} and flags derive from @code{<GFlags>}.
 
 @subsection Conversions
+These procedures are defined in @code{(gi types)}.
+
 @deffn Procedure number->enum (class <class>) (number <number>)
 @deffnx Procedure number->enum (class <class>)
 @deffnx Procedure number->flags (class <class>) (number <number>)
@@ -892,6 +894,11 @@ type. Note, that this type is shortened to its name without any
 prefixes.  For instance, a @code{GtkOrientation} may be created using
 @code{number->orientation}.  We will henceforth refer to this
 construction as ``binding @var{class} on @var{type}''
+@end deffn
+
+@deffn Procedure enum-set->list (class <class>)
+Returns a list of symbols that can be converted into enums of class
+@var{class}.
 @end deffn
 
 @deffn Procedure symbol->enum (class <class>) (symbol <symbol>)
@@ -945,6 +952,11 @@ If both @var{flags} and @var{class} are given, raises an error
 if @var{flags} is not of type @var{class}.
 
 Curries. Binds @var{class} on @var{type}.
+@end deffn
+
+@deffn Procedure flags-set->list (class <class>)
+Returns a list of symbols that could represent flags of class
+@var{class}.
 @end deffn
 
 @deffn Procedure flags->list (enum <GEnum>)

--- a/module/gi/types.scm
+++ b/module/gi/types.scm
@@ -27,7 +27,9 @@
             <GValue> transform
             <GClosure> procedure->closure
             <GEnum> <GFlags>
+            enum-set->list
             enum->number enum->symbol number->enum symbol->enum
+            flags-set->list
             flags->number flags->list number->flags list->flags flags-set?
             flags-mask flags-union flags-intersection flags-difference
             flags-complement flags-projection flags-projection/list
@@ -69,6 +71,13 @@
   (slot-set! closure 'procedure (lambda (type . args) (%invoke-closure closure type args))))
 
 ;;; Enum conversions
+
+(define-method (enum-set->list (class <class>))
+  (let ((hsh (class-slot-ref class 'obarray)))
+    (hash-fold (lambda (key value prev)
+                 (cons key prev))
+               '()
+               hsh)))
 
 (define-method (enum->symbol (enum <GEnum>))
   (let ((expected (slot-ref enum 'value)))
@@ -128,6 +137,13 @@
   (lambda (number) (number->enum class number)))
 
 ;;; Flag conversions
+
+(define-method (flags-set->list (class <class>))
+  (let ((hsh (class-slot-ref class 'obarray)))
+    (hash-fold (lambda (key value prev)
+                 (cons key prev))
+               '()
+               hsh)))
 
 (define-method (flags->number (number <number>))
   (format (current-error-port) "WARNING: passing number ~a as flags~%" number)


### PR DESCRIPTION
So when I tried to update some of the examples in the `example` directory, it wasn't obvious how to make `<GFlags>` or `<GEnum>` instances.

Is best practice intended to be that that I use symbols to create flag and enum instances?  Or rather should I be figuring out how to define them at introspection time?  Or are they defined and I just can't find them?

If the first case, some procedures like this merge set might be useful.