### PR TITLE
Add some basic hashtable support

### DIFF
--- a/doc/guile-gi.texi
+++ b/doc/guile-gi.texi
@@ -301,6 +301,24 @@ Internally to Guile-GI, all of the Guile classes for GObject structs,
 objects and unions are GOOPS types that handle managing the C pointer.
 The C pointer is ``hidden'' in the @code{ptr} slot of an object.
 
+@subsection Hash Tables and GHashTable Types
+
+One special case is that of GLib's @code{GHashTable} types.  The
+guile-gi library converts native Guile hash tables to @code{GHashTable}
+types as necessary when calling introspected C functions.  However,
+marshalling Guile hash tables into @code{GHashTable} types and back
+again has limitations.
+
+First, the keys of instances of @code{GHashTable} have a C type, and
+only a few common key types are handled by guile-gi: integers, real
+numbers, and strings can be converted.  All other types are treated as a
+pointer, which may not be what is intended.
+
+Second, some introspected C functions modify instances of
+@code{GHashTable} that are passed in as input arguments. The
+modifications to an instance of @code{GHashTable} input will not be
+reflected in the Guile hash tables from which is was created.
+
 @node Function Parameters Arity and Return Values
 @section Function Parameters, Arity, and Return Values
 @cindex arity

--- a/src/gig_data_type.c
+++ b/src/gig_data_type.c
@@ -81,7 +81,7 @@ add_child_params(GigTypeMeta *meta, GITypeInfo *type_info, gint n)
 
     for (int i = 0; i < n; i++) {
         param_type = g_type_info_get_param_type((GITypeInfo *)type_info, i);
-        gig_type_meta_init_from_type_info(meta->params, param_type);
+        gig_type_meta_init_from_type_info(&meta->params[i], param_type);
         g_base_info_unref(param_type);
 
         if (meta->transfer == GI_TRANSFER_EVERYTHING)

--- a/test/marshall.scm
+++ b/test/marshall.scm
@@ -1,4 +1,5 @@
 (use-modules (ice-9 receive)
+             (ice-9 hash-table)
 
              (rnrs bytevectors)
              (srfi srfi-1)
@@ -583,5 +584,110 @@
               list
               callback-return-value-and-multiple-out-parameters)
              (lambda () (values 1 2 3))))
+
+(define (hash-contains? hash key-list val-list)
+  (and (= (length key-list) (hash-count (const #t) hash))
+       (every
+        (lambda (key val)
+          (equal? (hash-ref hash key) val))
+        key-list
+        val-list)))
+
+(define (hash-contains-strings? hash)
+  (hash-contains? hash '("-1" "0" "1" "2") '("1" "0" "-1" "-2")))
+
+(test-assert "ghashtable-int-none-return"
+  (hash-contains? (ghashtable-int-none-return) '(-1 0 1 2) '(1 0 -1 -2)))
+
+(test-assert "ghashtable-utf8-none-return"
+  (hash-contains-strings? (ghashtable-utf8-none-return)))
+
+(test-assert "ghashtable-utf8-container-return"
+  (hash-contains-strings? (ghashtable-utf8-container-return)))
+
+(test-assert "ghashtable-utf8-full-return-return"
+  (hash-contains-strings? (ghashtable-utf8-container-return)))
+
+(test-assert "ghashtable-int-none-in"
+  (let ((H (alist->hash-table
+            '((-1 . 1)
+              (0 . 0)
+              (1 . -1)
+              (2 . -2)))))
+    (ghashtable-int-none-in H)
+    #t))
+
+(test-assert "ghashtable-utf8-none-in"
+  (let ((H (alist->hash-table
+            '(("-1" . "1")
+              ("0" . "0")
+              ("1" . "-1")
+              ("2" . "-2")))))
+    (ghashtable-utf8-none-in H)
+    #t))
+
+(test-assert "ghashtable-double-in"
+  (let ((H (alist->hash-table
+            '(("-1" . -0.1)
+              ("0" . 0.0)
+              ("1" . 0.1)
+              ("2" . 0.2)))))
+    (ghashtable-double-in H)
+    #t))
+
+(test-assert "ghashtable-float-in"
+  (let ((H (alist->hash-table
+            '(("-1" . -0.1)
+              ("0" . 0.0)
+              ("1" . 0.1)
+              ("2" . 0.2)))))
+    (ghashtable-float-in H)
+    #t))
+
+(test-assert "ghashtable-int64-in"
+  (let ((H (alist->hash-table
+            '(("-1" . -1)
+              ("0" . 0)
+              ("1" . 1)
+              ("2" . #x100000000)))))
+    (ghashtable-int64-in H)
+    #t))
+
+(test-assert "ghashtable-uint64-in"
+  (let ((H (alist->hash-table
+            '(("-1" . #x100000000)
+              ("0" . 0)
+              ("1" . 1)
+              ("2" . 2)))))
+    (ghashtable-uint64-in H)
+    #t))
+
+(test-assert "ghashtable-utf8-none-out"
+  (hash-contains-strings? (ghashtable-utf8-none-out)))
+
+(test-assert "ghashtable-utf8-container-out"
+  (hash-contains-strings? (ghashtable-utf8-container-out)))
+
+(test-assert "ghashtable-utf8-full-out"
+  (hash-contains-strings? (ghashtable-utf8-full-out)))
+
+(define (hash-utf8-inout? proc)
+  (let* ((H-in (alist->hash-table
+                '(("-1" . "1")
+                  ("0" . "0")
+                  ("1" . "-1")
+                  ("2" . "-2"))))
+         (H-out (proc H-in)))
+    (hash-contains? H-out
+                    '("-1" "0" "1") '("1" "0" "1"))))
+
+(test-assert "ghashtable-utf8-full-inout"
+  (hash-utf8-inout? ghashtable-utf8-full-inout))
+
+(test-assert "ghashtable-utf8-container-inout"
+  (hash-utf8-inout? ghashtable-utf8-container-inout))
+
+(test-assert "ghashtable-utf8-none-inout"
+  (hash-utf8-inout? ghashtable-utf8-none-inout))
 
 (test-end "marshall.scm")


### PR DESCRIPTION
This pulls the remaining relevant code from the unmerged wip-hashtables branch but removes the old direct hash API which is no longer needed.