### PR TITLE
marshall: Marshall C-native GType array.

### DIFF
--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -246,8 +246,10 @@ scm_to_c_interface(S2C_ARG_DECL)
         arg->v_pointer = NULL;
         return;
     }
-    else
-        UNHANDLED;
+    else {
+        arg->v_pointer = g_type_check_instance_cast((GTypeInstance*) gig_type_peek_object(object), meta->gtype);
+        return;
+    }
 }
 
 static void

--- a/src/gig_argument.c
+++ b/src/gig_argument.c
@@ -60,6 +60,7 @@ static void scm_to_c_native_boolean_array(S2C_ARG_DECL);
 static void scm_to_c_native_immediate_array(S2C_ARG_DECL);
 static void scm_to_c_native_string_array(S2C_ARG_DECL);
 static void scm_to_c_native_interface_array(S2C_ARG_DECL);
+static void scm_to_c_native_gtype_array(S2C_ARG_DECL);
 static void scm_to_c_garray(S2C_ARG_DECL);
 static void scm_to_c_byte_array(S2C_ARG_DECL);
 static void scm_to_c_ptr_array(S2C_ARG_DECL);
@@ -546,6 +547,8 @@ scm_to_c_native_array(S2C_ARG_DECL)
              || item_type == G_TYPE_UINT64
              || item_type == G_TYPE_FLOAT || item_type == G_TYPE_DOUBLE)
         scm_to_c_native_immediate_array(S2C_ARGS);
+    else if (item_type == G_TYPE_GTYPE)
+        scm_to_c_native_gtype_array(S2C_ARGS);
     else if (item_type == G_TYPE_STRING)
         scm_to_c_native_string_array(S2C_ARGS);
     else if (fundamental_item_type == G_TYPE_BOXED || item_type == G_TYPE_VARIANT
@@ -912,6 +915,26 @@ scm_to_c_ghashtable(S2C_ARG_DECL)
         ;
     }
     arg->v_pointer = hash;
+}
+
+static void
+scm_to_c_native_gtype_array(S2C_ARG_DECL)
+{
+    TRACE_S2C();
+    if (!scm_is_vector(object))
+        scm_wrong_type_arg_msg(subr, argpos, object, "vector of gtype-ables");
+    *size = scm_c_vector_length(object);
+    if (meta->is_zero_terminated) {
+        arg->v_pointer = malloc(sizeof(GType) * (*size + 1));
+        ((GType *)arg->v_pointer)[*size] = 0;
+        LATER_FREE(arg->v_pointer);
+    }
+    else {
+        arg->v_pointer = malloc(sizeof(GType) * *size);
+        LATER_FREE(arg->v_pointer);
+    }
+    for (gsize i = 0; i < *size; i++)
+        ((GType *)(arg->v_pointer))[i] = scm_to_gtype(scm_c_vector_ref(object, i));
 }
 
 static void

--- a/test/gtk.scm
+++ b/test/gtk.scm
@@ -1,4 +1,4 @@
-(use-modules (gi) (gi repository)
+(use-modules (gi) (gi repository) (gi types)
              (srfi srfi-1)
              (srfi srfi-64))
 
@@ -62,5 +62,17 @@
   (let ((box (make <GtkBox> #:orientation 'vertical #:spacing 2)))
     (and (is-a? box <GtkBox>)
          (= 2 (spacing box)))))
+
+(test-assert "load TreeStore"
+  (every load-by-name? '("Gtk" "Gtk") '("TreeModel" "TreeStore")))
+
+(test-assert "tree-store:new (lowlevel)"
+  (let ((tree-store (tree-store:new (vector G_TYPE_LONG G_TYPE_LONG G_TYPE_LONG))))
+    (and (= 3 (tree-model:get-n-columns tree-store)))))
+
+; Not possible--because the columns are not properties:
+;(test-assert "make tree store (highlevel)"
+;  (let ((tree-store (make <GtkTreeStore> #:columns (vector G_TYPE_LONG G_TYPE_LONG G_TYPE_LONG))))
+;    (and (= 3 (get-n-columns tree-store)))))
 
 (test-end "gtk.scm")

--- a/test/gtk.scm
+++ b/test/gtk.scm
@@ -63,12 +63,17 @@
     (and (is-a? box <GtkBox>)
          (= 2 (spacing box)))))
 
-(test-assert "load TreeStore"
-  (every load-by-name? '("Gtk" "Gtk") '("TreeModel" "TreeStore")))
+(test-assert "load TreeView"
+  (every load-by-name? '("Gtk" "Gtk" "Gtk") '("TreeModel" "TreeStore" "TreeView")))
 
 (test-assert "tree-store:new (lowlevel)"
   (let ((tree-store (tree-store:new (vector G_TYPE_LONG G_TYPE_LONG G_TYPE_LONG))))
     (and (= 3 (tree-model:get-n-columns tree-store)))))
+
+(test-assert "tree-view:set-model (lowlevel)"
+  (let ((tree-store (tree-store:new (vector G_TYPE_LONG G_TYPE_LONG G_TYPE_LONG)))
+        (tree-view (tree-view:new)))
+    (tree-view:set-model tree-view tree-store)))
 
 ; Not possible--because the columns are not properties:
 ;(test-assert "make tree store (highlevel)"


### PR DESCRIPTION
This is in order to support `(tree-store:new (vector G_TYPE_LONG))`.
