### PR TITLE
Guile 3.0.4

### DIFF
--- a/.github/workflows/ubuntu-bionic-guile-2.2.yml
+++ b/.github/workflows/ubuntu-bionic-guile-2.2.yml
@@ -1,0 +1,52 @@
+name: Ubuntu Bionic w/ Guile 2.2
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: env
+      run: export LANG=C.UTF-8 TERM=dumb VERBOSE=true DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles
+    - name: install packages
+      run: sudo apt-get install -y libgirepository1.0-dev guile-2.2-dev gnulib texlive
+    - name: look for guile
+      run: ls -l /usr/bin/gu*
+    - name: make dist directory
+      run: mkdir `pwd`/dist
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: GUILD=/usr/bin/guild ./configure --enable-hardening --with-gnu-filesystem-hierarchy --prefix=`pwd`/dist 
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make install
+      run: make install
+    - name: make distcheck
+      run: GUILD=/usr/bin/guild make distcheck
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Uncompress tarballs
+      run: gunzip *.tar.gz
+    - name: Archive tarball
+      uses: actions/upload-artifact@v2
+      with:
+        name: tarball
+        path: guile_gi*tar
+    - name: Archive test logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs
+        path: test-suite.log

--- a/src/gig_closure.c
+++ b/src/gig_closure.c
@@ -67,7 +67,7 @@ _gig_closure_marshal(GClosure *closure, GValue *ret, guint n_params, const GValu
             scm_misc_error(NULL, "~S returned more values than we can unpack",
                            scm_list_1(pc->callback));
 
-        gsize bit_count = scm_to_size_t(scm_bit_count(SCM_BOOL_T, pc->inout_mask));
+        gsize bit_count = scm_c_bitvector_count(pc->inout_mask);
         if (bit_count == 0 && nvalues == 1)
             /* fast path */
             return;
@@ -142,7 +142,7 @@ invoke_closure(SCM closure, SCM return_type, SCM inout_mask, SCM args)
     g_closure_invoke(real_closure, retval, nargs, params, NULL);
     ret = gig_type_transfer_object(G_TYPE_VALUE, retval, GI_TRANSFER_EVERYTHING);
 
-    if (scm_is_true(scm_bitvector_p(inout_mask))) {
+    if (scm_is_bitvector(inout_mask)) {
         ret = scm_cons(ret, SCM_EOL);
 
         gsize idx = 0, offset, length;
@@ -150,7 +150,7 @@ invoke_closure(SCM closure, SCM return_type, SCM inout_mask, SCM args)
         scm_t_array_handle handle;
         const guint32 *bits;
 
-        gsize bit_count = scm_to_size_t(scm_bit_count(SCM_BOOL_T, inout_mask));
+        gsize bit_count = scm_c_bitvector_count(inout_mask);
         if (bit_count > nargs)
             scm_misc_error(NULL, "~S returned fewer values than we should unpack",
                            scm_list_1(closure));
@@ -187,7 +187,7 @@ procedure_to_closure(SCM procedure, SCM inout_mask)
     SCM_ASSERT_TYPE(scm_is_true(scm_procedure_p(procedure)), procedure, SCM_ARG1,
                     "procedure->closure", "procedure");
     SCM_ASSERT_TYPE(SCM_UNBNDP(inout_mask) ||
-                    scm_is_true(scm_bitvector_p(inout_mask)), procedure, SCM_ARG2,
+                    scm_is_bitvector(inout_mask), procedure, SCM_ARG2,
                     "procedure->closure", "bitvector");
     GClosure *cls = gig_closure_new(procedure, inout_mask);
     g_closure_ref(cls);

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -233,7 +233,7 @@ proc4signal(GISignalInfo *info, const gchar *name, SCM self_type, int *req, int 
 
     // use base_info name without transformations, otherwise we could screw things up
     values[0] = scm_from_utf8_string(g_base_info_get_name(info));
-    values[1] = scm_make_bitvector(scm_from_int(*req + *opt), SCM_BOOL_F);
+    values[1] = scm_c_make_bitvector(scm_from_int(*req + *opt), SCM_BOOL_F);
 
     gsize offset, length;
     gssize pos = 0, inc;

--- a/src/gig_function.c
+++ b/src/gig_function.c
@@ -233,7 +233,7 @@ proc4signal(GISignalInfo *info, const gchar *name, SCM self_type, int *req, int 
 
     // use base_info name without transformations, otherwise we could screw things up
     values[0] = scm_from_utf8_string(g_base_info_get_name(info));
-    values[1] = scm_c_make_bitvector(scm_from_int(*req + *opt), SCM_BOOL_F);
+    values[1] = scm_c_make_bitvector(*req + *opt, SCM_BOOL_F);
 
     gsize offset, length;
     gssize pos = 0, inc;

--- a/src/gig_object.c
+++ b/src/gig_object.c
@@ -501,7 +501,7 @@ gig_i_scm_emit(SCM self, SCM signal, SCM s_detail, SCM args)
         ret = scm_cons(gig_value_as_scm(&retval, FALSE), ret);
 
     SCM output_mask = gig_signal_ref(signal, GIG_SIGNAL_SLOT_OUTPUT_MASK);
-    if (scm_is_true(scm_bitvector_p(output_mask))) {
+    if (scm_is_bitvector(output_mask)) {
         gsize offset, length;
         gssize pos = 0, inc;
         scm_t_array_handle handle;

--- a/src/gig_util.h
+++ b/src/gig_util.h
@@ -49,3 +49,7 @@ G_END_DECLS
 #define gig_debug_load(...)     gig_debug_internal(G_LOG_LEVEL_DEBUG, "load", __VA_ARGS__)
 #define gig_warning_load(...)   gig_debug_internal(G_LOG_LEVEL_WARNING, "load", __VA_ARGS__)
 #define gig_critical_load(...)  gig_debug_internal(G_LOG_LEVEL_CRITICAL, "load", __VA_ARGS__)
+
+#if SCM_MAJOR_VERSION == 3 && SCM_MINOR_VERSION == 0 && SCM_MICRO_VERSION <= 4
+#define scm_c_bitvector_count(x) scm_to_size_t(scm_bit_count(SCM_BOOL_T, (x)))
+#endif

--- a/src/gig_util.h
+++ b/src/gig_util.h
@@ -50,6 +50,6 @@ G_END_DECLS
 #define gig_warning_load(...)   gig_debug_internal(G_LOG_LEVEL_WARNING, "load", __VA_ARGS__)
 #define gig_critical_load(...)  gig_debug_internal(G_LOG_LEVEL_CRITICAL, "load", __VA_ARGS__)
 
-#if SCM_MAJOR_VERSION == 3 && SCM_MINOR_VERSION == 0 && SCM_MICRO_VERSION < 4
+#if (SCM_MAJOR_VERSION == 2) || (SCM_MAJOR_VERSION == 3 && SCM_MINOR_VERSION == 0 && SCM_MICRO_VERSION < 4)
 #define scm_c_bitvector_count(x) scm_to_size_t(scm_bit_count(SCM_BOOL_T, (x)))
 #endif

--- a/src/gig_util.h
+++ b/src/gig_util.h
@@ -50,6 +50,6 @@ G_END_DECLS
 #define gig_warning_load(...)   gig_debug_internal(G_LOG_LEVEL_WARNING, "load", __VA_ARGS__)
 #define gig_critical_load(...)  gig_debug_internal(G_LOG_LEVEL_CRITICAL, "load", __VA_ARGS__)
 
-#if SCM_MAJOR_VERSION == 3 && SCM_MINOR_VERSION == 0 && SCM_MICRO_VERSION <= 4
+#if SCM_MAJOR_VERSION == 3 && SCM_MINOR_VERSION == 0 && SCM_MICRO_VERSION < 4
 #define scm_c_bitvector_count(x) scm_to_size_t(scm_bit_count(SCM_BOOL_T, (x)))
 #endif


### PR DESCRIPTION
Adapts Guile-GI to changes in the bitvector API, that would otherwise raise deprecation warnings.