### PR TITLE
Remove fields

### DIFF
--- a/doc/guile-gi.texi
+++ b/doc/guile-gi.texi
@@ -579,15 +579,15 @@ Throws an error, if @var{name} could not be found.
 @deffnx Procedure load (info <GBaseInfo>) flags
 Generates bindings for @var{info}.
 
-@var{flags} is a logical or of @code{LOAD_METHODS}, @code{LOAD_SIGNALS},
-@code{LOAD_PROPERTIES} and @code{LOAD_FIELDS}
-and may be 0 or @code{LOAD_INFO_ONLY} tells @code{load}, how to handle
-infos with nested information, such as structs and objects.
+@var{flags} is a logical or of @code{LOAD_METHODS}, @code{LOAD_SIGNALS} and
+@code{LOAD_PROPERTIES}, and may be 0 or @code{LOAD_INFO_ONLY} tells @code{load},
+how to handle infos with nested information, such as structs and objects.
 They enable loading of methods, signals, properties and fields respectively.
 By default, all of them are loaded.
 
 @quotation Warning
-@code{LOAD_FIELDS} currently does nothing, as fields are not yet supported.
+Previous versions also documented @code{LOAD_FIELDS}, which was never actually supported.
+This flag is removed in current builds and will remain removed in upcoming versions.
 @end quotation
 @end deffn
 

--- a/module/gi/repository.scm
+++ b/module/gi/repository.scm
@@ -28,7 +28,7 @@
 
             get-search-path prepend-search-path!
 
-            LOAD_METHODS LOAD_PROPERTIES LOAD_SIGNALS LOAD_FIELDS
+            LOAD_METHODS LOAD_PROPERTIES LOAD_SIGNALS
             LOAD_EVERYTHING LOAD_INFO_ONLY))
 
 (eval-when (expand load eval)

--- a/src/gig_document.c
+++ b/src/gig_document.c
@@ -36,16 +36,15 @@ document_nested(GIBaseInfo *parent)
     gchar *_namespace = gig_gname_to_scm_name(g_base_info_get_name(parent));
     scm_dynwind_free(_namespace);
 
-    gint n_methods, n_properties, n_signals, n_fields;
-    GigRepositoryNested method, property, nested_signal, field;
+    gint n_methods, n_properties, n_signals;
+    GigRepositoryNested method, property, nested_signal;
 
     gig_repository_nested_infos(parent, &n_methods, &method, &n_properties, &property,
-                                &n_signals, &nested_signal, &n_fields, &field);
+                                &n_signals, &nested_signal);
 
     DOCUMENT_NESTED(n_methods, method);
     DOCUMENT_NESTED(n_properties, property);
     DOCUMENT_NESTED(n_signals, nested_signal);
-    DOCUMENT_NESTED(n_fields, field);
 
 #undef DOCUMENT_NESTED
 }
@@ -200,10 +199,6 @@ do_document(GIBaseInfo *info, const gchar *_namespace)
                    ((flags & G_PARAM_READABLE) != 0), ((flags & G_PARAM_WRITABLE) != 0));
         break;
     }
-    case GI_INFO_TYPE_FIELD:
-        scm_printf(SCM_UNDEFINED, "<field name=\"%s\" />", g_base_info_get_name(info));
-        break;
-
     case GI_INFO_TYPE_VALUE:
     {
         scheme_name = scm_dynwind_or_bust("%document",
@@ -217,6 +212,7 @@ do_document(GIBaseInfo *info, const gchar *_namespace)
         scm_printf(SCM_UNDEFINED, "/></scheme></member>", scheme_name);
     }
         break;
+    case GI_INFO_TYPE_FIELD:
     case GI_INFO_TYPE_CONSTANT:
     case GI_INFO_TYPE_CALLBACK:
     case GI_INFO_TYPE_ARG:

--- a/src/gig_repository.c
+++ b/src/gig_repository.c
@@ -76,8 +76,7 @@ typedef enum _LoadFlags
     LOAD_METHODS = 1 << 0,
     LOAD_PROPERTIES = 1 << 1,
     LOAD_SIGNALS = 1 << 2,
-    LOAD_FIELDS = 1 << 3,
-    LOAD_EVERYTHING = LOAD_METHODS | LOAD_PROPERTIES | LOAD_SIGNALS | LOAD_FIELDS
+    LOAD_EVERYTHING = LOAD_METHODS | LOAD_PROPERTIES | LOAD_SIGNALS
 } LoadFlags;
 
 void
@@ -87,34 +86,33 @@ gig_repository_nested_infos(GIBaseInfo *base,
                             gint *n_properties,
                             GigRepositoryNested *property,
                             gint *n_signals,
-                            GigRepositoryNested *signal,
-                            gint *n_fields, GigRepositoryNested *field)
+                            GigRepositoryNested *signal)
 {
     switch (g_base_info_get_type(base)) {
     case GI_INFO_TYPE_STRUCT:
         *n_methods = g_struct_info_get_n_methods(base);
         *method = (GigRepositoryNested)g_struct_info_get_method;
-        *n_properties = *n_signals = *n_fields = 0;
-        *property = *signal = *field = NULL;
+        *n_properties = *n_signals = 0;
+        *property = *signal = NULL;
         break;
     case GI_INFO_TYPE_UNION:
         *n_methods = g_union_info_get_n_methods(base);
         *method = (GigRepositoryNested)g_union_info_get_method;
-        *n_properties = *n_signals = *n_fields = 0;
-        *property = *signal = *field = NULL;
+        *n_properties = *n_signals = 0;
+        *property = *signal = NULL;
         break;
     case GI_INFO_TYPE_ENUM:
     case GI_INFO_TYPE_FLAGS:
         *n_methods = g_enum_info_get_n_methods(base);
         *method = (GigRepositoryNested)g_enum_info_get_method;
-        *n_properties = *n_signals = *n_fields = 0;
-        *property = *signal = *field = NULL;
+        *n_properties = *n_signals = 0;
+        *property = *signal = NULL;
         break;
     case GI_INFO_TYPE_INTERFACE:
         *n_methods = g_interface_info_get_n_methods(base);
         *method = (GigRepositoryNested)g_interface_info_get_method;
-        *n_properties = *n_signals = *n_fields = 0;
-        *property = *signal = *field = NULL;
+        *n_properties = *n_signals = 0;
+        *property = *signal = NULL;
         break;
     case GI_INFO_TYPE_OBJECT:
         *n_methods = g_object_info_get_n_methods(base);
@@ -123,12 +121,10 @@ gig_repository_nested_infos(GIBaseInfo *base,
         *property = (GigRepositoryNested)g_object_info_get_property;
         *n_signals = g_object_info_get_n_signals(base);
         *signal = (GigRepositoryNested)g_object_info_get_signal;
-        *n_fields = 0;
-        *field = NULL;
         break;
     default:
-        *n_methods = *n_properties = *n_signals = *n_fields = 0;
-        *method = *property = *signal = *field = NULL;
+        *n_methods = *n_properties = *n_signals = 0;
+        *method = *property = *signal = NULL;
     }
 }
 
@@ -260,16 +256,15 @@ load_info(GIBaseInfo *info, LoadFlags flags, SCM defs)
                 }                                               \
         } while (0)
 
-        gint n_methods, n_properties, n_signals, n_fields;
-        GigRepositoryNested method, property, nested_signal, field;
+        gint n_methods, n_properties, n_signals;
+        GigRepositoryNested method, property, nested_signal;
 
         gig_repository_nested_infos(info, &n_methods, &method, &n_properties, &property,
-                                    &n_signals, &nested_signal, &n_fields, &field);
+                                    &n_signals, &nested_signal);
 
         LOAD_NESTED(LOAD_METHODS, n_methods, method);
         LOAD_NESTED(LOAD_PROPERTIES, n_properties, property);
         LOAD_NESTED(LOAD_SIGNALS, n_signals, nested_signal);
-        LOAD_NESTED(LOAD_FIELDS, n_fields, field);
 #undef LOAD_NESTED
         goto end;
     }
@@ -356,6 +351,5 @@ gig_init_repository()
     D(LOAD_METHODS);
     D(LOAD_PROPERTIES);
     D(LOAD_SIGNALS);
-    D(LOAD_FIELDS);
     D(LOAD_EVERYTHING);
 }

--- a/src/gig_repository.h
+++ b/src/gig_repository.h
@@ -12,11 +12,9 @@ typedef GIBaseInfo *(*GigRepositoryNested)(GIBaseInfo *info, gint n);
  * @n_methods: (out): the number of methods in base
  * @n_properties: (out): the number of properties in base
  * @n_signals: (out): the number of signals in base
- * @n_fields: (out): the number of fields in base
  * @method: (out) (nullable): function by which methods are retrieved
  * @property: (out) (nullable): function by which properties are retrieved
  * @signal: (out) (nullable): function by which signals are retrieved
- * @field: (out) (nullable): function by which field are retrieved
  * Fetches all information of nested infos in BASE.
  */
 void gig_repository_nested_infos(GIBaseInfo *base,
@@ -25,8 +23,7 @@ void gig_repository_nested_infos(GIBaseInfo *base,
                                  gint *n_properties,
                                  GigRepositoryNested *property,
                                  gint *n_signals,
-                                 GigRepositoryNested *signal,
-                                 gint *n_fields, GigRepositoryNested *field);
+                                 GigRepositoryNested *signal);
 
 
 #endif


### PR DESCRIPTION
Field-related GI code only exists to support structs/object without other introspection info – i.e. types we don't support – and is very rudimentary.  I doubt it will be useful for us, at with GI as it currently is.

Closes #28.