### PR TITLE
WIP: Typelib loading

### DIFF
--- a/examples/editor.scm
+++ b/examples/editor.scm
@@ -22,8 +22,6 @@
 
 (push-duplicate-handler! 'merge-generics)
 (use-typelibs
- ;; load GObject first to prevent warnings, even if we don't directly need it
- (("GObject" "2.0") #:select ())
  (("Gio" "2.0") #:renamer (protect* '(application:new receive)))
  ("Gtk" "3.0")
  ("Gdk" "3.0"))

--- a/module/gi/repository.scm
+++ b/module/gi/repository.scm
@@ -57,6 +57,17 @@
       (set-module-kind! interface 'interface)
       (set-module-public-interface! module interface)))
 
+  (for-each
+   (lambda (dep)
+     (module-use!
+      module
+      (let ((module (list 'gi (string->symbol dep)))
+           (lib+version (string-split dep #\-)))
+       (or (false-if-exception (resolve-interface module))
+           (module-public-interface
+            (apply typelib->module module lib+version))))))
+   (immediate-dependencies lib))
+
   (save-module-excursion
    (lambda ()
      (set-current-module module)

--- a/module/gi/repository.scm
+++ b/module/gi/repository.scm
@@ -34,6 +34,14 @@
 (eval-when (expand load eval)
   (load-extension "libguile-gi" "gig_init_repository"))
 
+(define %gig-duplicate-handlers
+  (append
+   (lookup-duplicates-handlers
+    '(merge-generics replace warn-override-core))
+   (list %gig-duplicate-warn)
+   (lookup-duplicates-handlers
+    '(last))))
+
 (define-method (load (info <GIBaseInfo>))
   (%load-info info LOAD_EVERYTHING))
 
@@ -45,10 +53,14 @@
 
 (define* (typelib->module module lib #:optional version)
   (require lib version)
-  (set! module (cond
-                ((module? module) module)
-                ((list? module) (resolve-module module))
-                (else (error "not a module: ~A" module))))
+  (set! module
+    (cond
+     ((module? module) module)
+     ((list? module)
+      (let ((m (resolve-module module)))
+        (set-module-duplicates-handlers! m %gig-duplicate-handlers)
+        m))
+     (else (error "not a module: ~A" module))))
 
   (unless (module-public-interface module)
     (let ((interface (make-module)))


### PR DESCRIPTION
This patch adds the immediate dependencies of a typelib to the module-uses of the module generated from it and installs a duplicate handler, which reports duplicates as Guile-GI warnings. We should try to resolve those at some point, and especially find out why our generics sometimes won't merge.